### PR TITLE
feat(card): rota pública GET /cards/:token (PC-049)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,111 +1,161 @@
-# PetCard API — Contexto para Claude Code
+# PetCard — Contexto para Claude Code
 
-## Sobre o Projeto
+## Projeto
 
-PetCard é um TCC (Trabalho de Conclusão de Curso) que consiste em uma carteira digital de saúde para pets. A arquitetura é Multirepo com 5 repositórios sob a organização GitHub `PetCardOrg`.
+PetCard — carteira digital de saúde para pets. TCC do Ricardo Temporal.
+Multirepo sob `PetCardOrg`:
 
-## Repositórios
+- `petcard-api` (NestJS 11 + Prisma 6 + Postgres + Redis + RabbitMQ + S3)
+- `petcard-mobile` (React Native + Expo, `expo-auth-session` PKCE)
+- `petcard-web` (Vite + React 19 — esqueleto, sem router/UI ainda)
+- `petcard-shared` (npm `@petcardorg/shared@0.5.0` no GitHub Packages)
+- `petcard-docs` (ADRs em `architecture/adr/`, board centralizado)
 
-- **petcard-api** (este repo) — Backend NestJS (TypeScript)
-- **petcard-web** — Painel do Veterinário (React.js + Vite)
-- **petcard-mobile** — App do Tutor (React Native / Expo)
-- **petcard-shared** — Pacote npm `@petcardorg/shared` (DTOs, Enums, Types)
-- **petcard-docs** — Documentação e gestão central
+Equipe: Álvaro Araújo (Backend Lead), Camila Martins (DevOps/PM), Ricardo Temporal (Frontend Lead).
 
-## Equipe
+## Stack (api)
 
-- Álvaro Araújo
-- Camila Martins
-- Ricardo Temporal
+- NestJS 11, `@nestjs/passport` + `passport-jwt` + `jwks-rsa`
+- Prisma 6.19, Postgres via imagem `postgis/postgis:16-3.4` (PostGIS já provisionado para M3)
+- AWS SDK v3 (`@aws-sdk/client-s3`, `s3-request-presigner`)
+- `qrcode@1.5.4` para geração de PNG
+- Redis e RabbitMQ no docker-compose, **ainda não consumidos por código**
+- Jest unitário + e2e (`test/jest-e2e.json`)
+- `@petcardorg/shared@^0.5.0`
 
-## Stack Técnica (API)
+## Auth
 
-- **Framework:** NestJS (TypeScript, strict mode)
-- **ORM:** Prisma 6
-- **Banco:** PostgreSQL
-- **Autenticação:** Auth0 + JWT
-- **Pacote compartilhado:** `@petcardorg/shared` via GitHub Packages
-- **CI/CD:** GitHub Actions
-- **Gerenciador de pacotes:** npm
+- Auth0 (`AUTH0_DOMAIN`, `AUTH0_AUDIENCE`)
+- Roles: `TUTOR` (mobile), `VET` (web)
+- Decorators: `@Auth(Role)`, `@Roles(...)`, `@CurrentUser()`
+- Guards: `JwtAuthGuard`, `RolesGuard`
+- **Auth é opt-in** (não há `APP_GUARD` global). Rota sem `@Auth` é pública por design — cuidar ao criar endpoints
+- Mobile: `expo-auth-session` com PKCE (não `react-native-auth0`)
+- `RolesGuard` consulta o role no banco (não confia só no token)
 
-## Arquitetura do petcard-api
+## Status das milestones
 
+- **M0** ✅ Setup e Fundações (multirepo, GitHub Packages, ADR-001)
+- **M1** ✅ Auth + CRUDs (Tutor, Pet, Vaccine, Deworming, Medication), upload S3, seed
+- **M2** 🚧 Carteira Digital + QR Code — em andamento (3/10 issues fechadas + 2 fechadas no shared, 5 abertas)
+- **M3** 📋 Geolocalização + Clínicas — backlog detalhado, não iniciado
+
+## M2 — Carteira Digital + QR Code
+
+**Objetivo:** pet ganha uma carteira digital com QR Code que aponta para uma rota pública (sem auth) com o histórico de saúde — útil quando o pet é encontrado perdido ou em consulta com VET sem cadastro.
+
+### Issues
+
+| Código | Repo   | #   | Título                               | Status real                                                 | Evidência                                                             |
+| ------ | ------ | --- | ------------------------------------ | ----------------------------------------------------------- | --------------------------------------------------------------------- |
+| PC-047 | api    | #18 | Geração QR (UUID + token)            | ✅ Done                                                     | PR #53; `card.service.generateQrCode`                                 |
+| PC-048 | api    | #19 | Upload QR para S3                    | ✅ Done                                                     | PR #54; `upload.service.uploadBuffer`; key `qr-codes/{petId}.png`     |
+| PC-054 | api    | #22 | Migration `carteira_digital`         | ✅ Done                                                     | PR #55; migration `20260426204420`                                    |
+| PC-055 | shared | #6  | DTOs CarteiraDigital                 | ✅ Done                                                     | PR #23; em `@petcardorg/shared@0.4.0`                                 |
+| PC-056 | shared | #7  | Publicar shared com DTOs             | ✅ Done (0.5.0 publicado)                                   |
+| PC-049 | api    | #20 | Rota pública `GET /cards/:token`     | 🚧 In Progress (branch `feature/PC-049-rota-publica-cards`) | rota + service + specs + e2e prontos; aguarda PR                      |
+| PC-050 | api    | #21 | Worker RabbitMQ — geração assíncrona | 📋 To Do                                                    | RabbitMQ no compose, sem código; `bullmq`/`amqplib` ausentes          |
+| PC-051 | mobile | #13 | Tela carteira digital + QR           | 📋 To Do                                                    | sem `Carteira/Wallet/QRCode` screens; mobile ainda em shared `^0.2.1` |
+| PC-052 | mobile | #14 | Compartilhar link da carteira        | 📋 To Do                                                    | sem `expo-sharing`/`Share.share`                                      |
+| PC-053 | web    | #6  | Página pública SPA `/card/:token`    | 📋 To Do                                                    | repo só tem template Vite + React 19, sem router                      |
+
+### Decisões já tomadas (extraídas do código — não há ADR de M2)
+
+- **Token:** `randomUUID()` opaco, único por pet (`carteira_digital.token UNIQUE`). Renovado a cada `regenerateQrCode`.
+- **Conteúdo do QR:** PNG 400×400, errorCorrection `M`, payload **URL navegável** `${CARD_PUBLIC_BASE_URL}/${token}` (default `https://card.petcard.app/{token}`). Configurado via `card.publicBaseUrl` em `src/config/card.config.ts`.
+- **Rota pública:** `GET /cards/:token` no `CardController` (path `cards`, plural). Sem guard, **sem rate-limit por enquanto** (a adicionar em PC futuro), sem expiração do token.
+- **Resposta pública:** retorna pet completo + `tutor_name` + todos os vacinas/vermifugações/medicações (incluindo `notes` e `veterinarian_name`) ordenados desc por data. Filtro de privacidade pode ser revisitado depois.
+- **Bucket S3:** URL pública direta (`https://{bucket}.s3.{region}.amazonaws.com/{key}`) — assume bucket público. `qr-codes/{petId}.png` sobrescreve a cada regeneração.
+- **Source of truth do `qr_code_url`:** `carteira_digital.qr_code_url`. Coluna redundante em `pet` removida na migration `20260429171445_drop_pet_qr_code_url`. `pet.service` lê via `include: { carteiraDigital: true }`.
+- **Geração:** **síncrona** dentro de `pet.create()` e `pet.regenerateQrCode()`. Falha de S3 não quebra criação (`try/catch` + log + retorna `null`). PC-050 vai mover para fila.
+- **PrismaModule é `@Global()`** — qualquer service injeta `PrismaService` sem importar.
+
+### Decisões pendentes (perguntar ao Ricardo antes de codar)
+
+1. Stack do worker PC-050: BullMQ (Redis, já no compose) ou AMQP via `@golevelup/nestjs-rabbitmq`?
+2. Web (PC-053): router (react-router vs TanStack), state, UI lib — tudo em aberto.
+3. Mobile (PC-051): bumpar shared para `^0.5.0` antes? Lib de QR: `react-native-qrcode-svg`?
+4. Rate-limit na rota pública (deferido de PC-049): `@nestjs/throttler` quando?
+5. Filtro de privacidade na resposta pública (deferido de PC-049): ocultar `notes`/`veterinarian_name` dos registros médicos?
+
+### O que falta na M2 (ordem sugerida)
+
+1. PC-049: PR e merge na develop (rota pública pronta no working tree).
+2. Decidir #1 → implementar PC-050 (mover geração de QR para fila)
+3. Bumpar mobile para shared `^0.5.0` → PC-051 → PC-052
+4. Decidir #2 → bootstrap do `petcard-web` → PC-053
+5. PC-056: só corrigir título da issue (já entregue como 0.5.0)
+
+## M3 — Geolocalização + Clínicas (preview)
+
+PostGIS (`ST_DWithin`), Google Maps API geocoding, filtros de especialidade/avaliação/distância, migration com tipo `GEOGRAPHY`, seed de clínicas com coordenadas reais. Postgres já roda na imagem PostGIS desde M1. **Não codar nada de M3 até M2 fechar.**
+
+## Convenções
+
+- **Branches:** `feature/PC-XXX-descricao-kebab` (padrão visto em PRs mergeados)
+- **Commits:** Conventional Commits (`feat(card): ...`, `fix(auth): ...`, `chore(deps): ...`, `test(pet): ...`)
+- **PRs:** mergeados via PR (não direto em `develop`); título e branch carregam o `PC-XXX`
+- **DTOs compartilhados:** sempre em `@petcardorg/shared`; campos em `snake_case` (`pet_id`, `qr_code_url`); bump minor para nova feature, publicar via CI no GitHub Packages
+- **Testes:** unit obrigatório para services novos (`__tests__/<file>.spec.ts` colado ao módulo); e2e obrigatório para endpoints públicos sem auth
+- **Migrations:** `prisma migrate dev --name <descricao_snake_case>`; nome inclui timestamp gerado pelo Prisma
+- **ADRs:** decisões arquiteturais relevantes vão em `petcard-docs/architecture/adr/` antes de codar (hoje só ADR-001 existe — multirepo)
+
+## Princípios de trabalho
+
+- **YAGNI.** Não introduzir filas, caches ou abstrações sem demanda da issue.
+- **Reutilizar antes de criar.** Procurar equivalente em `petcard-api` e `@petcardorg/shared` antes de novo código.
+- **Investigar antes de codar.** Sempre ler o módulo existente antes de propor arquitetura — em especial `card.service`, `pet.service`, `upload.service`.
+- **Falha de serviço externo (S3) não quebra fluxo crítico** — degradar com graça, logar via `Logger`.
+- **Rotas públicas (sem auth) são superfície de risco** — validar token, retornar apenas o necessário, considerar rate-limit.
+- **Atualizar `@petcardorg/shared` exige bump de versão e publish via CI** — depois bumpar consumidores (api/mobile/web).
+
+## Escopo fora de M2 (não fazer agora)
+
+- Issues de M3 (PostGIS, Google Maps, clínicas)
+- Refactors amplos não relacionados à carteira digital
+- Substituir libs já estabelecidas (Prisma, NestJS, AWS SDK v3)
+
+## Ambiente de desenvolvimento
+
+- Codespace do `petcard-api` com `petcard-shared` e `petcard-mobile` clonados em `/workspaces/`
+- `petcard-web` e `petcard-docs` **não** clonados — usar `gh` CLI ou clonar sob demanda
+- Docker Compose em `docker/docker-compose.yml`: postgres (PostGIS), redis, rabbitmq (com management UI em :15672)
+- Mobile precisa `NODE_AUTH_TOKEN=$GITHUB_TOKEN` para resolver `@petcardorg/shared` no install
+- Setup local Windows também documentado em outra parte; Postgres 17 nativo precisa ficar parado para Docker usar a 5432
+
+## Comandos úteis
+
+```bash
+# API
+docker compose -f docker/docker-compose.yml up -d
+npm run start:dev
+npx prisma studio
+npx prisma migrate dev
+npm run db:seed
+npm test
+npm run test:e2e
+
+# Listar M2 em todos os repos (label não existe — usar milestone)
+for r in petcard-api petcard-mobile petcard-web petcard-shared petcard-docs; do
+  gh issue list --repo PetCardOrg/$r --milestone "M2 - Carteira Digital + QR Code" --state all
+done
+
+# Sincronizar todos os repos clonados
+for r in petcard-api petcard-mobile petcard-shared; do
+  git -C /workspaces/$r fetch --all --prune
+done
 ```
-src/
-├── modules/              # Módulos de domínio (1 por agregado)
-│   ├── auth/             # Auth0 + JWT (PC-027, PC-028)
-│   │   ├── auth.module.ts
-│   │   ├── auth.controller.ts
-│   │   ├── auth.service.ts
-│   │   ├── strategies/   # JWT strategy
-│   │   ├── guards/       # AuthGuard, RolesGuard
-│   │   └── __tests__/
-│   ├── pet/              # CRUD Pet
-│   ├── health/           # Vacinas, Vermifugações, Medicações
-│   ├── card/             # Carteira Digital + QR Code
-│   └── ...
-├── common/               # Cross-cutting concerns
-│   ├── decorators/
-│   ├── filters/
-│   ├── interceptors/
-│   ├── pipes/
-│   └── middleware/
-├── config/               # Configurações por ambiente
-├── app.module.ts
-└── main.ts
-prisma/
-├── schema.prisma
-├── migrations/
-└── seed.ts
-```
 
-## Convenções de Código
+## Referências rápidas
 
-- **Linguagem do código:** Inglês (nomes de variáveis, classes, funções)
-- **Comentários:** Podem ser em português
-- **Strict mode:** `"strict": true` no tsconfig
-- **Módulos NestJS:** Um módulo por domínio
-- **Services:** Contêm lógica de negócio
-- **Controllers:** Apenas roteiam (sem lógica de negócio)
-- **DTOs:** Validados com class-validator
-- **Testes:** Todo endpoint novo precisa de teste unitário no service
-- **Banco de dados:** Toda alteração via Prisma Migrations, nunca SQL manual
-- **Tabelas/colunas:** snake_case
+- Arquivos centrais de M2:
+  - `prisma/schema.prisma` — modelos `Pet`, `CarteiraDigital`
+  - `src/modules/card/card.service.ts` — `generateQrCode`, `issueTokenForPet`, `setCardQrCodeUrl`, `findPublicByToken`
+  - `src/modules/card/card.controller.ts` — `GET /cards/qr-code` (auth) e `GET /cards/:token` (público, em diff)
+  - `src/modules/pet/pet.service.ts:178` — `generateAndUploadQrCode`
+  - `src/modules/upload/upload.service.ts` — `uploadBuffer` (in-memory PNG)
+- ADRs: `gh api repos/PetCardOrg/petcard-docs/contents/architecture/adr` (hoje só `001-multirepo-strategy.md`)
 
-## Convenções de Commit
+## Última atualização
 
-Seguimos Conventional Commits:
-
-```
-feat(auth): implementa JWT strategy com Auth0
-fix(pet): corrige validação de espécie no cadastro
-test(auth): adiciona testes unitários do AuthService
-chore(ci): configura workflow de lint
-```
-
-## Branches
-
-- `main` — produção (protegida)
-- `develop` — integração (protegida)
-- Feature branches: `feature/PC-XXX-descricao-curta`
-
-Sempre criar branches a partir de `develop`.
-
-## Princípio YAGNI
-
-Só criar pastas e instalar dependências quando a issue em andamento exigir. Não criar estrutura antecipadamente.
-
-## Milestone Atual: M1 — MVP 1: Cadastro + Saúde Básica (Semana 3-6)
-
-Issues do M1 neste repo:
-
-- PC-027: Implementar módulo Auth (Auth0 + JWT strategy)
-- PC-028: Implementar guards de autenticação e autorização (RBAC)
-- PC-029: CRUD completo do módulo Tutor
-- PC-030: CRUD completo do módulo Pet
-- PC-031: CRUD módulo Vacina
-- PC-032: CRUD módulo Vermifugação
-- PC-033: CRUD módulo Medicação
-- PC-034: Upload de imagens para AWS S3
-- PC-035: Seed script com dados de teste
-- PC-046: Criar migrations para tabelas do MVP 1
+2026-04-29 — atualizado por Claude Code: redundância `pet.qr_code_url` resolvida (PR mergeado), decisões de PC-049 fechadas (URL no QR; sem rate-limit por agora; resposta pública sem filtro de privacidade)

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@nestjs/core": "^11.0.1",
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.0.1",
+        "@nestjs/throttler": "^6.5.0",
         "@petcardorg/shared": "^0.5.0",
         "@prisma/client": "^6.19.3",
         "jwks-rsa": "^4.0.1",
@@ -3272,6 +3273,17 @@
         "@nestjs/platform-express": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/throttler": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/throttler/-/throttler-6.5.0.tgz",
+      "integrity": "sha512-9j0ZRfH0QE1qyrj9JjIRDz5gQLPqq9yVC2nHsrosDVAfI5HHw08/aUAWx9DZLSdQf4HDkmhTTEGLrRFHENvchQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "reflect-metadata": "^0.1.13 || ^0.2.0"
       }
     },
     "node_modules/@noble/hashes": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@nestjs/core": "^11.0.1",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/throttler": "^6.5.0",
     "@petcardorg/shared": "^0.5.0",
     "@prisma/client": "^6.19.3",
     "jwks-rsa": "^4.0.1",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,6 +4,7 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { authConfig } from './config/auth.config';
 import { awsConfig } from './config/aws.config';
+import { cardConfig } from './config/card.config';
 import { AuthModule } from './modules/auth/auth.module';
 import { CardModule } from './modules/card/card.module';
 import { DewormingModule } from './modules/health/deworming/deworming.module';
@@ -18,7 +19,7 @@ import { PrismaModule } from './prisma/prisma.module';
   imports: [
     ConfigModule.forRoot({
       isGlobal: true,
-      load: [authConfig, awsConfig],
+      load: [authConfig, awsConfig, cardConfig],
     }),
     PrismaModule,
     AuthModule,

--- a/src/config/card.config.ts
+++ b/src/config/card.config.ts
@@ -1,0 +1,9 @@
+import { registerAs } from '@nestjs/config';
+
+export const cardConfig = registerAs('card', () => ({
+  publicBaseUrl: process.env.PUBLIC_CARD_BASE_URL ?? 'https://card.petcard.app',
+  publicThrottleTtlSeconds: Number(
+    process.env.PUBLIC_CARD_THROTTLE_TTL_SECONDS ?? 60,
+  ),
+  publicThrottleLimit: Number(process.env.PUBLIC_CARD_THROTTLE_LIMIT ?? 10),
+}));

--- a/src/modules/card/__tests__/card.controller.spec.ts
+++ b/src/modules/card/__tests__/card.controller.spec.ts
@@ -1,13 +1,19 @@
-import { UnauthorizedException } from '@nestjs/common';
+import { NotFoundException, UnauthorizedException } from '@nestjs/common';
 import { CardController } from '../card.controller';
 import { CardService } from '../card.service';
 
 describe('CardController', () => {
   let controller: CardController;
-  let cardService: { generateQrCode: jest.Mock };
+  let cardService: {
+    generateQrCode: jest.Mock;
+    findPublicByToken: jest.Mock;
+  };
 
   beforeEach(() => {
-    cardService = { generateQrCode: jest.fn() };
+    cardService = {
+      generateQrCode: jest.fn(),
+      findPublicByToken: jest.fn(),
+    };
     controller = new CardController(cardService as unknown as CardService);
   });
 
@@ -20,28 +26,54 @@ describe('CardController', () => {
     return { req, res };
   }
 
-  it('should return PNG buffer with correct headers', async () => {
-    const fakeBuffer = Buffer.from('fake-png');
-    cardService.generateQrCode.mockResolvedValue(fakeBuffer);
+  describe('getQrCode', () => {
+    it('should return PNG buffer with correct headers', async () => {
+      const fakeBuffer = Buffer.from('fake-png');
+      cardService.generateQrCode.mockResolvedValue(fakeBuffer);
 
-    const { req, res } = createMockReqRes('Bearer my-jwt-token');
-    await controller.getQrCode(req, res);
+      const { req, res } = createMockReqRes('Bearer my-jwt-token');
+      await controller.getQrCode(req, res);
 
-    expect(cardService.generateQrCode).toHaveBeenCalledWith('my-jwt-token');
-    expect((res as { set: jest.Mock }).set).toHaveBeenCalledWith(
-      expect.objectContaining({
-        'Content-Type': 'image/png',
-        'Cache-Control': 'no-store',
-      }),
-    );
-    expect((res as { send: jest.Mock }).send).toHaveBeenCalledWith(fakeBuffer);
+      expect(cardService.generateQrCode).toHaveBeenCalledWith('my-jwt-token');
+      expect((res as { set: jest.Mock }).set).toHaveBeenCalledWith(
+        expect.objectContaining({
+          'Content-Type': 'image/png',
+          'Cache-Control': 'no-store',
+        }),
+      );
+      expect((res as { send: jest.Mock }).send).toHaveBeenCalledWith(
+        fakeBuffer,
+      );
+    });
+
+    it('should throw UnauthorizedException when authorization header is missing', async () => {
+      const { req, res } = createMockReqRes(undefined);
+
+      await expect(controller.getQrCode(req, res)).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
   });
 
-  it('should throw UnauthorizedException when authorization header is missing', async () => {
-    const { req, res } = createMockReqRes(undefined);
+  describe('getPublicCard', () => {
+    it('should return the public card by token', async () => {
+      const dto = { pet_id: 'pet-1', pet_name: 'Rex' };
+      cardService.findPublicByToken.mockResolvedValue(dto);
 
-    await expect(controller.getQrCode(req, res)).rejects.toThrow(
-      UnauthorizedException,
-    );
+      const result = await controller.getPublicCard('tok-abc');
+
+      expect(cardService.findPublicByToken).toHaveBeenCalledWith('tok-abc');
+      expect(result).toBe(dto);
+    });
+
+    it('should propagate NotFoundException for invalid tokens', async () => {
+      cardService.findPublicByToken.mockRejectedValue(
+        new NotFoundException('Carteira digital not found'),
+      );
+
+      await expect(controller.getPublicCard('bad')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
   });
 });

--- a/src/modules/card/__tests__/card.service.spec.ts
+++ b/src/modules/card/__tests__/card.service.spec.ts
@@ -1,6 +1,11 @@
-import { InternalServerErrorException } from '@nestjs/common';
+import {
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import * as QRCode from 'qrcode';
+import { Sex, Species } from '@petcardorg/shared';
 import { PrismaService } from '../../../prisma/prisma.service';
 import { CardService } from '../card.service';
 
@@ -8,19 +13,33 @@ jest.mock('qrcode');
 
 describe('CardService', () => {
   let service: CardService;
-  const mockedQRCode = jest.mocked(QRCode);
-  const prismaMock = {
+  let prisma: {
     carteiraDigital: {
-      upsert: jest.fn(),
-      update: jest.fn(),
-    },
+      upsert: jest.Mock;
+      update: jest.Mock;
+      findUnique: jest.Mock;
+    };
   };
+  let configService: { get: jest.Mock };
+  const mockedQRCode = jest.mocked(QRCode);
 
   beforeEach(async () => {
+    prisma = {
+      carteiraDigital: {
+        upsert: jest.fn(),
+        update: jest.fn(),
+        findUnique: jest.fn(),
+      },
+    };
+    configService = {
+      get: jest.fn().mockReturnValue('https://card.petcard.app'),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         CardService,
-        { provide: PrismaService, useValue: prismaMock },
+        { provide: PrismaService, useValue: prisma },
+        { provide: ConfigService, useValue: configService },
       ],
     }).compile();
 
@@ -32,41 +51,29 @@ describe('CardService', () => {
   });
 
   describe('generateQrCode', () => {
-    it('should return a PNG buffer with uuid and token in the payload', async () => {
+    it('should encode the public card URL using PUBLIC_CARD_BASE_URL + token', async () => {
       const fakeBuffer = Buffer.from('fake-png');
       mockedQRCode.toBuffer.mockResolvedValue(fakeBuffer as never);
 
-      const result = await service.generateQrCode('my-jwt-token');
+      const result = await service.generateQrCode('tok-abc');
 
       expect(result).toBe(fakeBuffer);
-      expect(mockedQRCode.toBuffer).toHaveBeenCalledTimes(1);
-
-      const call = mockedQRCode.toBuffer.mock.calls[0] as unknown as [
-        string,
-        unknown,
-      ];
-      const payload = JSON.parse(call[0]) as { uuid: string; token: string };
-      expect(payload).toHaveProperty('uuid');
-      expect(payload.uuid).toMatch(
-        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+      expect(mockedQRCode.toBuffer).toHaveBeenCalledWith(
+        'https://card.petcard.app/tok-abc',
+        expect.objectContaining({ type: 'png' }),
       );
-      expect(payload.token).toBe('my-jwt-token');
     });
 
-    it('should generate a unique uuid on each call', async () => {
-      const fakeBuffer = Buffer.from('fake-png');
-      mockedQRCode.toBuffer.mockResolvedValue(fakeBuffer as never);
+    it('should strip trailing slashes from the configured base URL', async () => {
+      configService.get.mockReturnValue('https://card.petcard.app/');
+      mockedQRCode.toBuffer.mockResolvedValue(Buffer.from('x') as never);
 
-      await service.generateQrCode('token-1');
-      await service.generateQrCode('token-2');
+      await service.generateQrCode('tok-xyz');
 
-      const calls = mockedQRCode.toBuffer.mock.calls as unknown as [
-        string,
-        unknown,
-      ][];
-      const uuid1 = (JSON.parse(calls[0][0]) as { uuid: string }).uuid;
-      const uuid2 = (JSON.parse(calls[1][0]) as { uuid: string }).uuid;
-      expect(uuid1).not.toBe(uuid2);
+      expect(mockedQRCode.toBuffer).toHaveBeenCalledWith(
+        'https://card.petcard.app/tok-xyz',
+        expect.any(Object),
+      );
     });
 
     it('should throw InternalServerErrorException when QRCode generation fails', async () => {
@@ -78,33 +85,115 @@ describe('CardService', () => {
     });
   });
 
-  describe('generatePetQrCode', () => {
-    it('should return a PNG buffer with uuid and petId in the payload', async () => {
-      const fakeBuffer = Buffer.from('fake-png');
-      mockedQRCode.toBuffer.mockResolvedValue(fakeBuffer as never);
+  describe('issueTokenForPet', () => {
+    it('should upsert carteira_digital with a new uuid token', async () => {
+      prisma.carteiraDigital.upsert.mockResolvedValue({});
 
-      const result = await service.generatePetQrCode('pet-123');
+      const token = await service.issueTokenForPet('pet-1');
 
-      expect(result).toBe(fakeBuffer);
-
-      const callIndex = mockedQRCode.toBuffer.mock.calls.length - 1;
-      const call = mockedQRCode.toBuffer.mock.calls[callIndex] as unknown as [
-        string,
-        unknown,
-      ];
-      const payload = JSON.parse(call[0]) as { uuid: string; petId: string };
-      expect(payload).toHaveProperty('uuid');
-      expect(payload.uuid).toMatch(
+      expect(token).toMatch(
         /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
       );
-      expect(payload.petId).toBe('pet-123');
+      expect(prisma.carteiraDigital.upsert).toHaveBeenCalledWith({
+        where: { petId: 'pet-1' },
+        create: { petId: 'pet-1', token },
+        update: { token },
+      });
     });
 
-    it('should throw InternalServerErrorException when QRCode generation fails', async () => {
-      mockedQRCode.toBuffer.mockRejectedValue(new Error('QR fail') as never);
+    it('should rotate token on subsequent calls for the same pet', async () => {
+      prisma.carteiraDigital.upsert.mockResolvedValue({});
 
-      await expect(service.generatePetQrCode('pet-123')).rejects.toThrow(
-        InternalServerErrorException,
+      const t1 = await service.issueTokenForPet('pet-1');
+      const t2 = await service.issueTokenForPet('pet-1');
+
+      expect(t1).not.toBe(t2);
+    });
+  });
+
+  describe('setCardQrCodeUrl', () => {
+    it('should update carteira_digital qr_code_url', async () => {
+      prisma.carteiraDigital.update.mockResolvedValue({});
+
+      await service.setCardQrCodeUrl('pet-1', 'https://s3/qr.png');
+
+      expect(prisma.carteiraDigital.update).toHaveBeenCalledWith({
+        where: { petId: 'pet-1' },
+        data: { qrCodeUrl: 'https://s3/qr.png' },
+      });
+    });
+  });
+
+  describe('findPublicByToken', () => {
+    const baseDate = new Date('2026-04-01T10:00:00Z');
+
+    function makeCard(overrides: Record<string, unknown> = {}) {
+      return {
+        id: 'card-1',
+        petId: 'pet-1',
+        token: 'tok-abc',
+        qrCodeUrl: 'https://s3/qr.png',
+        createdAt: baseDate,
+        pet: {
+          id: 'pet-1',
+          name: 'Rex',
+          species: Species.DOG,
+          breed: 'Labrador',
+          sex: Sex.MALE,
+          birthDate: new Date('2022-03-10'),
+          weight: 12.5,
+          photoUrl: 'https://s3/pet.png',
+          tutor: { name: 'Alice' },
+          vaccineRecords: [
+            {
+              id: 'v1',
+              petId: 'pet-1',
+              vaccineName: 'V8',
+              appliedAt: baseDate,
+              nextDoseAt: null,
+              veterinarianName: null,
+              notes: null,
+              createdAt: baseDate,
+              updatedAt: baseDate,
+            },
+          ],
+          dewormingRecords: [],
+          medicationRecords: [],
+        },
+        ...overrides,
+      };
+    }
+
+    it('should return the public card data', async () => {
+      prisma.carteiraDigital.findUnique.mockResolvedValue(makeCard());
+
+      const result = await service.findPublicByToken('tok-abc');
+
+      expect(prisma.carteiraDigital.findUnique).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { token: 'tok-abc' } }),
+      );
+      expect(result).toMatchObject({
+        pet_id: 'pet-1',
+        pet_name: 'Rex',
+        species: Species.DOG,
+        sex: Sex.MALE,
+        birth_date: '2022-03-10',
+        weight: 12.5,
+        tutor_name: 'Alice',
+        qr_code_url: 'https://s3/qr.png',
+      });
+      expect(result.vaccines).toHaveLength(1);
+      expect(result.vaccines[0]).toMatchObject({
+        id: 'v1',
+        vaccine_name: 'V8',
+      });
+    });
+
+    it('should throw NotFoundException for invalid token', async () => {
+      prisma.carteiraDigital.findUnique.mockResolvedValue(null);
+
+      await expect(service.findPublicByToken('bad')).rejects.toThrow(
+        NotFoundException,
       );
     });
   });

--- a/src/modules/card/card.controller.ts
+++ b/src/modules/card/card.controller.ts
@@ -1,11 +1,15 @@
 import {
   Controller,
   Get,
+  Param,
   Req,
   Res,
   UnauthorizedException,
+  UseGuards,
 } from '@nestjs/common';
+import { Throttle, ThrottlerGuard } from '@nestjs/throttler';
 import type { Request, Response } from 'express';
+import { CarteiraDigitalPublicResponseDto } from '@petcardorg/shared';
 import { Auth } from '../auth/decorators/auth.decorator';
 import { Role } from '../auth/enums/role.enum';
 import { CardService } from './card.service';
@@ -34,5 +38,14 @@ export class CardController {
     });
 
     res.send(buffer);
+  }
+
+  @Get(':token')
+  @UseGuards(ThrottlerGuard)
+  @Throttle({ 'public-card': {} })
+  async getPublicCard(
+    @Param('token') token: string,
+  ): Promise<CarteiraDigitalPublicResponseDto> {
+    return this.cardService.findPublicByToken(token);
   }
 }

--- a/src/modules/card/card.module.ts
+++ b/src/modules/card/card.module.ts
@@ -1,10 +1,27 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { ThrottlerModule } from '@nestjs/throttler';
 import { AuthModule } from '../auth/auth.module';
 import { CardController } from './card.controller';
 import { CardService } from './card.service';
 
 @Module({
-  imports: [AuthModule],
+  imports: [
+    AuthModule,
+    ThrottlerModule.forRootAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (config: ConfigService) => ({
+        throttlers: [
+          {
+            name: 'public-card',
+            ttl: config.get<number>('card.publicThrottleTtlSeconds', 60) * 1000,
+            limit: config.get<number>('card.publicThrottleLimit', 10),
+          },
+        ],
+      }),
+    }),
+  ],
   controllers: [CardController],
   providers: [CardService],
   exports: [CardService],

--- a/src/modules/card/card.service.ts
+++ b/src/modules/card/card.service.ts
@@ -1,28 +1,32 @@
-import { Injectable, InternalServerErrorException } from '@nestjs/common';
+import {
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { randomUUID } from 'crypto';
 import * as QRCode from 'qrcode';
+import {
+  CarteiraDigitalPublicResponseDto,
+  Sex,
+  Species,
+} from '@petcardorg/shared';
 import { PrismaService } from '../../prisma/prisma.service';
 
 @Injectable()
 export class CardService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly configService: ConfigService,
+  ) {}
 
   async generateQrCode(token: string): Promise<Buffer> {
-    const payload = JSON.stringify({
-      uuid: randomUUID(),
-      token,
-    });
-
-    return this.generateBuffer(payload);
-  }
-
-  async generatePetQrCode(petId: string): Promise<Buffer> {
-    const payload = JSON.stringify({
-      uuid: randomUUID(),
-      petId,
-    });
-
-    return this.generateBuffer(payload);
+    const baseUrl = this.configService.get<string>(
+      'card.publicBaseUrl',
+      'https://card.petcard.app',
+    );
+    const url = `${baseUrl.replace(/\/+$/, '')}/${token}`;
+    return this.generateBuffer(url);
   }
 
   async issueTokenForPet(petId: string): Promise<string> {
@@ -40,6 +44,80 @@ export class CardService {
       where: { petId },
       data: { qrCodeUrl },
     });
+  }
+
+  async findPublicByToken(
+    token: string,
+  ): Promise<CarteiraDigitalPublicResponseDto> {
+    const card = await this.prisma.carteiraDigital.findUnique({
+      where: { token },
+      include: {
+        pet: {
+          include: {
+            tutor: true,
+            vaccineRecords: { orderBy: { appliedAt: 'desc' } },
+            dewormingRecords: { orderBy: { appliedAt: 'desc' } },
+            medicationRecords: { orderBy: { startDate: 'desc' } },
+          },
+        },
+      },
+    });
+
+    if (!card) {
+      throw new NotFoundException('Carteira digital not found');
+    }
+
+    const { pet } = card;
+
+    return {
+      pet_id: pet.id,
+      pet_name: pet.name,
+      species: pet.species as unknown as Species,
+      breed: pet.breed ?? undefined,
+      sex: pet.sex as unknown as Sex,
+      birth_date: pet.birthDate
+        ? pet.birthDate.toISOString().split('T')[0]
+        : undefined,
+      weight: pet.weight ?? undefined,
+      photo_url: pet.photoUrl ?? undefined,
+      qr_code_url: card.qrCodeUrl ?? undefined,
+      tutor_name: pet.tutor.name,
+      vaccines: pet.vaccineRecords.map((r) => ({
+        id: r.id,
+        pet_id: r.petId,
+        vaccine_name: r.vaccineName,
+        applied_at: r.appliedAt.toISOString(),
+        next_dose_at: r.nextDoseAt?.toISOString(),
+        veterinarian_name: r.veterinarianName ?? undefined,
+        notes: r.notes ?? undefined,
+        created_at: r.createdAt,
+        updated_at: r.updatedAt,
+      })),
+      dewormings: pet.dewormingRecords.map((r) => ({
+        id: r.id,
+        pet_id: r.petId,
+        product_name: r.productName,
+        applied_at: r.appliedAt.toISOString(),
+        next_dose_at: r.nextDoseAt?.toISOString(),
+        veterinarian_name: r.veterinarianName ?? undefined,
+        notes: r.notes ?? undefined,
+        created_at: r.createdAt,
+        updated_at: r.updatedAt,
+      })),
+      medications: pet.medicationRecords.map((r) => ({
+        id: r.id,
+        pet_id: r.petId,
+        medication_name: r.medicationName,
+        dosage: r.dosage,
+        frequency: r.frequency,
+        start_date: r.startDate.toISOString(),
+        end_date: r.endDate?.toISOString(),
+        notes: r.notes ?? undefined,
+        created_at: r.createdAt,
+        updated_at: r.updatedAt,
+      })),
+      issued_at: card.createdAt,
+    };
   }
 
   private async generateBuffer(data: string): Promise<Buffer> {

--- a/test/cards-public.e2e-spec.ts
+++ b/test/cards-public.e2e-spec.ts
@@ -1,0 +1,122 @@
+jest.mock('jwks-rsa', () => ({
+  passportJwtSecret:
+    () =>
+    (
+      _req: unknown,
+      _token: unknown,
+      done: (err: Error | null, key: string) => void,
+    ) =>
+      done(null, 'test-secret'),
+}));
+
+process.env.PUBLIC_CARD_THROTTLE_TTL_SECONDS = '60';
+process.env.PUBLIC_CARD_THROTTLE_LIMIT = '3';
+
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ThrottlerStorage } from '@nestjs/throttler';
+import request from 'supertest';
+import type { App } from 'supertest/types';
+import { AppModule } from '../src/app.module';
+import { PrismaService } from '../src/prisma/prisma.service';
+
+const baseDate = new Date('2026-04-01T10:00:00Z');
+
+const cardWithPet = {
+  id: 'card-1',
+  petId: 'pet-1',
+  token: 'valid-token',
+  qrCodeUrl: 'https://bucket.s3.us-east-1.amazonaws.com/qr-codes/pet-1.png',
+  createdAt: baseDate,
+  pet: {
+    id: 'pet-1',
+    name: 'Rex',
+    species: 'DOG',
+    breed: 'Labrador',
+    sex: 'MALE',
+    birthDate: new Date('2022-03-10'),
+    weight: 12.5,
+    photoUrl: null,
+    tutor: { name: 'Alice' },
+    vaccineRecords: [],
+    dewormingRecords: [],
+    medicationRecords: [],
+  },
+};
+
+const mockPrisma = {
+  carteiraDigital: {
+    findUnique: jest.fn(),
+  },
+  $connect: jest.fn(),
+  $disconnect: jest.fn(),
+};
+
+describe('Public card route (e2e)', () => {
+  let app: INestApplication<App>;
+  let throttlerStorage: ThrottlerStorage & {
+    storage?: Map<string, unknown>;
+  };
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideProvider(PrismaService)
+      .useValue(mockPrisma)
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
+    await app.init();
+
+    throttlerStorage = app.get(ThrottlerStorage);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    throttlerStorage.storage?.clear();
+    mockPrisma.carteiraDigital.findUnique.mockImplementation(
+      ({ where }: { where: { token: string } }) =>
+        where.token === 'valid-token'
+          ? Promise.resolve(cardWithPet)
+          : Promise.resolve(null),
+    );
+  });
+
+  it('GET /cards/:token returns 200 and the public card payload for a valid token', async () => {
+    await request(app.getHttpServer())
+      .get('/cards/valid-token')
+      .expect(200)
+      .expect((res) => {
+        expect(res.body).toMatchObject({
+          pet_id: 'pet-1',
+          pet_name: 'Rex',
+          tutor_name: 'Alice',
+        });
+      });
+  });
+
+  it('GET /cards/:token returns 404 when the token does not exist', async () => {
+    await request(app.getHttpServer()).get('/cards/does-not-exist').expect(404);
+  });
+
+  it('GET /cards/:token returns 429 once the per-IP rate limit is exceeded', async () => {
+    const limit = Number(process.env.PUBLIC_CARD_THROTTLE_LIMIT);
+    for (let i = 0; i < limit; i++) {
+      await request(app.getHttpServer()).get('/cards/valid-token').expect(200);
+    }
+
+    await request(app.getHttpServer()).get('/cards/valid-token').expect(429);
+  });
+});


### PR DESCRIPTION
  Adiciona endpoint público (sem auth) para consulta da carteira digital
  via token opaco. QR Code agora codifica URL navegável
  (/). CLAUDE.md atualizado com decisões
  finais de PC-049.
  Decisões: payload URL (não JSON); sem rate-limit por enquanto;
  resposta retorna pet completo + tutor_name + registros médicos.