### PR TITLE
feat: PC-067 - Cron diario de lembretes de proxima dose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,13 @@ FIREBASE_PROJECT_ID=seu_project_id
 FIREBASE_PRIVATE_KEY="sua_private_key"
 FIREBASE_CLIENT_EMAIL=seu_client_email
 
+# ---------- Lembretes de dose (cron diário) ----------
+# Cron varre vaccine/deworming com next_dose_at na janela e dispara 1 push por dose.
+# Desligue em ambientes onde o scheduler não deve rodar.
+DOSE_REMINDER_ENABLED=true
+# Quantos dias de antecedência abrem a janela de lembrete.
+DOSE_REMINDER_WINDOW_DAYS=3
+
 # ---------- Google APIs ----------
 GOOGLE_MAPS_API_KEY=sua_api_key
 GOOGLE_CALENDAR_CLIENT_ID=seu_client_id

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@nestjs/microservices": "^11.1.19",
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.0.1",
+        "@nestjs/schedule": "^6.1.3",
         "@nestjs/throttler": "^6.5.0",
         "@petcardorg/shared": "^0.8.0",
         "@prisma/client": "^6.19.3",
@@ -3652,6 +3653,19 @@
         "@nestjs/core": "^11.0.0"
       }
     },
+    "node_modules/@nestjs/schedule": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-6.1.3.tgz",
+      "integrity": "sha512-RflMFOpR16Dwd1jAUbeB4mfGTCh65fvEdL4mSjQPJChpkRGRjIXjb+6YQcK2faQrVT60c9DmLmoVR7/ONCtuYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cron": "4.4.0"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^10.0.0 || ^11.0.0"
+      }
+    },
     "node_modules/@nestjs/schematics": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-11.1.0.tgz",
@@ -5004,6 +5018,12 @@
       "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@types/luxon": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.7.1.tgz",
+      "integrity": "sha512-H3iskjFIAn5SlJU7OuxUmTEpebK6TKB8rxZShDslBMZJ5u9S//KM1sbdAisiSrqwLQncVjnpi2OK2J51h+4lsg==",
+      "license": "MIT"
     },
     "node_modules/@types/methods": {
       "version": "1.1.4",
@@ -7237,6 +7257,23 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cron": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-4.4.0.tgz",
+      "integrity": "sha512-fkdfq+b+AHI4cKdhZlppHveI/mgz2qpiYxcm+t5E5TsxX7QrLS1VE0+7GENEk9z0EeGPcpSciGv6ez24duWhwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/luxon": "~3.7.0",
+        "luxon": "~3.7.0"
+      },
+      "engines": {
+        "node": ">=18.x"
+      },
+      "funding": {
+        "type": "ko-fi",
+        "url": "https://ko-fi.com/intcreator"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -10974,6 +11011,15 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@nestjs/microservices": "^11.1.19",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/schedule": "^6.1.3",
     "@nestjs/throttler": "^6.5.0",
     "@petcardorg/shared": "^0.8.0",
     "@prisma/client": "^6.19.3",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
+import { ScheduleModule } from '@nestjs/schedule';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { appConfig } from './config/app.config';
@@ -9,6 +10,7 @@ import { cardConfig } from './config/card.config';
 import { firebaseConfig } from './config/firebase.config';
 import { googleMapsConfig } from './config/google-maps.config';
 import { rabbitmqConfig } from './config/rabbitmq.config';
+import { reminderConfig } from './config/reminder.config';
 import { AuthModule } from './modules/auth/auth.module';
 import { CardModule } from './modules/card/card.module';
 import { ClinicaModule } from './modules/clinica/clinica.module';
@@ -18,6 +20,7 @@ import { VaccineModule } from './modules/health/vaccine/vaccine.module';
 import { NotificationModule } from './modules/notification/notification.module';
 import { PetModule } from './modules/pet/pet.module';
 import { QueueModule } from './modules/queue/queue.module';
+import { ReminderModule } from './modules/reminder/reminder.module';
 import { TutorModule } from './modules/tutor/tutor.module';
 import { UploadModule } from './modules/upload/upload.module';
 import { PrismaModule } from './prisma/prisma.module';
@@ -34,8 +37,10 @@ import { PrismaModule } from './prisma/prisma.module';
         firebaseConfig,
         googleMapsConfig,
         rabbitmqConfig,
+        reminderConfig,
       ],
     }),
+    ScheduleModule.forRoot(),
     PrismaModule,
     AuthModule,
     CardModule,
@@ -48,6 +53,7 @@ import { PrismaModule } from './prisma/prisma.module';
     QueueModule,
     ClinicaModule,
     NotificationModule,
+    ReminderModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/config/reminder.config.ts
+++ b/src/config/reminder.config.ts
@@ -1,0 +1,11 @@
+import { registerAs } from '@nestjs/config';
+
+function parseBool(value: string | undefined, fallback: boolean): boolean {
+  if (value === undefined) return fallback;
+  return value.toLowerCase() === 'true';
+}
+
+export const reminderConfig = registerAs('reminder', () => ({
+  enabled: parseBool(process.env.DOSE_REMINDER_ENABLED, true),
+  windowDays: Number(process.env.DOSE_REMINDER_WINDOW_DAYS ?? 3),
+}));

--- a/src/modules/reminder/__tests__/dose-reminder.service.spec.ts
+++ b/src/modules/reminder/__tests__/dose-reminder.service.spec.ts
@@ -1,0 +1,165 @@
+import { ConfigService } from '@nestjs/config';
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotificationKind } from '@prisma/client';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { NotificationService } from '../../notification/notification.service';
+import { DoseReminderService } from '../dose-reminder.service';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const vaccineRecord = (overrides: Record<string, unknown> = {}) => ({
+  id: 'vac-1',
+  petId: 'pet-1',
+  nextDoseAt: new Date(Date.now() + 2 * DAY_MS),
+  lastNotifiedAt: null,
+  pet: { name: 'Rex', tutorId: 'tutor-1' },
+  ...overrides,
+});
+
+describe('DoseReminderService', () => {
+  let service: DoseReminderService;
+  let prisma: {
+    vaccineRecord: { findMany: jest.Mock; update: jest.Mock };
+    dewormingRecord: { findMany: jest.Mock; update: jest.Mock };
+  };
+  let notificationService: { schedulePush: jest.Mock };
+  let config: { get: jest.Mock };
+
+  beforeEach(async () => {
+    prisma = {
+      vaccineRecord: { findMany: jest.fn(), update: jest.fn() },
+      dewormingRecord: { findMany: jest.fn(), update: jest.fn() },
+    };
+    notificationService = {
+      schedulePush: jest.fn().mockResolvedValue([{ id: 'n1' }]),
+    };
+    config = {
+      get: jest.fn((key: string) => {
+        if (key === 'reminder.enabled') return true;
+        if (key === 'reminder.windowDays') return 3;
+        return undefined;
+      }),
+    };
+    prisma.vaccineRecord.findMany.mockResolvedValue([]);
+    prisma.dewormingRecord.findMany.mockResolvedValue([]);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DoseReminderService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: NotificationService, useValue: notificationService },
+        { provide: ConfigService, useValue: config },
+      ],
+    }).compile();
+
+    service = module.get(DoseReminderService);
+  });
+
+  describe('handleCron', () => {
+    it('skips the run when DOSE_REMINDER_ENABLED is false', async () => {
+      config.get.mockImplementation((key: string) =>
+        key === 'reminder.enabled' ? false : undefined,
+      );
+
+      await service.handleCron();
+
+      expect(prisma.vaccineRecord.findMany).not.toHaveBeenCalled();
+      expect(prisma.dewormingRecord.findMany).not.toHaveBeenCalled();
+    });
+
+    it('runs the reminders when enabled', async () => {
+      await service.handleCron();
+
+      expect(prisma.vaccineRecord.findMany).toHaveBeenCalledTimes(1);
+      expect(prisma.dewormingRecord.findMany).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('runDoseReminders', () => {
+    it('returns zero counts when no records are in the window', async () => {
+      const result = await service.runDoseReminders();
+
+      expect(result).toEqual({ vaccine: 0, deworming: 0 });
+      expect(notificationService.schedulePush).not.toHaveBeenCalled();
+    });
+
+    it('schedules a push and stamps lastNotifiedAt for a due vaccine record', async () => {
+      prisma.vaccineRecord.findMany.mockResolvedValue([vaccineRecord()]);
+
+      const result = await service.runDoseReminders();
+
+      expect(result.vaccine).toBe(1);
+      expect(notificationService.schedulePush).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tutorId: 'tutor-1',
+          kind: NotificationKind.DOSE_REMINDER,
+          referenceType: 'VACCINE_RECORD',
+          referenceId: 'vac-1',
+        }),
+      );
+      expect(prisma.vaccineRecord.update).toHaveBeenCalledWith({
+        where: { id: 'vac-1' },
+        data: { lastNotifiedAt: expect.any(Date) as unknown },
+      });
+    });
+
+    it('skips a record already notified within its current dose window', async () => {
+      prisma.vaccineRecord.findMany.mockResolvedValue([
+        vaccineRecord({ lastNotifiedAt: new Date() }),
+      ]);
+
+      const result = await service.runDoseReminders();
+
+      expect(result.vaccine).toBe(0);
+      expect(notificationService.schedulePush).not.toHaveBeenCalled();
+      expect(prisma.vaccineRecord.update).not.toHaveBeenCalled();
+    });
+
+    it('re-notifies when the last push predates the current dose window', async () => {
+      prisma.vaccineRecord.findMany.mockResolvedValue([
+        vaccineRecord({
+          nextDoseAt: new Date(Date.now() + 2 * DAY_MS),
+          lastNotifiedAt: new Date(Date.now() - 30 * DAY_MS),
+        }),
+      ]);
+
+      const result = await service.runDoseReminders();
+
+      expect(result.vaccine).toBe(1);
+      expect(notificationService.schedulePush).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not stamp lastNotifiedAt when the tutor has no device tokens', async () => {
+      prisma.vaccineRecord.findMany.mockResolvedValue([vaccineRecord()]);
+      notificationService.schedulePush.mockResolvedValue([]);
+
+      const result = await service.runDoseReminders();
+
+      expect(result.vaccine).toBe(0);
+      expect(prisma.vaccineRecord.update).not.toHaveBeenCalled();
+    });
+
+    it('processes deworming records the same way', async () => {
+      prisma.dewormingRecord.findMany.mockResolvedValue([
+        {
+          id: 'dew-1',
+          petId: 'pet-1',
+          nextDoseAt: new Date(Date.now() + 1 * DAY_MS),
+          lastNotifiedAt: null,
+          pet: { name: 'Rex', tutorId: 'tutor-1' },
+        },
+      ]);
+
+      const result = await service.runDoseReminders();
+
+      expect(result.deworming).toBe(1);
+      expect(notificationService.schedulePush).toHaveBeenCalledWith(
+        expect.objectContaining({ referenceType: 'DEWORMING_RECORD' }),
+      );
+      expect(prisma.dewormingRecord.update).toHaveBeenCalledWith({
+        where: { id: 'dew-1' },
+        data: { lastNotifiedAt: expect.any(Date) as unknown },
+      });
+    });
+  });
+});

--- a/src/modules/reminder/dose-reminder.service.ts
+++ b/src/modules/reminder/dose-reminder.service.ts
@@ -1,0 +1,165 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { NotificationKind } from '@prisma/client';
+import { PrismaService } from '../../prisma/prisma.service';
+import { NotificationService } from '../notification/notification.service';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+interface DueRecord {
+  id: string;
+  petId: string;
+  nextDoseAt: Date | null;
+  lastNotifiedAt: Date | null;
+  pet: { name: string; tutorId: string };
+}
+
+@Injectable()
+export class DoseReminderService {
+  private readonly logger = new Logger(DoseReminderService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly notificationService: NotificationService,
+    private readonly config: ConfigService,
+  ) {}
+
+  @Cron(CronExpression.EVERY_DAY_AT_9AM, {
+    name: 'dose-reminder',
+    timeZone: 'America/Fortaleza',
+  })
+  async handleCron(): Promise<void> {
+    if (!this.config.get<boolean>('reminder.enabled')) {
+      this.logger.debug('Dose reminder cron disabled; skipping run');
+      return;
+    }
+    await this.runDoseReminders();
+  }
+
+  /**
+   * Scans vaccine and deworming records whose next dose falls within the
+   * reminder window and schedules a single push per record. Idempotent via
+   * `lastNotifiedAt`: a record is re-notified only once its current dose
+   * window opens, so a vet setting a new future dose triggers a fresh push.
+   */
+  async runDoseReminders(): Promise<{ vaccine: number; deworming: number }> {
+    const windowDays = this.config.get<number>('reminder.windowDays') ?? 3;
+    const now = new Date();
+    const windowEnd = new Date(now.getTime() + windowDays * DAY_MS);
+
+    const vaccine = await this.processVaccineReminders(
+      now,
+      windowEnd,
+      windowDays,
+    );
+    const deworming = await this.processDewormingReminders(
+      now,
+      windowEnd,
+      windowDays,
+    );
+
+    this.logger.log(
+      `Dose reminders: ${vaccine} vaccine + ${deworming} deworming notification(s) scheduled`,
+    );
+    return { vaccine, deworming };
+  }
+
+  private async processVaccineReminders(
+    now: Date,
+    windowEnd: Date,
+    windowDays: number,
+  ): Promise<number> {
+    const records = await this.prisma.vaccineRecord.findMany({
+      where: { nextDoseAt: { gte: now, lte: windowEnd } },
+      include: { pet: { select: { name: true, tutorId: true } } },
+    });
+
+    let scheduled = 0;
+    for (const record of records) {
+      if (!this.isDue(record, windowDays)) continue;
+      const label = this.describe(record, `vacina`);
+      const delivered = await this.notify(
+        record,
+        'VACCINE_RECORD',
+        'Vacina chegando',
+        label,
+      );
+      if (delivered) {
+        await this.prisma.vaccineRecord.update({
+          where: { id: record.id },
+          data: { lastNotifiedAt: new Date() },
+        });
+        scheduled++;
+      }
+    }
+    return scheduled;
+  }
+
+  private async processDewormingReminders(
+    now: Date,
+    windowEnd: Date,
+    windowDays: number,
+  ): Promise<number> {
+    const records = await this.prisma.dewormingRecord.findMany({
+      where: { nextDoseAt: { gte: now, lte: windowEnd } },
+      include: { pet: { select: { name: true, tutorId: true } } },
+    });
+
+    let scheduled = 0;
+    for (const record of records) {
+      if (!this.isDue(record, windowDays)) continue;
+      const label = this.describe(record, `vermifugo`);
+      const delivered = await this.notify(
+        record,
+        'DEWORMING_RECORD',
+        'Vermifugo chegando',
+        label,
+      );
+      if (delivered) {
+        await this.prisma.dewormingRecord.update({
+          where: { id: record.id },
+          data: { lastNotifiedAt: new Date() },
+        });
+        scheduled++;
+      }
+    }
+    return scheduled;
+  }
+
+  /** True when the record has not yet been notified for its current dose. */
+  private isDue(record: DueRecord, windowDays: number): boolean {
+    if (!record.nextDoseAt) return false;
+    if (!record.lastNotifiedAt) return true;
+    const windowStart = new Date(
+      record.nextDoseAt.getTime() - windowDays * DAY_MS,
+    );
+    return record.lastNotifiedAt < windowStart;
+  }
+
+  private describe(record: DueRecord, kind: string): string {
+    const date = record.nextDoseAt!.toLocaleDateString('pt-BR', {
+      timeZone: 'America/Fortaleza',
+    });
+    return `${record.pet.name}: proxima dose de ${kind} prevista para ${date}.`;
+  }
+
+  /** Schedules the push; returns true when at least one device was targeted. */
+  private async notify(
+    record: DueRecord,
+    referenceType: string,
+    title: string,
+    body: string,
+  ): Promise<boolean> {
+    const notifications = await this.notificationService.schedulePush({
+      tutorId: record.pet.tutorId,
+      kind: NotificationKind.DOSE_REMINDER,
+      referenceType,
+      referenceId: record.id,
+      title,
+      body,
+      data: { reference_type: referenceType, reference_id: record.id },
+    });
+    return notifications.length > 0;
+  }
+}

--- a/src/modules/reminder/reminder.module.ts
+++ b/src/modules/reminder/reminder.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { NotificationModule } from '../notification/notification.module';
+import { DoseReminderService } from './dose-reminder.service';
+
+@Module({
+  imports: [NotificationModule],
+  providers: [DoseReminderService],
+  exports: [DoseReminderService],
+})
+export class ReminderModule {}


### PR DESCRIPTION
## Summary
Adiciona o **cron diário de lembretes de próxima dose**, que dispara o início do fluxo de push montado nas PC-066/068.

- `DoseReminderService` — `@Cron` diário às 09:00 (`America/Fortaleza`):
  - varre `vaccine_record` / `deworming_record` com `next_dose_at` na janela configurável (`DOSE_REMINDER_WINDOW_DAYS`, default 3)
  - agenda 1 push por dose vencendo via `NotificationService.schedulePush`
  - grava `last_notified_at` apenas quando há device token alvo
  - idempotente: re-notifica somente quando a janela da dose atual abre
- `ReminderModule` + `reminder.config.ts` (`DOSE_REMINDER_ENABLED` / `DOSE_REMINDER_WINDOW_DAYS`)
- `ScheduleModule.forRoot()` registrado; dependência `@nestjs/schedule`
- `.env.example` com o bloco de lembretes de dose

## Decisões aplicadas (ADR-002)
- **#1** Cron diário, janela X dias, idempotência via `last_notified_at`.
- **#6** 1 push por dose, sem escalonamento (política escalonada fica para M5+).

## Fora de escopo / divergências a reconciliar
- **Medicação:** `MedicationRecord` não tem `next_dose_at` (é contínua, baseada em `frequency`). Ficou de fora do cron — precisa de modelo de lembrete próprio (issue separada / M5). ADR-002 #1 cita "medication" e merece uma nota de correção.
- **Issue #31** descreve escalonamento "24h/1h/15min", anterior ao ADR-002. Os critérios de aceite da issue precisam ser atualizados (escalonamento → M5).

## Test plan
- [x] Unit: 97/97 passing (8 novos do `DoseReminderService`)
- [x] E2E: 33/33 passing
- [x] `npx tsc --noEmit` clean
- [x] CI verde
- [ ] Smoke: rodar `runDoseReminders()` com registro na janela e verificar `Notification` criada

## Próxima issue na trilha
PC-064 — Integração Google Calendar (`POST /appointments` + OAuth do tutor).