### PR TITLE
feat(card): cria migration da tabela carteira_digital (PC-054)

### DIFF
--- a/prisma/migrations/20260426204420_add_carteira_digital/migration.sql
+++ b/prisma/migrations/20260426204420_add_carteira_digital/migration.sql
@@ -1,0 +1,19 @@
+-- CreateTable
+CREATE TABLE "carteira_digital" (
+    "id" TEXT NOT NULL,
+    "pet_id" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "qr_code_url" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "carteira_digital_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "carteira_digital_pet_id_key" ON "carteira_digital"("pet_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "carteira_digital_token_key" ON "carteira_digital"("token");
+
+-- AddForeignKey
+ALTER TABLE "carteira_digital" ADD CONSTRAINT "carteira_digital_pet_id_fkey" FOREIGN KEY ("pet_id") REFERENCES "pet"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -58,8 +58,21 @@ model Pet {
   vaccineRecords     VaccineRecord[]
   dewormingRecords   DewormingRecord[]
   medicationRecords  MedicationRecord[]
+  carteiraDigital    CarteiraDigital?
 
   @@map("pet")
+}
+
+model CarteiraDigital {
+  id        String   @id @default(uuid())
+  petId     String   @unique @map("pet_id")
+  token     String   @unique
+  qrCodeUrl String?  @map("qr_code_url")
+  createdAt DateTime @default(now()) @map("created_at")
+
+  pet Pet @relation(fields: [petId], references: [id], onDelete: Cascade)
+
+  @@map("carteira_digital")
 }
 
 model VaccineRecord {


### PR DESCRIPTION
  Adiciona model CarteiraDigital com campos id, pet_id (unique),
  token (unique), qr_code_url e created_at, com FK para pet em cascade.