### PR TITLE
feat: PC-068 - Worker para envio assincrono de notificacoes push

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,8 @@ import { NestFactory } from '@nestjs/core';
 import { MicroserviceOptions, Transport } from '@nestjs/microservices';
 import { AppModule } from './app.module';
 import {
+  NOTIFICATION_PUSH_DLQ_ROUTING_KEY,
+  NOTIFICATION_PUSH_DLX,
   QR_CODE_DLQ_ROUTING_KEY,
   QR_CODE_DLX,
 } from './modules/queue/queue.constants';
@@ -34,6 +36,23 @@ async function bootstrap() {
         arguments: {
           'x-dead-letter-exchange': QR_CODE_DLX,
           'x-dead-letter-routing-key': QR_CODE_DLQ_ROUTING_KEY,
+        },
+      },
+      noAck: false,
+      prefetchCount: 1,
+    },
+  });
+
+  app.connectMicroservice<MicroserviceOptions>({
+    transport: Transport.RMQ,
+    options: {
+      urls: [config.get<string>('rabbitmq.url')!],
+      queue: config.get<string>('rabbitmq.notificationPushQueue')!,
+      queueOptions: {
+        durable: true,
+        arguments: {
+          'x-dead-letter-exchange': NOTIFICATION_PUSH_DLX,
+          'x-dead-letter-routing-key': NOTIFICATION_PUSH_DLQ_ROUTING_KEY,
         },
       },
       noAck: false,

--- a/src/modules/notification/__tests__/notification-push.consumer.spec.ts
+++ b/src/modules/notification/__tests__/notification-push.consumer.spec.ts
@@ -1,0 +1,187 @@
+import { RmqContext } from '@nestjs/microservices';
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotificationKind } from '@prisma/client';
+import type { NotificationPushMessage } from '../../queue/dto/notification-push.message';
+import {
+  NOTIFICATION_PUSH_MAX_RETRIES,
+  NOTIFICATION_PUSH_RETRY_HEADER,
+} from '../../queue/queue.constants';
+import { FcmClient } from '../fcm.client';
+import { NotificationPushConsumer } from '../notification-push.consumer';
+import { NotificationService } from '../notification.service';
+
+const baseMessage: NotificationPushMessage = {
+  notification_id: 'n1',
+  tutor_id: 'tutor-1',
+  device_token: 'fcm-token-abc',
+  kind: NotificationKind.DOSE_REMINDER,
+  title: 'Vacina',
+  body: 'Hora da próxima dose',
+};
+
+const buildContext = (
+  channel: { ack: jest.Mock; nack: jest.Mock; publish: jest.Mock },
+  headers: Record<string, unknown> = {},
+) => {
+  const message = {
+    content: Buffer.from(JSON.stringify(baseMessage)),
+    fields: { routingKey: 'notification.push' },
+    properties: { headers },
+  };
+  const context = {
+    getChannelRef: () => channel,
+    getMessage: () => message,
+  } as unknown as RmqContext;
+  return { context, message };
+};
+
+describe('NotificationPushConsumer', () => {
+  let consumer: NotificationPushConsumer;
+  let fcmClient: { send: jest.Mock };
+  let notificationService: {
+    markSent: jest.Mock;
+    markFailed: jest.Mock;
+    deleteByToken: jest.Mock;
+  };
+  let channel: { ack: jest.Mock; nack: jest.Mock; publish: jest.Mock };
+
+  beforeEach(async () => {
+    fcmClient = { send: jest.fn() };
+    notificationService = {
+      markSent: jest.fn().mockResolvedValue(undefined),
+      markFailed: jest.fn().mockResolvedValue(undefined),
+      deleteByToken: jest.fn().mockResolvedValue(undefined),
+    };
+    channel = { ack: jest.fn(), nack: jest.fn(), publish: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        NotificationPushConsumer,
+        { provide: FcmClient, useValue: fcmClient },
+        { provide: NotificationService, useValue: notificationService },
+      ],
+    }).compile();
+
+    consumer = module.get(NotificationPushConsumer);
+  });
+
+  it('marks the notification SENT and acks on successful send', async () => {
+    fcmClient.send.mockResolvedValue({ messageId: 'msg-123' });
+    const { context, message } = buildContext(channel);
+
+    await consumer.handlePush(baseMessage, context);
+
+    expect(fcmClient.send).toHaveBeenCalledWith('fcm-token-abc', {
+      title: 'Vacina',
+      body: 'Hora da próxima dose',
+      data: undefined,
+    });
+    expect(notificationService.markSent).toHaveBeenCalledWith('n1', 'msg-123');
+    expect(channel.ack).toHaveBeenCalledWith(message);
+    expect(channel.nack).not.toHaveBeenCalled();
+    expect(channel.publish).not.toHaveBeenCalled();
+  });
+
+  it('marks SENT (no messageId) and acks when FCM is disabled', async () => {
+    fcmClient.send.mockResolvedValue({});
+    const { context, message } = buildContext(channel);
+
+    await consumer.handlePush(baseMessage, context);
+
+    expect(notificationService.markSent).toHaveBeenCalledWith('n1', undefined);
+    expect(channel.ack).toHaveBeenCalledWith(message);
+  });
+
+  it('acks and skips when notification_id is missing', async () => {
+    const { context, message } = buildContext(channel);
+
+    await consumer.handlePush(
+      {} as unknown as NotificationPushMessage,
+      context,
+    );
+
+    expect(fcmClient.send).not.toHaveBeenCalled();
+    expect(channel.ack).toHaveBeenCalledWith(message);
+  });
+
+  it('soft-invalidates a dead token and marks FAILED without retrying', async () => {
+    fcmClient.send.mockResolvedValue({
+      errorCode: 'messaging/registration-token-not-registered',
+    });
+    const { context, message } = buildContext(channel);
+
+    await consumer.handlePush(baseMessage, context);
+
+    expect(notificationService.deleteByToken).toHaveBeenCalledWith(
+      'fcm-token-abc',
+    );
+    expect(notificationService.markFailed).toHaveBeenCalledWith(
+      'n1',
+      'messaging/registration-token-not-registered',
+    );
+    expect(channel.ack).toHaveBeenCalledWith(message);
+    expect(channel.publish).not.toHaveBeenCalled();
+    expect(channel.nack).not.toHaveBeenCalled();
+  });
+
+  it('retries with incremented counter on a transient FCM error', async () => {
+    fcmClient.send.mockResolvedValue({
+      errorCode: 'messaging/server-unavailable',
+    });
+    const { context, message } = buildContext(channel);
+
+    await consumer.handlePush(baseMessage, context);
+
+    expect(channel.publish).toHaveBeenCalledWith(
+      '',
+      'notification.push',
+      message.content,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          [NOTIFICATION_PUSH_RETRY_HEADER]: 1,
+        }) as unknown,
+      }),
+    );
+    expect(channel.ack).toHaveBeenCalledWith(message);
+    expect(notificationService.markFailed).not.toHaveBeenCalled();
+  });
+
+  it('marks FAILED and nacks to DLQ when retries are exhausted', async () => {
+    fcmClient.send.mockResolvedValue({
+      errorCode: 'messaging/server-unavailable',
+    });
+    const { context, message } = buildContext(channel, {
+      [NOTIFICATION_PUSH_RETRY_HEADER]: NOTIFICATION_PUSH_MAX_RETRIES,
+    });
+
+    await consumer.handlePush(baseMessage, context);
+
+    expect(notificationService.markFailed).toHaveBeenCalledWith(
+      'n1',
+      'messaging/server-unavailable',
+    );
+    expect(channel.nack).toHaveBeenCalledWith(message, false, false);
+    expect(channel.publish).not.toHaveBeenCalled();
+    expect(channel.ack).not.toHaveBeenCalled();
+  });
+
+  it('retries when an unexpected error is thrown (e.g. DB update fails)', async () => {
+    fcmClient.send.mockResolvedValue({ messageId: 'msg-123' });
+    notificationService.markSent.mockRejectedValue(new Error('DB down'));
+    const { context, message } = buildContext(channel);
+
+    await consumer.handlePush(baseMessage, context);
+
+    expect(channel.publish).toHaveBeenCalledWith(
+      '',
+      'notification.push',
+      message.content,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          [NOTIFICATION_PUSH_RETRY_HEADER]: 1,
+        }) as unknown,
+      }),
+    );
+    expect(channel.ack).toHaveBeenCalledWith(message);
+  });
+});

--- a/src/modules/notification/__tests__/notification.service.spec.ts
+++ b/src/modules/notification/__tests__/notification.service.spec.ts
@@ -14,7 +14,7 @@ describe('NotificationService', () => {
       findMany: jest.Mock;
       deleteMany: jest.Mock;
     };
-    notification: { create: jest.Mock };
+    notification: { create: jest.Mock; update: jest.Mock };
   };
   let publisher: { publish: jest.Mock };
 
@@ -26,7 +26,7 @@ describe('NotificationService', () => {
         findMany: jest.fn(),
         deleteMany: jest.fn(),
       },
-      notification: { create: jest.fn() },
+      notification: { create: jest.fn(), update: jest.fn() },
     };
     publisher = { publish: jest.fn().mockResolvedValue(undefined) };
 
@@ -155,6 +155,43 @@ describe('NotificationService', () => {
 
       expect(result).toHaveLength(1);
       expect(prisma.notification.create).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('markSent', () => {
+    it('updates the notification to SENT with fcmMessageId and sentAt', async () => {
+      await service.markSent('n1', 'msg-123');
+
+      expect(prisma.notification.update).toHaveBeenCalledWith({
+        where: { id: 'n1' },
+        data: expect.objectContaining({
+          status: 'SENT',
+          fcmMessageId: 'msg-123',
+        }) as unknown,
+      });
+    });
+
+    it('stores null fcmMessageId when none is provided (FCM disabled)', async () => {
+      await service.markSent('n1');
+
+      expect(prisma.notification.update).toHaveBeenCalledWith({
+        where: { id: 'n1' },
+        data: expect.objectContaining({
+          status: 'SENT',
+          fcmMessageId: null,
+        }) as unknown,
+      });
+    });
+  });
+
+  describe('markFailed', () => {
+    it('updates the notification to FAILED with the error code', async () => {
+      await service.markFailed('n1', 'messaging/server-unavailable');
+
+      expect(prisma.notification.update).toHaveBeenCalledWith({
+        where: { id: 'n1' },
+        data: { status: 'FAILED', errorCode: 'messaging/server-unavailable' },
+      });
     });
   });
 });

--- a/src/modules/notification/notification-push.consumer.ts
+++ b/src/modules/notification/notification-push.consumer.ts
@@ -1,0 +1,134 @@
+import { Controller, Logger } from '@nestjs/common';
+import { Ctx, MessagePattern, Payload } from '@nestjs/microservices';
+import type { RmqContext } from '@nestjs/microservices';
+import type { Channel, ConsumeMessage } from 'amqplib';
+import type { NotificationPushMessage } from '../queue/dto/notification-push.message';
+import {
+  NOTIFICATION_PUSH_MAX_RETRIES,
+  NOTIFICATION_PUSH_PATTERN,
+  NOTIFICATION_PUSH_RETRY_HEADER,
+} from '../queue/queue.constants';
+import { FcmClient } from './fcm.client';
+import { NotificationService } from './notification.service';
+
+@Controller()
+export class NotificationPushConsumer {
+  private readonly logger = new Logger(NotificationPushConsumer.name);
+
+  /** FCM error codes that mean the device token is permanently dead. */
+  private static readonly UNREGISTERED_TOKEN_CODES = new Set([
+    'messaging/registration-token-not-registered',
+    'messaging/invalid-registration-token',
+  ]);
+
+  constructor(
+    private readonly fcmClient: FcmClient,
+    private readonly notificationService: NotificationService,
+  ) {}
+
+  @MessagePattern(NOTIFICATION_PUSH_PATTERN)
+  async handlePush(
+    @Payload() data: NotificationPushMessage,
+    @Ctx() context: RmqContext,
+  ): Promise<void> {
+    const channel = context.getChannelRef() as Channel;
+    const originalMessage = context.getMessage() as ConsumeMessage;
+    const notificationId = data?.notification_id;
+
+    if (!notificationId || !data?.device_token) {
+      this.logger.warn(
+        'Received notification.push message without notification_id/device_token',
+      );
+      channel.ack(originalMessage);
+      return;
+    }
+
+    try {
+      const result = await this.fcmClient.send(data.device_token, {
+        title: data.title,
+        body: data.body,
+        data: data.data,
+      });
+
+      if (result.errorCode) {
+        // A dead token never recovers — soft-invalidate it instead of retrying.
+        if (this.isUnregisteredTokenError(result.errorCode)) {
+          await this.notificationService.deleteByToken(data.device_token);
+          await this.notificationService.markFailed(
+            notificationId,
+            result.errorCode,
+          );
+          this.logger.warn(
+            `Stale device token removed for notification ${notificationId} (code=${result.errorCode})`,
+          );
+          channel.ack(originalMessage);
+          return;
+        }
+        // Transient FCM error — retry, then DLQ.
+        await this.retryOrDlq(
+          notificationId,
+          result.errorCode,
+          channel,
+          originalMessage,
+        );
+        return;
+      }
+
+      // Success (messageId is absent when FCM is disabled in dev — still SENT).
+      await this.notificationService.markSent(notificationId, result.messageId);
+      this.logger.log(`Push delivered for notification ${notificationId}`);
+      channel.ack(originalMessage);
+    } catch (error) {
+      // Unexpected failure (e.g. DB update) — retry, then DLQ.
+      const reason = error instanceof Error ? error.message : String(error);
+      await this.retryOrDlq(notificationId, reason, channel, originalMessage);
+    }
+  }
+
+  private async retryOrDlq(
+    notificationId: string,
+    errorCode: string,
+    channel: Channel,
+    message: ConsumeMessage,
+  ): Promise<void> {
+    const retryCount = this.getRetryCount(message);
+
+    if (retryCount < NOTIFICATION_PUSH_MAX_RETRIES) {
+      this.logger.warn(
+        `Retry ${retryCount + 1}/${NOTIFICATION_PUSH_MAX_RETRIES} for notification ${notificationId}: ${errorCode}`,
+      );
+      channel.publish('', message.fields.routingKey, message.content, {
+        ...message.properties,
+        headers: {
+          ...message.properties.headers,
+          [NOTIFICATION_PUSH_RETRY_HEADER]: retryCount + 1,
+        },
+      });
+      channel.ack(message);
+      return;
+    }
+
+    this.logger.error(
+      `Exhausted retries for notification ${notificationId} (${errorCode}); routing to DLQ`,
+    );
+    try {
+      await this.notificationService.markFailed(notificationId, errorCode);
+    } catch (error) {
+      this.logger.error(
+        `Failed to mark notification ${notificationId} as FAILED`,
+        error instanceof Error ? error.stack : error,
+      );
+    }
+    channel.nack(message, false, false);
+  }
+
+  private isUnregisteredTokenError(code: string): boolean {
+    return NotificationPushConsumer.UNREGISTERED_TOKEN_CODES.has(code);
+  }
+
+  private getRetryCount(message: ConsumeMessage): number {
+    const raw: unknown =
+      message.properties.headers?.[NOTIFICATION_PUSH_RETRY_HEADER];
+    return typeof raw === 'number' ? raw : 0;
+  }
+}

--- a/src/modules/notification/notification.module.ts
+++ b/src/modules/notification/notification.module.ts
@@ -3,11 +3,12 @@ import { AuthModule } from '../auth/auth.module';
 import { TutorModule } from '../tutor/tutor.module';
 import { DevicesController } from './devices.controller';
 import { FcmClient } from './fcm.client';
+import { NotificationPushConsumer } from './notification-push.consumer';
 import { NotificationService } from './notification.service';
 
 @Module({
   imports: [AuthModule, TutorModule],
-  controllers: [DevicesController],
+  controllers: [DevicesController, NotificationPushConsumer],
   providers: [FcmClient, NotificationService],
   exports: [FcmClient, NotificationService],
 })

--- a/src/modules/notification/notification.service.ts
+++ b/src/modules/notification/notification.service.ts
@@ -55,6 +55,24 @@ export class NotificationService {
     await this.prisma.deviceToken.deleteMany({ where: { token } });
   }
 
+  async markSent(notificationId: string, fcmMessageId?: string): Promise<void> {
+    await this.prisma.notification.update({
+      where: { id: notificationId },
+      data: {
+        status: NotificationStatus.SENT,
+        fcmMessageId: fcmMessageId ?? null,
+        sentAt: new Date(),
+      },
+    });
+  }
+
+  async markFailed(notificationId: string, errorCode: string): Promise<void> {
+    await this.prisma.notification.update({
+      where: { id: notificationId },
+      data: { status: NotificationStatus.FAILED, errorCode },
+    });
+  }
+
   async schedulePush(input: SchedulePushInput): Promise<Notification[]> {
     const tokens = await this.prisma.deviceToken.findMany({
       where: { tutorId: input.tutorId },


### PR DESCRIPTION
## Summary
Fecha o fluxo de push aberto pela PC-066: adiciona o **worker que consome a fila `notification.push`** e dispara o envio via FCM.

- `NotificationPushConsumer` (`@MessagePattern('notification.push')`):
  - **sucesso** → `Notification.status=SENT` + `fcmMessageId` + `sentAt`
  - **token morto** (`registration-token-not-registered` / `invalid-registration-token`) → soft-invalida o `device_token` + `status=FAILED`, sem retry
  - **erro transitório do FCM / exceção inesperada** → retry via `x-retry-count` (até 3) → `markFailed` + DLQ na exaustão
- `NotificationService.markSent` / `markFailed`
- `NotificationPushConsumer` registrado em `NotificationModule.controllers`
- `main.ts` conecta o microservice RMQ da fila `notification.push` (DLX/DLQ, `prefetchCount: 1`)

## Decisões aplicadas (ADR-002)
- **#3** Worker chama o FCM; cron/serviço só publica. Mesma topologia DLX/DLQ + `x-retry-count` da `qr-code.generate`.
- **#2** Token que o FCM retornar como não-registrado é soft-invalidado.
- **#7** Falha do FCM degrada graceful: log ERROR + retry + DLQ; nenhuma request do tutor é afetada.

## Test plan
- [x] Unit: 89/89 passing (10 novos: 7 do consumer + 3 de `markSent`/`markFailed`)
- [x] E2E: 33/33 passing
- [x] `npx tsc --noEmit` clean
- [ ] CI verde
- [ ] Smoke manual: publicar em `notification.push` e verificar `Notification` indo para `SENT`

## Próxima issue na trilha
PC-067 — Cron diário de lembretes de próxima dose (publica em `notification.push`).