### PR TITLE
feat(mvp1): implementa CRUDs de tutor, pet e registros de saúde

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "petcard-api",
       "version": "0.0.1",
+      "hasInstallScript": true,
       "license": "UNLICENSED",
       "dependencies": {
         "@nestjs/common": "^11.0.1",
@@ -14,6 +15,7 @@
         "@nestjs/core": "^11.0.1",
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.0.1",
+        "@petcardorg/shared": "^0.2.0",
         "@prisma/client": "^6.19.3",
         "jwks-rsa": "^4.0.1",
         "passport": "^0.7.0",
@@ -2421,6 +2423,16 @@
         "@noble/hashes": "^1.1.5"
       }
     },
+    "node_modules/@petcardorg/shared": {
+      "version": "0.2.0",
+      "resolved": "https://npm.pkg.github.com/download/@petcardorg/shared/0.2.0/1ec6c1e6fabc17b495d71951c05cab6c753d595e",
+      "integrity": "sha512-HZzWYgDr1s1bkB7qb3ivnqVwSifpNv8ilvXzJSz7OkJPEy24KjS0uQffab90NH6d/H/hJLhae9aKBX4qbvBUXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "class-transformer": "^0.5.1",
+        "class-validator": "^0.15.1"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -2936,6 +2948,12 @@
         "@types/methods": "^1.1.4",
         "@types/superagent": "^8.1.0"
       }
+    },
+    "node_modules/@types/validator": {
+      "version": "13.15.10",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.15.10.tgz",
+      "integrity": "sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==",
+      "license": "MIT"
     },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
@@ -4458,6 +4476,23 @@
       "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/class-transformer": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
+      "license": "MIT"
+    },
+    "node_modules/class-validator": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.15.1.tgz",
+      "integrity": "sha512-LqoS80HBBSCVhz/3KloUly0ovokxpdOLR++Al3J3+dHXWt9sTKlKd4eYtoxhxyUjoe5+UcIM+5k9MIxyBWnRTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/validator": "^13.15.3",
+        "libphonenumber-js": "^1.11.1",
+        "validator": "^13.15.22"
+      }
     },
     "node_modules/cli-cursor": {
       "version": "3.1.0",
@@ -7660,6 +7695,12 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/libphonenumber-js": {
+      "version": "1.12.41",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.12.41.tgz",
+      "integrity": "sha512-lsmMmGXBxXIK/VMLEj0kL6MtUs1kBGj1nTCzi6zgQoG1DEwqwt2DQyHxcLykceIxAnfE3hya7NuIh6PpC6S3fA==",
+      "license": "MIT"
+    },
     "node_modules/limiter": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
@@ -10731,6 +10772,15 @@
       },
       "engines": {
         "node": ">=10.12.0"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.15.35",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.35.tgz",
+      "integrity": "sha512-TQ5pAGhd5whStmqWvYF4OjQROlmv9SMFVt37qoCBdqRffuuklWYQlCNnEs2ZaIBD1kZRNnikiZOS1eqgkar0iw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@nestjs/core": "^11.0.1",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",
+    "@petcardorg/shared": "^0.2.0",
     "@prisma/client": "^6.19.3",
     "jwks-rsa": "^4.0.1",
     "passport": "^0.7.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,6 +4,11 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { authConfig } from './config/auth.config';
 import { AuthModule } from './modules/auth/auth.module';
+import { DewormingModule } from './modules/health/deworming/deworming.module';
+import { MedicationModule } from './modules/health/medication/medication.module';
+import { VaccineModule } from './modules/health/vaccine/vaccine.module';
+import { PetModule } from './modules/pet/pet.module';
+import { TutorModule } from './modules/tutor/tutor.module';
 import { PrismaModule } from './prisma/prisma.module';
 
 @Module({
@@ -14,6 +19,11 @@ import { PrismaModule } from './prisma/prisma.module';
     }),
     PrismaModule,
     AuthModule,
+    TutorModule,
+    PetModule,
+    VaccineModule,
+    DewormingModule,
+    MedicationModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,16 @@
+import { ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      transform: true,
+    }),
+  );
   await app.listen(process.env.PORT ?? 3000);
 }
 void bootstrap();

--- a/src/modules/health/deworming/__tests__/deworming.service.spec.ts
+++ b/src/modules/health/deworming/__tests__/deworming.service.spec.ts
@@ -1,0 +1,100 @@
+import { NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { PrismaService } from '../../../../prisma/prisma.service';
+import { PetService } from '../../../pet/pet.service';
+import { DewormingService } from '../deworming.service';
+
+describe('DewormingService', () => {
+  let service: DewormingService;
+  let prisma: {
+    dewormingRecord: {
+      create: jest.Mock;
+      findMany: jest.Mock;
+      findUnique: jest.Mock;
+      update: jest.Mock;
+      delete: jest.Mock;
+    };
+  };
+  let petService: {
+    assertAccess: jest.Mock;
+    assertOwnership: jest.Mock;
+  };
+
+  const record = {
+    id: 'dew-1',
+    petId: 'pet-1',
+    productName: 'Drontal',
+    appliedAt: new Date('2026-01-01'),
+    nextDoseAt: null,
+    veterinarianName: null,
+    notes: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  beforeEach(async () => {
+    prisma = {
+      dewormingRecord: {
+        create: jest.fn(),
+        findMany: jest.fn(),
+        findUnique: jest.fn(),
+        update: jest.fn(),
+        delete: jest.fn(),
+      },
+    };
+    petService = {
+      assertAccess: jest.fn().mockResolvedValue({ id: 'pet-1' }),
+      assertOwnership: jest.fn().mockResolvedValue({ id: 'pet-1' }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DewormingService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: PetService, useValue: petService },
+      ],
+    }).compile();
+
+    service = module.get<DewormingService>(DewormingService);
+  });
+
+  it('should create a record after access check', async () => {
+    prisma.dewormingRecord.create.mockResolvedValue(record);
+
+    await service.create('pet-1', 'auth0|abc', false, {
+      product_name: 'Drontal',
+      applied_at: '2026-01-01',
+    });
+
+    expect(petService.assertAccess).toHaveBeenCalled();
+    expect(prisma.dewormingRecord.create).toHaveBeenCalled();
+  });
+
+  it('should list records for a pet', async () => {
+    prisma.dewormingRecord.findMany.mockResolvedValue([record]);
+
+    const result = await service.findAllForPet('pet-1', 'auth0|abc', false);
+
+    expect(result).toEqual([record]);
+  });
+
+  it('should throw when updating missing record', async () => {
+    prisma.dewormingRecord.findUnique.mockResolvedValue(null);
+
+    await expect(
+      service.update('missing', 'auth0|abc', false, {}),
+    ).rejects.toThrow(NotFoundException);
+  });
+
+  it('should delete owned record', async () => {
+    prisma.dewormingRecord.findUnique.mockResolvedValue(record);
+    prisma.dewormingRecord.delete.mockResolvedValue(record);
+
+    await service.remove('dew-1', 'auth0|abc');
+
+    expect(petService.assertOwnership).toHaveBeenCalledWith(
+      'pet-1',
+      'auth0|abc',
+    );
+  });
+});

--- a/src/modules/health/deworming/deworming.controller.ts
+++ b/src/modules/health/deworming/deworming.controller.ts
@@ -1,0 +1,68 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Patch,
+  Post,
+} from '@nestjs/common';
+import { DewormingRecord } from '@prisma/client';
+import {
+  CreateDewormingRecordDto,
+  UpdateDewormingRecordDto,
+} from '@petcardorg/shared';
+import { Auth } from '../../auth/decorators/auth.decorator';
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
+import { Role } from '../../auth/enums/role.enum';
+import type { JwtPayload } from '../../auth/strategies/jwt.strategy';
+import { DewormingService } from './deworming.service';
+
+@Controller()
+export class DewormingController {
+  constructor(private readonly dewormingService: DewormingService) {}
+
+  @Post('pets/:petId/dewormings')
+  @Auth(Role.TUTOR, Role.VET)
+  async create(
+    @Param('petId') petId: string,
+    @CurrentUser() user: JwtPayload,
+    @Body() dto: CreateDewormingRecordDto,
+  ): Promise<DewormingRecord> {
+    const isVet = user.permissions?.includes(Role.VET) ?? false;
+    return this.dewormingService.create(petId, user.sub, isVet, dto);
+  }
+
+  @Get('pets/:petId/dewormings')
+  @Auth(Role.TUTOR, Role.VET)
+  async findAll(
+    @Param('petId') petId: string,
+    @CurrentUser() user: JwtPayload,
+  ): Promise<DewormingRecord[]> {
+    const isVet = user.permissions?.includes(Role.VET) ?? false;
+    return this.dewormingService.findAllForPet(petId, user.sub, isVet);
+  }
+
+  @Patch('dewormings/:id')
+  @Auth(Role.TUTOR, Role.VET)
+  async update(
+    @Param('id') id: string,
+    @CurrentUser() user: JwtPayload,
+    @Body() dto: UpdateDewormingRecordDto,
+  ): Promise<DewormingRecord> {
+    const isVet = user.permissions?.includes(Role.VET) ?? false;
+    return this.dewormingService.update(id, user.sub, isVet, dto);
+  }
+
+  @Delete('dewormings/:id')
+  @Auth(Role.TUTOR)
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async remove(
+    @Param('id') id: string,
+    @CurrentUser() user: JwtPayload,
+  ): Promise<void> {
+    return this.dewormingService.remove(id, user.sub);
+  }
+}

--- a/src/modules/health/deworming/deworming.module.ts
+++ b/src/modules/health/deworming/deworming.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { AuthModule } from '../../auth/auth.module';
+import { PetModule } from '../../pet/pet.module';
+import { DewormingController } from './deworming.controller';
+import { DewormingService } from './deworming.service';
+
+@Module({
+  imports: [AuthModule, PetModule],
+  controllers: [DewormingController],
+  providers: [DewormingService],
+})
+export class DewormingModule {}

--- a/src/modules/health/deworming/deworming.service.ts
+++ b/src/modules/health/deworming/deworming.service.ts
@@ -1,0 +1,85 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { DewormingRecord } from '@prisma/client';
+import {
+  CreateDewormingRecordDto,
+  UpdateDewormingRecordDto,
+} from '@petcardorg/shared';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { PetService } from '../../pet/pet.service';
+
+type DewormingInput = Omit<CreateDewormingRecordDto, 'pet_id'>;
+
+@Injectable()
+export class DewormingService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly petService: PetService,
+  ) {}
+
+  async create(
+    petId: string,
+    auth0Id: string,
+    isVet: boolean,
+    dto: DewormingInput,
+  ): Promise<DewormingRecord> {
+    await this.petService.assertAccess(petId, auth0Id, isVet);
+    return this.prisma.dewormingRecord.create({
+      data: {
+        petId,
+        productName: dto.product_name,
+        appliedAt: new Date(dto.applied_at),
+        nextDoseAt: dto.next_dose_at ? new Date(dto.next_dose_at) : null,
+        veterinarianName: dto.veterinarian_name,
+        notes: dto.notes,
+      },
+    });
+  }
+
+  async findAllForPet(
+    petId: string,
+    auth0Id: string,
+    isVet: boolean,
+  ): Promise<DewormingRecord[]> {
+    await this.petService.assertAccess(petId, auth0Id, isVet);
+    return this.prisma.dewormingRecord.findMany({
+      where: { petId },
+      orderBy: { appliedAt: 'desc' },
+    });
+  }
+
+  async update(
+    id: string,
+    auth0Id: string,
+    isVet: boolean,
+    dto: Omit<UpdateDewormingRecordDto, 'pet_id'>,
+  ): Promise<DewormingRecord> {
+    const record = await this.getRecord(id);
+    await this.petService.assertAccess(record.petId, auth0Id, isVet);
+    return this.prisma.dewormingRecord.update({
+      where: { id },
+      data: {
+        productName: dto.product_name,
+        appliedAt: dto.applied_at ? new Date(dto.applied_at) : undefined,
+        nextDoseAt: dto.next_dose_at ? new Date(dto.next_dose_at) : undefined,
+        veterinarianName: dto.veterinarian_name,
+        notes: dto.notes,
+      },
+    });
+  }
+
+  async remove(id: string, auth0Id: string): Promise<void> {
+    const record = await this.getRecord(id);
+    await this.petService.assertOwnership(record.petId, auth0Id);
+    await this.prisma.dewormingRecord.delete({ where: { id } });
+  }
+
+  private async getRecord(id: string): Promise<DewormingRecord> {
+    const record = await this.prisma.dewormingRecord.findUnique({
+      where: { id },
+    });
+    if (!record) {
+      throw new NotFoundException(`Deworming record with id ${id} not found`);
+    }
+    return record;
+  }
+}

--- a/src/modules/health/medication/__tests__/medication.service.spec.ts
+++ b/src/modules/health/medication/__tests__/medication.service.spec.ts
@@ -1,0 +1,110 @@
+import { NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { PrismaService } from '../../../../prisma/prisma.service';
+import { PetService } from '../../../pet/pet.service';
+import { MedicationService } from '../medication.service';
+
+describe('MedicationService', () => {
+  let service: MedicationService;
+  let prisma: {
+    medicationRecord: {
+      create: jest.Mock;
+      findMany: jest.Mock;
+      findUnique: jest.Mock;
+      update: jest.Mock;
+      delete: jest.Mock;
+    };
+  };
+  let petService: {
+    assertAccess: jest.Mock;
+    assertOwnership: jest.Mock;
+  };
+
+  const record = {
+    id: 'med-1',
+    petId: 'pet-1',
+    medicationName: 'Amoxicillin',
+    dosage: '500mg',
+    frequency: '8h',
+    startDate: new Date('2026-01-01'),
+    endDate: null,
+    notes: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  beforeEach(async () => {
+    prisma = {
+      medicationRecord: {
+        create: jest.fn(),
+        findMany: jest.fn(),
+        findUnique: jest.fn(),
+        update: jest.fn(),
+        delete: jest.fn(),
+      },
+    };
+    petService = {
+      assertAccess: jest.fn().mockResolvedValue({ id: 'pet-1' }),
+      assertOwnership: jest.fn().mockResolvedValue({ id: 'pet-1' }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MedicationService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: PetService, useValue: petService },
+      ],
+    }).compile();
+
+    service = module.get<MedicationService>(MedicationService);
+  });
+
+  it('should create a medication after access check', async () => {
+    prisma.medicationRecord.create.mockResolvedValue(record);
+
+    await service.create('pet-1', 'auth0|abc', true, {
+      medication_name: 'Amoxicillin',
+      dosage: '500mg',
+      frequency: '8h',
+      start_date: '2026-01-01',
+    });
+
+    expect(petService.assertAccess).toHaveBeenCalledWith(
+      'pet-1',
+      'auth0|abc',
+      true,
+    );
+    expect(prisma.medicationRecord.create).toHaveBeenCalled();
+  });
+
+  it('should list records ordered by start date', async () => {
+    prisma.medicationRecord.findMany.mockResolvedValue([record]);
+
+    const result = await service.findAllForPet('pet-1', 'auth0|abc', false);
+
+    expect(prisma.medicationRecord.findMany).toHaveBeenCalledWith({
+      where: { petId: 'pet-1' },
+      orderBy: { startDate: 'desc' },
+    });
+    expect(result).toEqual([record]);
+  });
+
+  it('should throw when updating a missing record', async () => {
+    prisma.medicationRecord.findUnique.mockResolvedValue(null);
+
+    await expect(
+      service.update('missing', 'auth0|abc', false, {}),
+    ).rejects.toThrow(NotFoundException);
+  });
+
+  it('should delete an owned record', async () => {
+    prisma.medicationRecord.findUnique.mockResolvedValue(record);
+    prisma.medicationRecord.delete.mockResolvedValue(record);
+
+    await service.remove('med-1', 'auth0|abc');
+
+    expect(prisma.medicationRecord.delete).toHaveBeenCalledWith({
+      where: { id: 'med-1' },
+    });
+  });
+});

--- a/src/modules/health/medication/medication.controller.ts
+++ b/src/modules/health/medication/medication.controller.ts
@@ -1,0 +1,68 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Patch,
+  Post,
+} from '@nestjs/common';
+import { MedicationRecord } from '@prisma/client';
+import {
+  CreateMedicationRecordDto,
+  UpdateMedicationRecordDto,
+} from '@petcardorg/shared';
+import { Auth } from '../../auth/decorators/auth.decorator';
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
+import { Role } from '../../auth/enums/role.enum';
+import type { JwtPayload } from '../../auth/strategies/jwt.strategy';
+import { MedicationService } from './medication.service';
+
+@Controller()
+export class MedicationController {
+  constructor(private readonly medicationService: MedicationService) {}
+
+  @Post('pets/:petId/medications')
+  @Auth(Role.TUTOR, Role.VET)
+  async create(
+    @Param('petId') petId: string,
+    @CurrentUser() user: JwtPayload,
+    @Body() dto: CreateMedicationRecordDto,
+  ): Promise<MedicationRecord> {
+    const isVet = user.permissions?.includes(Role.VET) ?? false;
+    return this.medicationService.create(petId, user.sub, isVet, dto);
+  }
+
+  @Get('pets/:petId/medications')
+  @Auth(Role.TUTOR, Role.VET)
+  async findAll(
+    @Param('petId') petId: string,
+    @CurrentUser() user: JwtPayload,
+  ): Promise<MedicationRecord[]> {
+    const isVet = user.permissions?.includes(Role.VET) ?? false;
+    return this.medicationService.findAllForPet(petId, user.sub, isVet);
+  }
+
+  @Patch('medications/:id')
+  @Auth(Role.TUTOR, Role.VET)
+  async update(
+    @Param('id') id: string,
+    @CurrentUser() user: JwtPayload,
+    @Body() dto: UpdateMedicationRecordDto,
+  ): Promise<MedicationRecord> {
+    const isVet = user.permissions?.includes(Role.VET) ?? false;
+    return this.medicationService.update(id, user.sub, isVet, dto);
+  }
+
+  @Delete('medications/:id')
+  @Auth(Role.TUTOR)
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async remove(
+    @Param('id') id: string,
+    @CurrentUser() user: JwtPayload,
+  ): Promise<void> {
+    return this.medicationService.remove(id, user.sub);
+  }
+}

--- a/src/modules/health/medication/medication.module.ts
+++ b/src/modules/health/medication/medication.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { AuthModule } from '../../auth/auth.module';
+import { PetModule } from '../../pet/pet.module';
+import { MedicationController } from './medication.controller';
+import { MedicationService } from './medication.service';
+
+@Module({
+  imports: [AuthModule, PetModule],
+  controllers: [MedicationController],
+  providers: [MedicationService],
+})
+export class MedicationModule {}

--- a/src/modules/health/medication/medication.service.ts
+++ b/src/modules/health/medication/medication.service.ts
@@ -1,0 +1,87 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { MedicationRecord } from '@prisma/client';
+import {
+  CreateMedicationRecordDto,
+  UpdateMedicationRecordDto,
+} from '@petcardorg/shared';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { PetService } from '../../pet/pet.service';
+
+type MedicationInput = Omit<CreateMedicationRecordDto, 'pet_id'>;
+
+@Injectable()
+export class MedicationService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly petService: PetService,
+  ) {}
+
+  async create(
+    petId: string,
+    auth0Id: string,
+    isVet: boolean,
+    dto: MedicationInput,
+  ): Promise<MedicationRecord> {
+    await this.petService.assertAccess(petId, auth0Id, isVet);
+    return this.prisma.medicationRecord.create({
+      data: {
+        petId,
+        medicationName: dto.medication_name,
+        dosage: dto.dosage,
+        frequency: dto.frequency,
+        startDate: new Date(dto.start_date),
+        endDate: dto.end_date ? new Date(dto.end_date) : null,
+        notes: dto.notes,
+      },
+    });
+  }
+
+  async findAllForPet(
+    petId: string,
+    auth0Id: string,
+    isVet: boolean,
+  ): Promise<MedicationRecord[]> {
+    await this.petService.assertAccess(petId, auth0Id, isVet);
+    return this.prisma.medicationRecord.findMany({
+      where: { petId },
+      orderBy: { startDate: 'desc' },
+    });
+  }
+
+  async update(
+    id: string,
+    auth0Id: string,
+    isVet: boolean,
+    dto: Omit<UpdateMedicationRecordDto, 'pet_id'>,
+  ): Promise<MedicationRecord> {
+    const record = await this.getRecord(id);
+    await this.petService.assertAccess(record.petId, auth0Id, isVet);
+    return this.prisma.medicationRecord.update({
+      where: { id },
+      data: {
+        medicationName: dto.medication_name,
+        dosage: dto.dosage,
+        frequency: dto.frequency,
+        startDate: dto.start_date ? new Date(dto.start_date) : undefined,
+        endDate: dto.end_date ? new Date(dto.end_date) : undefined,
+        notes: dto.notes,
+      },
+    });
+  }
+
+  async remove(id: string, auth0Id: string): Promise<void> {
+    const record = await this.getRecord(id);
+    await this.petService.assertOwnership(record.petId, auth0Id);
+    await this.prisma.medicationRecord.delete({ where: { id } });
+  }
+
+  private async getRecord(id: string): Promise<MedicationRecord> {
+    const record = await this.prisma.medicationRecord.findUnique({
+      where: { id },
+    });
+    if (!record) {
+      throw new NotFoundException(`Medication record with id ${id} not found`);
+    }
+    return record;
+  }
+}

--- a/src/modules/health/vaccine/__tests__/vaccine.service.spec.ts
+++ b/src/modules/health/vaccine/__tests__/vaccine.service.spec.ts
@@ -1,0 +1,134 @@
+import { NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { PrismaService } from '../../../../prisma/prisma.service';
+import { PetService } from '../../../pet/pet.service';
+import { VaccineService } from '../vaccine.service';
+
+describe('VaccineService', () => {
+  let service: VaccineService;
+  let prisma: {
+    vaccineRecord: {
+      create: jest.Mock;
+      findMany: jest.Mock;
+      findUnique: jest.Mock;
+      update: jest.Mock;
+      delete: jest.Mock;
+    };
+  };
+  let petService: {
+    assertAccess: jest.Mock;
+    assertOwnership: jest.Mock;
+  };
+
+  const record = {
+    id: 'vac-1',
+    petId: 'pet-1',
+    vaccineName: 'Rabies',
+    appliedAt: new Date('2026-01-01'),
+    nextDoseAt: null,
+    veterinarianName: null,
+    notes: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  beforeEach(async () => {
+    prisma = {
+      vaccineRecord: {
+        create: jest.fn(),
+        findMany: jest.fn(),
+        findUnique: jest.fn(),
+        update: jest.fn(),
+        delete: jest.fn(),
+      },
+    };
+    petService = {
+      assertAccess: jest.fn().mockResolvedValue({ id: 'pet-1' }),
+      assertOwnership: jest.fn().mockResolvedValue({ id: 'pet-1' }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        VaccineService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: PetService, useValue: petService },
+      ],
+    }).compile();
+
+    service = module.get<VaccineService>(VaccineService);
+  });
+
+  describe('create', () => {
+    it('should check pet access before creating the record', async () => {
+      prisma.vaccineRecord.create.mockResolvedValue(record);
+
+      await service.create('pet-1', 'auth0|abc', false, {
+        vaccine_name: 'Rabies',
+        applied_at: '2026-01-01',
+      });
+
+      expect(petService.assertAccess).toHaveBeenCalledWith(
+        'pet-1',
+        'auth0|abc',
+        false,
+      );
+      expect(prisma.vaccineRecord.create).toHaveBeenCalled();
+    });
+  });
+
+  describe('findAllForPet', () => {
+    it('should return all records for the pet', async () => {
+      prisma.vaccineRecord.findMany.mockResolvedValue([record]);
+
+      const result = await service.findAllForPet('pet-1', 'auth0|abc', true);
+
+      expect(petService.assertAccess).toHaveBeenCalledWith(
+        'pet-1',
+        'auth0|abc',
+        true,
+      );
+      expect(result).toEqual([record]);
+    });
+  });
+
+  describe('update', () => {
+    it('should throw NotFoundException when the record is missing', async () => {
+      prisma.vaccineRecord.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.update('missing', 'auth0|abc', false, {}),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should update the record when access is granted', async () => {
+      prisma.vaccineRecord.findUnique.mockResolvedValue(record);
+      prisma.vaccineRecord.update.mockResolvedValue({
+        ...record,
+        vaccineName: 'Rabies Plus',
+      });
+
+      const result = await service.update('vac-1', 'auth0|abc', false, {
+        vaccine_name: 'Rabies Plus',
+      });
+
+      expect(result.vaccineName).toBe('Rabies Plus');
+    });
+  });
+
+  describe('remove', () => {
+    it('should delete the record when owned', async () => {
+      prisma.vaccineRecord.findUnique.mockResolvedValue(record);
+      prisma.vaccineRecord.delete.mockResolvedValue(record);
+
+      await service.remove('vac-1', 'auth0|abc');
+
+      expect(petService.assertOwnership).toHaveBeenCalledWith(
+        'pet-1',
+        'auth0|abc',
+      );
+      expect(prisma.vaccineRecord.delete).toHaveBeenCalledWith({
+        where: { id: 'vac-1' },
+      });
+    });
+  });
+});

--- a/src/modules/health/vaccine/vaccine.controller.ts
+++ b/src/modules/health/vaccine/vaccine.controller.ts
@@ -1,0 +1,68 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Patch,
+  Post,
+} from '@nestjs/common';
+import { VaccineRecord } from '@prisma/client';
+import {
+  CreateVaccineRecordDto,
+  UpdateVaccineRecordDto,
+} from '@petcardorg/shared';
+import { Auth } from '../../auth/decorators/auth.decorator';
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
+import { Role } from '../../auth/enums/role.enum';
+import type { JwtPayload } from '../../auth/strategies/jwt.strategy';
+import { VaccineService } from './vaccine.service';
+
+@Controller()
+export class VaccineController {
+  constructor(private readonly vaccineService: VaccineService) {}
+
+  @Post('pets/:petId/vaccines')
+  @Auth(Role.TUTOR, Role.VET)
+  async create(
+    @Param('petId') petId: string,
+    @CurrentUser() user: JwtPayload,
+    @Body() dto: CreateVaccineRecordDto,
+  ): Promise<VaccineRecord> {
+    const isVet = user.permissions?.includes(Role.VET) ?? false;
+    return this.vaccineService.create(petId, user.sub, isVet, dto);
+  }
+
+  @Get('pets/:petId/vaccines')
+  @Auth(Role.TUTOR, Role.VET)
+  async findAll(
+    @Param('petId') petId: string,
+    @CurrentUser() user: JwtPayload,
+  ): Promise<VaccineRecord[]> {
+    const isVet = user.permissions?.includes(Role.VET) ?? false;
+    return this.vaccineService.findAllForPet(petId, user.sub, isVet);
+  }
+
+  @Patch('vaccines/:id')
+  @Auth(Role.TUTOR, Role.VET)
+  async update(
+    @Param('id') id: string,
+    @CurrentUser() user: JwtPayload,
+    @Body() dto: UpdateVaccineRecordDto,
+  ): Promise<VaccineRecord> {
+    const isVet = user.permissions?.includes(Role.VET) ?? false;
+    return this.vaccineService.update(id, user.sub, isVet, dto);
+  }
+
+  @Delete('vaccines/:id')
+  @Auth(Role.TUTOR)
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async remove(
+    @Param('id') id: string,
+    @CurrentUser() user: JwtPayload,
+  ): Promise<void> {
+    return this.vaccineService.remove(id, user.sub);
+  }
+}

--- a/src/modules/health/vaccine/vaccine.module.ts
+++ b/src/modules/health/vaccine/vaccine.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { AuthModule } from '../../auth/auth.module';
+import { PetModule } from '../../pet/pet.module';
+import { VaccineController } from './vaccine.controller';
+import { VaccineService } from './vaccine.service';
+
+@Module({
+  imports: [AuthModule, PetModule],
+  controllers: [VaccineController],
+  providers: [VaccineService],
+})
+export class VaccineModule {}

--- a/src/modules/health/vaccine/vaccine.service.ts
+++ b/src/modules/health/vaccine/vaccine.service.ts
@@ -1,0 +1,85 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { VaccineRecord } from '@prisma/client';
+import {
+  CreateVaccineRecordDto,
+  UpdateVaccineRecordDto,
+} from '@petcardorg/shared';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { PetService } from '../../pet/pet.service';
+
+type VaccineInput = Omit<CreateVaccineRecordDto, 'pet_id'>;
+
+@Injectable()
+export class VaccineService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly petService: PetService,
+  ) {}
+
+  async create(
+    petId: string,
+    auth0Id: string,
+    isVet: boolean,
+    dto: VaccineInput,
+  ): Promise<VaccineRecord> {
+    await this.petService.assertAccess(petId, auth0Id, isVet);
+    return this.prisma.vaccineRecord.create({
+      data: {
+        petId,
+        vaccineName: dto.vaccine_name,
+        appliedAt: new Date(dto.applied_at),
+        nextDoseAt: dto.next_dose_at ? new Date(dto.next_dose_at) : null,
+        veterinarianName: dto.veterinarian_name,
+        notes: dto.notes,
+      },
+    });
+  }
+
+  async findAllForPet(
+    petId: string,
+    auth0Id: string,
+    isVet: boolean,
+  ): Promise<VaccineRecord[]> {
+    await this.petService.assertAccess(petId, auth0Id, isVet);
+    return this.prisma.vaccineRecord.findMany({
+      where: { petId },
+      orderBy: { appliedAt: 'desc' },
+    });
+  }
+
+  async update(
+    id: string,
+    auth0Id: string,
+    isVet: boolean,
+    dto: Omit<UpdateVaccineRecordDto, 'pet_id'>,
+  ): Promise<VaccineRecord> {
+    const record = await this.getRecord(id);
+    await this.petService.assertAccess(record.petId, auth0Id, isVet);
+    return this.prisma.vaccineRecord.update({
+      where: { id },
+      data: {
+        vaccineName: dto.vaccine_name,
+        appliedAt: dto.applied_at ? new Date(dto.applied_at) : undefined,
+        nextDoseAt: dto.next_dose_at ? new Date(dto.next_dose_at) : undefined,
+        veterinarianName: dto.veterinarian_name,
+        notes: dto.notes,
+      },
+    });
+  }
+
+  async remove(id: string, auth0Id: string): Promise<void> {
+    const record = await this.getRecord(id);
+    await this.petService.assertOwnership(record.petId, auth0Id);
+    await this.prisma.vaccineRecord.delete({ where: { id } });
+  }
+
+  private async getRecord(id: string): Promise<VaccineRecord> {
+    const record = await this.prisma.vaccineRecord.findUnique({
+      where: { id },
+    });
+    if (!record) {
+      throw new NotFoundException(`Vaccine record with id ${id} not found`);
+    }
+    return record;
+  }
+}

--- a/src/modules/pet/__tests__/pet.service.spec.ts
+++ b/src/modules/pet/__tests__/pet.service.spec.ts
@@ -1,0 +1,157 @@
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { Sex, Species } from '@petcardorg/shared';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { TutorService } from '../../tutor/tutor.service';
+import { PetService } from '../pet.service';
+
+describe('PetService', () => {
+  let service: PetService;
+  let prisma: {
+    pet: {
+      create: jest.Mock;
+      findMany: jest.Mock;
+      findUnique: jest.Mock;
+      update: jest.Mock;
+      delete: jest.Mock;
+    };
+  };
+  let tutorService: { findByAuth0Id: jest.Mock };
+
+  const tutor = { id: 'tutor-1', auth0Id: 'auth0|abc' };
+  const pet = {
+    id: 'pet-1',
+    name: 'Rex',
+    species: Species.DOG,
+    sex: Sex.MALE,
+    tutorId: 'tutor-1',
+  };
+
+  beforeEach(async () => {
+    prisma = {
+      pet: {
+        create: jest.fn(),
+        findMany: jest.fn(),
+        findUnique: jest.fn(),
+        update: jest.fn(),
+        delete: jest.fn(),
+      },
+    };
+    tutorService = { findByAuth0Id: jest.fn().mockResolvedValue(tutor) };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PetService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: TutorService, useValue: tutorService },
+      ],
+    }).compile();
+
+    service = module.get<PetService>(PetService);
+  });
+
+  describe('create', () => {
+    it('should create a pet linked to the authenticated tutor', async () => {
+      prisma.pet.create.mockResolvedValue(pet);
+
+      const result = await service.create('auth0|abc', {
+        name: 'Rex',
+        species: Species.DOG,
+        sex: Sex.MALE,
+      });
+
+      const calls = prisma.pet.create.mock.calls as Array<
+        [{ data: Record<string, unknown> }]
+      >;
+      expect(calls[0][0].data).toMatchObject({
+        name: 'Rex',
+        species: Species.DOG,
+        sex: Sex.MALE,
+        tutorId: 'tutor-1',
+      });
+      expect(result).toBe(pet);
+    });
+  });
+
+  describe('findAllForTutor', () => {
+    it('should return only pets owned by the tutor', async () => {
+      prisma.pet.findMany.mockResolvedValue([pet]);
+
+      const result = await service.findAllForTutor('auth0|abc');
+
+      expect(prisma.pet.findMany).toHaveBeenCalledWith({
+        where: { tutorId: 'tutor-1' },
+      });
+      expect(result).toEqual([pet]);
+    });
+  });
+
+  describe('findOne', () => {
+    it('should allow the owner to read a pet', async () => {
+      prisma.pet.findUnique.mockResolvedValue(pet);
+
+      const result = await service.findOne('pet-1', 'auth0|abc', false);
+
+      expect(result).toBe(pet);
+    });
+
+    it('should deny access to non-owner tutors', async () => {
+      prisma.pet.findUnique.mockResolvedValue({ ...pet, tutorId: 'other' });
+
+      await expect(
+        service.findOne('pet-1', 'auth0|abc', false),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should allow any vet to read the pet', async () => {
+      prisma.pet.findUnique.mockResolvedValue({ ...pet, tutorId: 'other' });
+
+      const result = await service.findOne('pet-1', 'auth0|vet', true);
+
+      expect(result.id).toBe('pet-1');
+      expect(tutorService.findByAuth0Id).not.toHaveBeenCalled();
+    });
+
+    it('should throw NotFoundException when the pet is missing', async () => {
+      prisma.pet.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.findOne('missing', 'auth0|abc', false),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('update', () => {
+    it('should update owned pets', async () => {
+      prisma.pet.findUnique.mockResolvedValue(pet);
+      prisma.pet.update.mockResolvedValue({ ...pet, name: 'Rex II' });
+
+      const result = await service.update('pet-1', 'auth0|abc', {
+        name: 'Rex II',
+      });
+
+      expect(result.name).toBe('Rex II');
+    });
+
+    it('should refuse updates from non-owners', async () => {
+      prisma.pet.findUnique.mockResolvedValue({ ...pet, tutorId: 'other' });
+
+      await expect(
+        service.update('pet-1', 'auth0|abc', { name: 'Rex II' }),
+      ).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  describe('remove', () => {
+    it('should delete owned pets', async () => {
+      prisma.pet.findUnique.mockResolvedValue(pet);
+      prisma.pet.delete.mockResolvedValue(pet);
+
+      await service.remove('pet-1', 'auth0|abc');
+
+      expect(prisma.pet.delete).toHaveBeenCalledWith({
+        where: { id: 'pet-1' },
+      });
+    });
+  });
+});

--- a/src/modules/pet/pet.controller.ts
+++ b/src/modules/pet/pet.controller.ts
@@ -1,0 +1,68 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Patch,
+  Post,
+} from '@nestjs/common';
+import { Pet } from '@prisma/client';
+import { CreatePetDto, UpdatePetDto } from '@petcardorg/shared';
+import { Auth } from '../auth/decorators/auth.decorator';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { Role } from '../auth/enums/role.enum';
+import type { JwtPayload } from '../auth/strategies/jwt.strategy';
+import { PetService } from './pet.service';
+
+@Controller('pets')
+export class PetController {
+  constructor(private readonly petService: PetService) {}
+
+  @Post()
+  @Auth(Role.TUTOR)
+  async create(
+    @CurrentUser() user: JwtPayload,
+    @Body() dto: CreatePetDto,
+  ): Promise<Pet> {
+    return this.petService.create(user.sub, dto);
+  }
+
+  @Get()
+  @Auth(Role.TUTOR)
+  async findAll(@CurrentUser() user: JwtPayload): Promise<Pet[]> {
+    return this.petService.findAllForTutor(user.sub);
+  }
+
+  @Get(':id')
+  @Auth(Role.TUTOR, Role.VET)
+  async findOne(
+    @Param('id') id: string,
+    @CurrentUser() user: JwtPayload,
+  ): Promise<Pet> {
+    const isVet = user.permissions?.includes(Role.VET) ?? false;
+    return this.petService.findOne(id, user.sub, isVet);
+  }
+
+  @Patch(':id')
+  @Auth(Role.TUTOR)
+  async update(
+    @Param('id') id: string,
+    @CurrentUser() user: JwtPayload,
+    @Body() dto: UpdatePetDto,
+  ): Promise<Pet> {
+    return this.petService.update(id, user.sub, dto);
+  }
+
+  @Delete(':id')
+  @Auth(Role.TUTOR)
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async remove(
+    @Param('id') id: string,
+    @CurrentUser() user: JwtPayload,
+  ): Promise<void> {
+    return this.petService.remove(id, user.sub);
+  }
+}

--- a/src/modules/pet/pet.module.ts
+++ b/src/modules/pet/pet.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { AuthModule } from '../auth/auth.module';
+import { TutorModule } from '../tutor/tutor.module';
+import { PetController } from './pet.controller';
+import { PetService } from './pet.service';
+
+@Module({
+  imports: [AuthModule, TutorModule],
+  controllers: [PetController],
+  providers: [PetService],
+  exports: [PetService],
+})
+export class PetModule {}

--- a/src/modules/pet/pet.service.ts
+++ b/src/modules/pet/pet.service.ts
@@ -1,0 +1,106 @@
+import {
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { Pet } from '@prisma/client';
+import { CreatePetDto, UpdatePetDto } from '@petcardorg/shared';
+import { PrismaService } from '../../prisma/prisma.service';
+import { TutorService } from '../tutor/tutor.service';
+
+type PetInput = Omit<CreatePetDto, 'tutor_id'>;
+
+@Injectable()
+export class PetService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly tutorService: TutorService,
+  ) {}
+
+  async create(auth0Id: string, dto: PetInput): Promise<Pet> {
+    const tutor = await this.tutorService.findByAuth0Id(auth0Id);
+    return this.prisma.pet.create({
+      data: {
+        name: dto.name,
+        species: dto.species,
+        breed: dto.breed,
+        sex: dto.sex,
+        birthDate: dto.birth_date ? new Date(dto.birth_date) : null,
+        weight: dto.weight,
+        photoUrl: dto.photo_url,
+        tutorId: tutor.id,
+      },
+    });
+  }
+
+  async findAllForTutor(auth0Id: string): Promise<Pet[]> {
+    const tutor = await this.tutorService.findByAuth0Id(auth0Id);
+    return this.prisma.pet.findMany({ where: { tutorId: tutor.id } });
+  }
+
+  async findOne(id: string, auth0Id: string, isVet: boolean): Promise<Pet> {
+    const pet = await this.prisma.pet.findUnique({ where: { id } });
+    if (!pet) {
+      throw new NotFoundException(`Pet with id ${id} not found`);
+    }
+    if (!isVet) {
+      const tutor = await this.tutorService.findByAuth0Id(auth0Id);
+      if (pet.tutorId !== tutor.id) {
+        throw new ForbiddenException('You do not own this pet');
+      }
+    }
+    return pet;
+  }
+
+  async update(
+    id: string,
+    auth0Id: string,
+    dto: Omit<UpdatePetDto, 'tutor_id'>,
+  ): Promise<Pet> {
+    await this.assertOwnership(id, auth0Id);
+    return this.prisma.pet.update({
+      where: { id },
+      data: {
+        name: dto.name,
+        species: dto.species,
+        breed: dto.breed,
+        sex: dto.sex,
+        birthDate: dto.birth_date ? new Date(dto.birth_date) : undefined,
+        weight: dto.weight,
+        photoUrl: dto.photo_url,
+      },
+    });
+  }
+
+  async remove(id: string, auth0Id: string): Promise<void> {
+    await this.assertOwnership(id, auth0Id);
+    await this.prisma.pet.delete({ where: { id } });
+  }
+
+  async assertOwnership(petId: string, auth0Id: string): Promise<Pet> {
+    const pet = await this.prisma.pet.findUnique({ where: { id: petId } });
+    if (!pet) {
+      throw new NotFoundException(`Pet with id ${petId} not found`);
+    }
+    const tutor = await this.tutorService.findByAuth0Id(auth0Id);
+    if (pet.tutorId !== tutor.id) {
+      throw new ForbiddenException('You do not own this pet');
+    }
+    return pet;
+  }
+
+  async assertAccess(
+    petId: string,
+    auth0Id: string,
+    isVet: boolean,
+  ): Promise<Pet> {
+    if (isVet) {
+      const pet = await this.prisma.pet.findUnique({ where: { id: petId } });
+      if (!pet) {
+        throw new NotFoundException(`Pet with id ${petId} not found`);
+      }
+      return pet;
+    }
+    return this.assertOwnership(petId, auth0Id);
+  }
+}

--- a/src/modules/tutor/__tests__/tutor.service.spec.ts
+++ b/src/modules/tutor/__tests__/tutor.service.spec.ts
@@ -1,0 +1,114 @@
+import { NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { TutorService } from '../tutor.service';
+
+describe('TutorService', () => {
+  let service: TutorService;
+  let prisma: {
+    tutor: {
+      upsert: jest.Mock;
+      findUnique: jest.Mock;
+      update: jest.Mock;
+    };
+  };
+
+  const tutorFixture = {
+    id: 'tutor-1',
+    auth0Id: 'auth0|123',
+    name: 'Alice',
+    email: 'alice@example.com',
+    phone: null,
+    profileImageUrl: null,
+    role: 'TUTOR',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  beforeEach(async () => {
+    prisma = {
+      tutor: {
+        upsert: jest.fn(),
+        findUnique: jest.fn(),
+        update: jest.fn(),
+      },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [TutorService, { provide: PrismaService, useValue: prisma }],
+    }).compile();
+
+    service = module.get<TutorService>(TutorService);
+  });
+
+  describe('findOrCreate', () => {
+    it('should upsert a tutor by auth0Id', async () => {
+      prisma.tutor.upsert.mockResolvedValue(tutorFixture);
+
+      const result = await service.findOrCreate(
+        'auth0|123',
+        'alice@example.com',
+        'Alice',
+      );
+
+      expect(prisma.tutor.upsert).toHaveBeenCalledWith({
+        where: { auth0Id: 'auth0|123' },
+        update: {},
+        create: {
+          auth0Id: 'auth0|123',
+          email: 'alice@example.com',
+          name: 'Alice',
+        },
+      });
+      expect(result).toBe(tutorFixture);
+    });
+  });
+
+  describe('findByAuth0Id', () => {
+    it('should return the tutor when found', async () => {
+      prisma.tutor.findUnique.mockResolvedValue(tutorFixture);
+
+      const result = await service.findByAuth0Id('auth0|123');
+
+      expect(result).toBe(tutorFixture);
+    });
+
+    it('should throw NotFoundException when tutor is missing', async () => {
+      prisma.tutor.findUnique.mockResolvedValue(null);
+
+      await expect(service.findByAuth0Id('auth0|missing')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('findById', () => {
+    it('should throw NotFoundException when tutor is missing', async () => {
+      prisma.tutor.findUnique.mockResolvedValue(null);
+
+      await expect(service.findById('missing')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('updateByAuth0Id', () => {
+    it('should update the tutor profile', async () => {
+      prisma.tutor.findUnique.mockResolvedValue(tutorFixture);
+      prisma.tutor.update.mockResolvedValue({
+        ...tutorFixture,
+        name: 'Alice Updated',
+      });
+
+      const result = await service.updateByAuth0Id('auth0|123', {
+        name: 'Alice Updated',
+      });
+
+      expect(prisma.tutor.update).toHaveBeenCalledWith({
+        where: { auth0Id: 'auth0|123' },
+        data: { name: 'Alice Updated' },
+      });
+      expect(result.name).toBe('Alice Updated');
+    });
+  });
+});

--- a/src/modules/tutor/tutor.controller.ts
+++ b/src/modules/tutor/tutor.controller.ts
@@ -1,0 +1,34 @@
+import { Body, Controller, Get, Param, Patch } from '@nestjs/common';
+import { Tutor } from '@prisma/client';
+import { UpdateTutorDto } from '@petcardorg/shared';
+import { Auth } from '../auth/decorators/auth.decorator';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { Role } from '../auth/enums/role.enum';
+import type { JwtPayload } from '../auth/strategies/jwt.strategy';
+import { TutorService } from './tutor.service';
+
+@Controller('tutors')
+export class TutorController {
+  constructor(private readonly tutorService: TutorService) {}
+
+  @Get('me')
+  @Auth(Role.TUTOR)
+  async getMe(@CurrentUser() user: JwtPayload): Promise<Tutor> {
+    return this.tutorService.findByAuth0Id(user.sub);
+  }
+
+  @Patch('me')
+  @Auth(Role.TUTOR)
+  async updateMe(
+    @CurrentUser() user: JwtPayload,
+    @Body() dto: UpdateTutorDto,
+  ): Promise<Tutor> {
+    return this.tutorService.updateByAuth0Id(user.sub, dto);
+  }
+
+  @Get(':id')
+  @Auth(Role.VET)
+  async findOne(@Param('id') id: string): Promise<Tutor> {
+    return this.tutorService.findById(id);
+  }
+}

--- a/src/modules/tutor/tutor.module.ts
+++ b/src/modules/tutor/tutor.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { AuthModule } from '../auth/auth.module';
+import { TutorController } from './tutor.controller';
+import { TutorService } from './tutor.service';
+
+@Module({
+  imports: [AuthModule],
+  controllers: [TutorController],
+  providers: [TutorService],
+  exports: [TutorService],
+})
+export class TutorModule {}

--- a/src/modules/tutor/tutor.service.ts
+++ b/src/modules/tutor/tutor.service.ts
@@ -1,0 +1,45 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { Tutor } from '@prisma/client';
+import { UpdateTutorDto } from '@petcardorg/shared';
+import { PrismaService } from '../../prisma/prisma.service';
+
+@Injectable()
+export class TutorService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findOrCreate(
+    auth0Id: string,
+    email: string,
+    name: string,
+  ): Promise<Tutor> {
+    return this.prisma.tutor.upsert({
+      where: { auth0Id },
+      update: {},
+      create: { auth0Id, email, name },
+    });
+  }
+
+  async findByAuth0Id(auth0Id: string): Promise<Tutor> {
+    const tutor = await this.prisma.tutor.findUnique({ where: { auth0Id } });
+    if (!tutor) {
+      throw new NotFoundException(`Tutor with auth0Id ${auth0Id} not found`);
+    }
+    return tutor;
+  }
+
+  async findById(id: string): Promise<Tutor> {
+    const tutor = await this.prisma.tutor.findUnique({ where: { id } });
+    if (!tutor) {
+      throw new NotFoundException(`Tutor with id ${id} not found`);
+    }
+    return tutor;
+  }
+
+  async updateByAuth0Id(auth0Id: string, data: UpdateTutorDto): Promise<Tutor> {
+    await this.findByAuth0Id(auth0Id);
+    return this.prisma.tutor.update({
+      where: { auth0Id },
+      data,
+    });
+  }
+}

--- a/test/cruds-mvp1.e2e-spec.ts
+++ b/test/cruds-mvp1.e2e-spec.ts
@@ -1,0 +1,508 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+jest.mock('jwks-rsa', () => ({
+  passportJwtSecret:
+    () =>
+    (
+      _req: unknown,
+      _token: unknown,
+      done: (err: Error | null, key: string) => void,
+    ) =>
+      done(null, 'test-secret'),
+}));
+
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import request from 'supertest';
+import type { App } from 'supertest/types';
+import { AppModule } from '../src/app.module';
+import { JwtAuthGuard } from '../src/modules/auth/guards/jwt-auth.guard';
+import { PrismaService } from '../src/prisma/prisma.service';
+
+type Ctx = {
+  sub: string;
+  email: string;
+  permissions: string[];
+};
+
+const tutorCtx: Ctx = {
+  sub: 'auth0|tutor-1',
+  email: 'tutor@petcard.com',
+  permissions: ['TUTOR'],
+};
+const vetCtx: Ctx = {
+  sub: 'auth0|vet-1',
+  email: 'vet@petcard.com',
+  permissions: ['VET'],
+};
+
+let currentUser: Ctx = tutorCtx;
+
+const mockPrisma = {
+  tutor: {
+    findUnique: jest.fn(),
+    upsert: jest.fn(),
+    update: jest.fn(),
+  },
+  pet: {
+    create: jest.fn(),
+    findMany: jest.fn(),
+    findUnique: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+  },
+  vaccineRecord: {
+    create: jest.fn(),
+    findMany: jest.fn(),
+    findUnique: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+  },
+  dewormingRecord: {
+    create: jest.fn(),
+    findMany: jest.fn(),
+    findUnique: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+  },
+  medicationRecord: {
+    create: jest.fn(),
+    findMany: jest.fn(),
+    findUnique: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+  },
+  $connect: jest.fn(),
+  $disconnect: jest.fn(),
+};
+
+const tutor1 = {
+  id: '22222222-2222-4222-8222-222222222222',
+  auth0Id: 'auth0|tutor-1',
+  name: 'Alice',
+  email: 'tutor@petcard.com',
+  phone: null,
+  profileImageUrl: null,
+  role: 'TUTOR',
+  createdAt: new Date('2026-01-01'),
+  updatedAt: new Date('2026-01-01'),
+};
+
+const pet1 = {
+  id: '11111111-1111-4111-8111-111111111111',
+  name: 'Rex',
+  species: 'DOG',
+  breed: 'Labrador',
+  sex: 'MALE',
+  birthDate: new Date('2023-05-01'),
+  weight: 20,
+  photoUrl: null,
+  tutorId: '22222222-2222-4222-8222-222222222222',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const vaccine1 = {
+  id: 'vac-uuid-1',
+  petId: '11111111-1111-4111-8111-111111111111',
+  vaccineName: 'Rabies',
+  appliedAt: new Date('2026-01-10'),
+  nextDoseAt: null,
+  veterinarianName: null,
+  notes: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const deworming1 = {
+  id: 'dew-uuid-1',
+  petId: '11111111-1111-4111-8111-111111111111',
+  productName: 'Drontal',
+  appliedAt: new Date('2026-02-01'),
+  nextDoseAt: null,
+  veterinarianName: null,
+  notes: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const medication1 = {
+  id: 'med-uuid-1',
+  petId: '11111111-1111-4111-8111-111111111111',
+  medicationName: 'Amoxicillin',
+  dosage: '500mg',
+  frequency: '8h',
+  startDate: new Date('2026-03-01'),
+  endDate: null,
+  notes: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+describe('CRUDs MVP1 (e2e)', () => {
+  let app: INestApplication<App>;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideProvider(PrismaService)
+      .useValue(mockPrisma)
+      .overrideGuard(JwtAuthGuard)
+      .useValue({
+        canActivate: (context: {
+          switchToHttp: () => { getRequest: () => { user: Ctx } };
+        }) => {
+          const req = context.switchToHttp().getRequest();
+          req.user = currentUser;
+          return true;
+        },
+      })
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    currentUser = tutorCtx;
+    mockPrisma.tutor.findUnique.mockImplementation(
+      ({ where }: { where: { auth0Id?: string; id?: string } }) => {
+        if (
+          where.auth0Id === 'auth0|tutor-1' ||
+          where.id === '22222222-2222-4222-8222-222222222222'
+        ) {
+          return Promise.resolve(tutor1);
+        }
+        return Promise.resolve(null);
+      },
+    );
+  });
+
+  // ============ TUTOR ============
+  describe('Tutor', () => {
+    it('GET /tutors/me returns the authenticated tutor', async () => {
+      await request(app.getHttpServer())
+        .get('/tutors/me')
+        .expect(200)
+        .expect((res) => {
+          expect(res.body.id).toBe('22222222-2222-4222-8222-222222222222');
+          expect(res.body.email).toBe('tutor@petcard.com');
+        });
+    });
+
+    it('PATCH /tutors/me updates the authenticated tutor', async () => {
+      mockPrisma.tutor.update.mockResolvedValue({ ...tutor1, name: 'Alice B' });
+
+      await request(app.getHttpServer())
+        .patch('/tutors/me')
+        .send({ name: 'Alice B' })
+        .expect(200)
+        .expect((res) => expect(res.body.name).toBe('Alice B'));
+
+      expect(mockPrisma.tutor.update).toHaveBeenCalledWith({
+        where: { auth0Id: 'auth0|tutor-1' },
+        data: { name: 'Alice B' },
+      });
+    });
+
+    it('PATCH /tutors/me rejects invalid payload', async () => {
+      await request(app.getHttpServer())
+        .patch('/tutors/me')
+        .send({ email: 'not-an-email' })
+        .expect(400);
+    });
+
+    it('GET /tutors/:id requires VET role', async () => {
+      currentUser = tutorCtx;
+      await request(app.getHttpServer())
+        .get('/tutors/22222222-2222-4222-8222-222222222222')
+        .expect(403);
+    });
+
+    it('GET /tutors/:id returns tutor for VET', async () => {
+      currentUser = vetCtx;
+      await request(app.getHttpServer())
+        .get('/tutors/22222222-2222-4222-8222-222222222222')
+        .expect(200)
+        .expect((res) =>
+          expect(res.body.id).toBe('22222222-2222-4222-8222-222222222222'),
+        );
+    });
+  });
+
+  // ============ PET ============
+  describe('Pet', () => {
+    it('POST /pets creates a pet for the tutor', async () => {
+      mockPrisma.pet.create.mockResolvedValue(pet1);
+
+      await request(app.getHttpServer())
+        .post('/pets')
+        .send({
+          name: 'Rex',
+          species: 'DOG',
+          sex: 'MALE',
+          breed: 'Labrador',
+          weight: 20,
+          tutor_id: '22222222-2222-4222-8222-222222222222',
+        })
+        .expect(201)
+        .expect((res) =>
+          expect(res.body.id).toBe('11111111-1111-4111-8111-111111111111'),
+        );
+
+      expect(mockPrisma.pet.create).toHaveBeenCalled();
+      const arg = mockPrisma.pet.create.mock.calls[0][0] as {
+        data: { tutorId: string };
+      };
+      expect(arg.data.tutorId).toBe('22222222-2222-4222-8222-222222222222');
+    });
+
+    it('POST /pets rejects missing required fields', async () => {
+      await request(app.getHttpServer())
+        .post('/pets')
+        .send({ name: 'Rex' })
+        .expect(400);
+    });
+
+    it('GET /pets lists tutor pets', async () => {
+      mockPrisma.pet.findMany.mockResolvedValue([pet1]);
+
+      await request(app.getHttpServer())
+        .get('/pets')
+        .expect(200)
+        .expect((res) => {
+          expect(res.body).toHaveLength(1);
+          expect(res.body[0].id).toBe('11111111-1111-4111-8111-111111111111');
+        });
+
+      expect(mockPrisma.pet.findMany).toHaveBeenCalledWith({
+        where: { tutorId: '22222222-2222-4222-8222-222222222222' },
+      });
+    });
+
+    it('GET /pets/:id returns the pet for the owner', async () => {
+      mockPrisma.pet.findUnique.mockResolvedValue(pet1);
+
+      await request(app.getHttpServer())
+        .get('/pets/11111111-1111-4111-8111-111111111111')
+        .expect(200)
+        .expect((res) =>
+          expect(res.body.id).toBe('11111111-1111-4111-8111-111111111111'),
+        );
+    });
+
+    it('GET /pets/:id forbids non-owner tutor', async () => {
+      mockPrisma.pet.findUnique.mockResolvedValue({
+        ...pet1,
+        tutorId: 'other-tutor',
+      });
+
+      await request(app.getHttpServer())
+        .get('/pets/11111111-1111-4111-8111-111111111111')
+        .expect(403);
+    });
+
+    it('GET /pets/:id allows VET access', async () => {
+      currentUser = vetCtx;
+      mockPrisma.pet.findUnique.mockResolvedValue({
+        ...pet1,
+        tutorId: 'other-tutor',
+      });
+
+      await request(app.getHttpServer())
+        .get('/pets/11111111-1111-4111-8111-111111111111')
+        .expect(200);
+    });
+
+    it('PATCH /pets/:id updates an owned pet', async () => {
+      mockPrisma.pet.findUnique.mockResolvedValue(pet1);
+      mockPrisma.pet.update.mockResolvedValue({ ...pet1, name: 'Rex II' });
+
+      await request(app.getHttpServer())
+        .patch('/pets/11111111-1111-4111-8111-111111111111')
+        .send({ name: 'Rex II' })
+        .expect(200)
+        .expect((res) => expect(res.body.name).toBe('Rex II'));
+    });
+
+    it('DELETE /pets/:id deletes an owned pet', async () => {
+      mockPrisma.pet.findUnique.mockResolvedValue(pet1);
+      mockPrisma.pet.delete.mockResolvedValue(pet1);
+
+      await request(app.getHttpServer())
+        .delete('/pets/11111111-1111-4111-8111-111111111111')
+        .expect(204);
+    });
+  });
+
+  // ============ VACCINE ============
+  describe('Vaccine', () => {
+    beforeEach(() => {
+      mockPrisma.pet.findUnique.mockResolvedValue(pet1);
+    });
+
+    it('POST /pets/:petId/vaccines creates a record', async () => {
+      mockPrisma.vaccineRecord.create.mockResolvedValue(vaccine1);
+
+      await request(app.getHttpServer())
+        .post('/pets/11111111-1111-4111-8111-111111111111/vaccines')
+        .send({
+          pet_id: '11111111-1111-4111-8111-111111111111',
+          vaccine_name: 'Rabies',
+          applied_at: '2026-01-10',
+        })
+        .expect(201)
+        .expect((res) => expect(res.body.id).toBe('vac-uuid-1'));
+    });
+
+    it('GET /pets/:petId/vaccines lists records', async () => {
+      mockPrisma.vaccineRecord.findMany.mockResolvedValue([vaccine1]);
+
+      await request(app.getHttpServer())
+        .get('/pets/11111111-1111-4111-8111-111111111111/vaccines')
+        .expect(200)
+        .expect((res) => expect(res.body).toHaveLength(1));
+    });
+
+    it('PATCH /vaccines/:id updates the record', async () => {
+      mockPrisma.vaccineRecord.findUnique.mockResolvedValue(vaccine1);
+      mockPrisma.vaccineRecord.update.mockResolvedValue({
+        ...vaccine1,
+        vaccineName: 'Rabies Plus',
+      });
+
+      await request(app.getHttpServer())
+        .patch('/vaccines/vac-uuid-1')
+        .send({ vaccine_name: 'Rabies Plus' })
+        .expect(200)
+        .expect((res) => expect(res.body.vaccineName).toBe('Rabies Plus'));
+    });
+
+    it('DELETE /vaccines/:id removes the record', async () => {
+      mockPrisma.vaccineRecord.findUnique.mockResolvedValue(vaccine1);
+      mockPrisma.vaccineRecord.delete.mockResolvedValue(vaccine1);
+
+      await request(app.getHttpServer())
+        .delete('/vaccines/vac-uuid-1')
+        .expect(204);
+    });
+  });
+
+  // ============ DEWORMING ============
+  describe('Deworming', () => {
+    beforeEach(() => {
+      mockPrisma.pet.findUnique.mockResolvedValue(pet1);
+    });
+
+    it('POST /pets/:petId/dewormings creates a record', async () => {
+      mockPrisma.dewormingRecord.create.mockResolvedValue(deworming1);
+
+      await request(app.getHttpServer())
+        .post('/pets/11111111-1111-4111-8111-111111111111/dewormings')
+        .send({
+          pet_id: '11111111-1111-4111-8111-111111111111',
+          product_name: 'Drontal',
+          applied_at: '2026-02-01',
+        })
+        .expect(201)
+        .expect((res) => expect(res.body.id).toBe('dew-uuid-1'));
+    });
+
+    it('GET /pets/:petId/dewormings lists records', async () => {
+      mockPrisma.dewormingRecord.findMany.mockResolvedValue([deworming1]);
+
+      await request(app.getHttpServer())
+        .get('/pets/11111111-1111-4111-8111-111111111111/dewormings')
+        .expect(200)
+        .expect((res) => expect(res.body).toHaveLength(1));
+    });
+
+    it('PATCH /dewormings/:id updates the record', async () => {
+      mockPrisma.dewormingRecord.findUnique.mockResolvedValue(deworming1);
+      mockPrisma.dewormingRecord.update.mockResolvedValue({
+        ...deworming1,
+        productName: 'Drontal Plus',
+      });
+
+      await request(app.getHttpServer())
+        .patch('/dewormings/dew-uuid-1')
+        .send({ product_name: 'Drontal Plus' })
+        .expect(200);
+    });
+
+    it('DELETE /dewormings/:id removes the record', async () => {
+      mockPrisma.dewormingRecord.findUnique.mockResolvedValue(deworming1);
+      mockPrisma.dewormingRecord.delete.mockResolvedValue(deworming1);
+
+      await request(app.getHttpServer())
+        .delete('/dewormings/dew-uuid-1')
+        .expect(204);
+    });
+  });
+
+  // ============ MEDICATION ============
+  describe('Medication', () => {
+    beforeEach(() => {
+      mockPrisma.pet.findUnique.mockResolvedValue(pet1);
+    });
+
+    it('POST /pets/:petId/medications creates a record', async () => {
+      mockPrisma.medicationRecord.create.mockResolvedValue(medication1);
+
+      await request(app.getHttpServer())
+        .post('/pets/11111111-1111-4111-8111-111111111111/medications')
+        .send({
+          pet_id: '11111111-1111-4111-8111-111111111111',
+          medication_name: 'Amoxicillin',
+          dosage: '500mg',
+          frequency: '8h',
+          start_date: '2026-03-01',
+        })
+        .expect(201)
+        .expect((res) => expect(res.body.id).toBe('med-uuid-1'));
+    });
+
+    it('GET /pets/:petId/medications lists records', async () => {
+      mockPrisma.medicationRecord.findMany.mockResolvedValue([medication1]);
+
+      await request(app.getHttpServer())
+        .get('/pets/11111111-1111-4111-8111-111111111111/medications')
+        .expect(200)
+        .expect((res) => expect(res.body).toHaveLength(1));
+    });
+
+    it('PATCH /medications/:id updates the record', async () => {
+      mockPrisma.medicationRecord.findUnique.mockResolvedValue(medication1);
+      mockPrisma.medicationRecord.update.mockResolvedValue({
+        ...medication1,
+        dosage: '250mg',
+      });
+
+      await request(app.getHttpServer())
+        .patch('/medications/med-uuid-1')
+        .send({ dosage: '250mg' })
+        .expect(200);
+    });
+
+    it('DELETE /medications/:id removes the record', async () => {
+      mockPrisma.medicationRecord.findUnique.mockResolvedValue(medication1);
+      mockPrisma.medicationRecord.delete.mockResolvedValue(medication1);
+
+      await request(app.getHttpServer())
+        .delete('/medications/med-uuid-1')
+        .expect(204);
+    });
+  });
+});

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -5,5 +5,6 @@
   "testRegex": ".e2e-spec.ts$",
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
-  }
+  },
+  "transformIgnorePatterns": ["node_modules/(?!jose)"]
 }


### PR DESCRIPTION
  Adiciona os módulos Tutor, Pet, Vaccine, Deworming e Medication com
  endpoints protegidos por @Auth e validação de ownership. Habilita
  ValidationPipe global e inclui testes unitários e e2e cobrindo os
  18 endpoints.

  PC-029, PC-030, PC-031, PC-032, PC-033