### PR TITLE
feat: PC-069 - Worker para sincronização com Google Calendar

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,8 @@ RABBITMQ_QR_CODE_QUEUE=qr-code.generate
 RABBITMQ_QR_CODE_DLQ=qr-code.generate.dlq
 RABBITMQ_NOTIFICATION_PUSH_QUEUE=notification.push
 RABBITMQ_NOTIFICATION_PUSH_DLQ=notification.push.dlq
+RABBITMQ_CALENDAR_SYNC_QUEUE=calendar.sync
+RABBITMQ_CALENDAR_SYNC_DLQ=calendar.sync.dlq
 
 # ---------- Notificações Push (Firebase Cloud Messaging) ----------
 # Toggle de envio: false em dev sem credenciais (FcmClient.send vira no-op + warn).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,4 +165,6 @@ open http://localhost:3000/auth/google/connect
 
 ## Última atualização
 
-2026-05-16 — decisões de arquitetura M4 (#1-#8) fechadas em sessão com Ricardo; ver lista numerada acima e ADR-002 (`petcard-docs/architecture/adr/002-m4-integracoes-externas.md`). Próximo passo: abrir PC-072 (migrations) seguindo a ordem PC-072 → PC-066 → PC-068 → PC-067 → PC-064 → PC-069 → PC-065.
+2026-05-27 — PC-069 entregue: sincronização com Google Calendar passa por fila `calendar.sync` (DLX/DLQ + retry header), substituindo o fire-and-forget anterior do `AppointmentService`. `GoogleCalendarService` agora re-throwa exceções (após persistir `syncStatus=FAILED`) para o consumer decidir entre retry e DLQ. Token revogado (`invalid_grant`) e 404 em UPDATE/DELETE são tratados como permanentes (ack sem retry). Restante de M4: PC-065 (sync bidirecional).
+
+2026-05-16 — decisões de arquitetura M4 (#1-#8) fechadas em sessão com Ricardo; ver lista numerada acima e ADR-002 (`petcard-docs/architecture/adr/002-m4-integracoes-externas.md`).

--- a/src/config/rabbitmq.config.ts
+++ b/src/config/rabbitmq.config.ts
@@ -8,4 +8,8 @@ export const rabbitmqConfig = registerAs('rabbitmq', () => ({
     process.env.RABBITMQ_NOTIFICATION_PUSH_QUEUE ?? 'notification.push',
   notificationPushDlq:
     process.env.RABBITMQ_NOTIFICATION_PUSH_DLQ ?? 'notification.push.dlq',
+  calendarSyncQueue:
+    process.env.RABBITMQ_CALENDAR_SYNC_QUEUE ?? 'calendar.sync',
+  calendarSyncDlq:
+    process.env.RABBITMQ_CALENDAR_SYNC_DLQ ?? 'calendar.sync.dlq',
 }));

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,8 @@ import { NestFactory } from '@nestjs/core';
 import { MicroserviceOptions, Transport } from '@nestjs/microservices';
 import { AppModule } from './app.module';
 import {
+  CALENDAR_SYNC_DLQ_ROUTING_KEY,
+  CALENDAR_SYNC_DLX,
   NOTIFICATION_PUSH_DLQ_ROUTING_KEY,
   NOTIFICATION_PUSH_DLX,
   QR_CODE_DLQ_ROUTING_KEY,
@@ -53,6 +55,23 @@ async function bootstrap() {
         arguments: {
           'x-dead-letter-exchange': NOTIFICATION_PUSH_DLX,
           'x-dead-letter-routing-key': NOTIFICATION_PUSH_DLQ_ROUTING_KEY,
+        },
+      },
+      noAck: false,
+      prefetchCount: 1,
+    },
+  });
+
+  app.connectMicroservice<MicroserviceOptions>({
+    transport: Transport.RMQ,
+    options: {
+      urls: [config.get<string>('rabbitmq.url')!],
+      queue: config.get<string>('rabbitmq.calendarSyncQueue')!,
+      queueOptions: {
+        durable: true,
+        arguments: {
+          'x-dead-letter-exchange': CALENDAR_SYNC_DLX,
+          'x-dead-letter-routing-key': CALENDAR_SYNC_DLQ_ROUTING_KEY,
         },
       },
       noAck: false,

--- a/src/modules/appointment/appointment.module.ts
+++ b/src/modules/appointment/appointment.module.ts
@@ -1,11 +1,10 @@
 import { Module } from '@nestjs/common';
 import { AuthModule } from '../auth/auth.module';
-import { CalendarModule } from '../calendar/calendar.module';
 import { AppointmentController } from './appointment.controller';
 import { AppointmentService } from './appointment.service';
 
 @Module({
-  imports: [AuthModule, CalendarModule],
+  imports: [AuthModule],
   controllers: [AppointmentController],
   providers: [AppointmentService],
   exports: [AppointmentService],

--- a/src/modules/appointment/appointment.service.ts
+++ b/src/modules/appointment/appointment.service.ts
@@ -5,7 +5,7 @@ import {
 } from '@nestjs/common';
 import { Appointment } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
-import { GoogleCalendarService } from '../calendar/google-calendar.service';
+import { CalendarSyncPublisher } from '../queue/calendar-sync.publisher';
 import { CreateAppointmentDto } from './dto/create-appointment.dto';
 import { UpdateAppointmentDto } from './dto/update-appointment.dto';
 
@@ -47,7 +47,7 @@ function toResponse(a: AppointmentWithPet): AppointmentResponse {
 export class AppointmentService {
   constructor(
     private readonly prisma: PrismaService,
-    private readonly calendarService: GoogleCalendarService,
+    private readonly calendarSyncPublisher: CalendarSyncPublisher,
   ) {}
 
   async create(
@@ -67,10 +67,11 @@ export class AppointmentService {
       include: { pet: { select: { name: true } } },
     });
 
-    // Fire-and-forget: sync to Google Calendar if connected
-    this.calendarService
-      .syncAppointment(userId, appointment.id)
-      .catch(() => {});
+    await this.calendarSyncPublisher.publish({
+      action: 'CREATE',
+      appointment_id: appointment.id,
+      tutor_id: userId,
+    });
 
     return toResponse(appointment);
   }
@@ -122,18 +123,28 @@ export class AppointmentService {
       include: { pet: { select: { name: true } } },
     });
 
-    this.calendarService
-      .syncAppointment(userId, appointment.id)
-      .catch(() => {});
+    await this.calendarSyncPublisher.publish({
+      action: 'UPDATE',
+      appointment_id: appointment.id,
+      tutor_id: userId,
+    });
 
     return toResponse(appointment);
   }
 
   async remove(id: string, userId: string): Promise<void> {
-    await this.findAndAssertOwnership(id, userId);
+    const appointment = await this.findAndAssertOwnership(id, userId);
 
-    // Delete from Google Calendar first (needs the appointment data)
-    await this.calendarService.deleteEvent(userId, id).catch(() => {});
+    // Capture the event id before deleting the row — the worker needs it to
+    // call the Calendar API after the appointment is gone from the DB.
+    if (appointment.googleEventId) {
+      await this.calendarSyncPublisher.publish({
+        action: 'DELETE',
+        appointment_id: id,
+        tutor_id: userId,
+        google_event_id: appointment.googleEventId,
+      });
+    }
 
     await this.prisma.appointment.delete({ where: { id } });
   }

--- a/src/modules/calendar/__tests__/calendar-sync.consumer.spec.ts
+++ b/src/modules/calendar/__tests__/calendar-sync.consumer.spec.ts
@@ -1,0 +1,193 @@
+import { RmqContext } from '@nestjs/microservices';
+import { Test, TestingModule } from '@nestjs/testing';
+import type { CalendarSyncMessage } from '../../queue/dto/calendar-sync.message';
+import {
+  CALENDAR_SYNC_MAX_RETRIES,
+  CALENDAR_SYNC_RETRY_HEADER,
+} from '../../queue/queue.constants';
+import { CalendarSyncConsumer } from '../calendar-sync.consumer';
+import { GoogleCalendarService } from '../google-calendar.service';
+
+const createMessage = (
+  overrides: Partial<CalendarSyncMessage> = {},
+): CalendarSyncMessage => ({
+  action: 'CREATE',
+  appointment_id: 'appt-1',
+  tutor_id: 'tutor-1',
+  ...overrides,
+});
+
+const buildContext = (
+  channel: { ack: jest.Mock; nack: jest.Mock; publish: jest.Mock },
+  payload: CalendarSyncMessage,
+  headers: Record<string, unknown> = {},
+) => {
+  const message = {
+    content: Buffer.from(JSON.stringify(payload)),
+    fields: { routingKey: 'calendar.sync' },
+    properties: { headers },
+  };
+  const context = {
+    getChannelRef: () => channel,
+    getMessage: () => message,
+  } as unknown as RmqContext;
+  return { context, message };
+};
+
+describe('CalendarSyncConsumer', () => {
+  let consumer: CalendarSyncConsumer;
+  let calendarService: {
+    syncAppointment: jest.Mock;
+    deleteEvent: jest.Mock;
+  };
+  let channel: { ack: jest.Mock; nack: jest.Mock; publish: jest.Mock };
+
+  beforeEach(async () => {
+    calendarService = {
+      syncAppointment: jest.fn().mockResolvedValue(undefined),
+      deleteEvent: jest.fn().mockResolvedValue(undefined),
+    };
+    channel = { ack: jest.fn(), nack: jest.fn(), publish: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CalendarSyncConsumer,
+        { provide: GoogleCalendarService, useValue: calendarService },
+      ],
+    }).compile();
+
+    consumer = module.get(CalendarSyncConsumer);
+  });
+
+  it('calls syncAppointment and acks on a successful CREATE', async () => {
+    const payload = createMessage({ action: 'CREATE' });
+    const { context, message } = buildContext(channel, payload);
+
+    await consumer.handleSync(payload, context);
+
+    expect(calendarService.syncAppointment).toHaveBeenCalledWith(
+      'tutor-1',
+      'appt-1',
+    );
+    expect(channel.ack).toHaveBeenCalledWith(message);
+    expect(channel.nack).not.toHaveBeenCalled();
+    expect(channel.publish).not.toHaveBeenCalled();
+  });
+
+  it('calls syncAppointment and acks on a successful UPDATE', async () => {
+    const payload = createMessage({ action: 'UPDATE' });
+    const { context, message } = buildContext(channel, payload);
+
+    await consumer.handleSync(payload, context);
+
+    expect(calendarService.syncAppointment).toHaveBeenCalledWith(
+      'tutor-1',
+      'appt-1',
+    );
+    expect(channel.ack).toHaveBeenCalledWith(message);
+  });
+
+  it('calls deleteEvent with the google_event_id and acks on DELETE', async () => {
+    const payload = createMessage({
+      action: 'DELETE',
+      google_event_id: 'evt-42',
+    });
+    const { context, message } = buildContext(channel, payload);
+
+    await consumer.handleSync(payload, context);
+
+    expect(calendarService.deleteEvent).toHaveBeenCalledWith(
+      'tutor-1',
+      'evt-42',
+    );
+    expect(calendarService.syncAppointment).not.toHaveBeenCalled();
+    expect(channel.ack).toHaveBeenCalledWith(message);
+  });
+
+  it('acks and skips DELETE messages missing google_event_id', async () => {
+    const payload = createMessage({ action: 'DELETE' });
+    const { context, message } = buildContext(channel, payload);
+
+    await consumer.handleSync(payload, context);
+
+    expect(calendarService.deleteEvent).not.toHaveBeenCalled();
+    expect(channel.ack).toHaveBeenCalledWith(message);
+  });
+
+  it('acks and skips messages with missing required fields', async () => {
+    const payload = {} as unknown as CalendarSyncMessage;
+    const { context, message } = buildContext(channel, createMessage());
+
+    await consumer.handleSync(payload, context);
+
+    expect(calendarService.syncAppointment).not.toHaveBeenCalled();
+    expect(channel.ack).toHaveBeenCalledWith(message);
+  });
+
+  it('acks without retry on a permanent OAuth error (invalid_grant)', async () => {
+    calendarService.syncAppointment.mockRejectedValue(
+      new Error('invalid_grant: Token has been expired or revoked.'),
+    );
+    const payload = createMessage({ action: 'UPDATE' });
+    const { context, message } = buildContext(channel, payload);
+
+    await consumer.handleSync(payload, context);
+
+    expect(channel.ack).toHaveBeenCalledWith(message);
+    expect(channel.publish).not.toHaveBeenCalled();
+    expect(channel.nack).not.toHaveBeenCalled();
+  });
+
+  it('acks UPDATE when the event is already gone (404)', async () => {
+    const notFound = Object.assign(new Error('Not Found'), { code: 404 });
+    calendarService.syncAppointment.mockRejectedValue(notFound);
+    const payload = createMessage({ action: 'UPDATE' });
+    const { context, message } = buildContext(channel, payload);
+
+    await consumer.handleSync(payload, context);
+
+    expect(channel.ack).toHaveBeenCalledWith(message);
+    expect(channel.publish).not.toHaveBeenCalled();
+  });
+
+  it('retries with incremented counter on a transient error', async () => {
+    const transient = Object.assign(new Error('Service Unavailable'), {
+      code: 503,
+    });
+    calendarService.syncAppointment.mockRejectedValue(transient);
+    const payload = createMessage({ action: 'CREATE' });
+    const { context, message } = buildContext(channel, payload);
+
+    await consumer.handleSync(payload, context);
+
+    expect(channel.publish).toHaveBeenCalledWith(
+      '',
+      'calendar.sync',
+      message.content,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          [CALENDAR_SYNC_RETRY_HEADER]: 1,
+        }) as unknown,
+      }),
+    );
+    expect(channel.ack).toHaveBeenCalledWith(message);
+    expect(channel.nack).not.toHaveBeenCalled();
+  });
+
+  it('nacks to DLQ when retries are exhausted', async () => {
+    const transient = Object.assign(new Error('Service Unavailable'), {
+      code: 503,
+    });
+    calendarService.syncAppointment.mockRejectedValue(transient);
+    const payload = createMessage({ action: 'CREATE' });
+    const { context, message } = buildContext(channel, payload, {
+      [CALENDAR_SYNC_RETRY_HEADER]: CALENDAR_SYNC_MAX_RETRIES,
+    });
+
+    await consumer.handleSync(payload, context);
+
+    expect(channel.nack).toHaveBeenCalledWith(message, false, false);
+    expect(channel.publish).not.toHaveBeenCalled();
+    expect(channel.ack).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/calendar/calendar-sync.consumer.ts
+++ b/src/modules/calendar/calendar-sync.consumer.ts
@@ -1,0 +1,150 @@
+import { Controller, Logger } from '@nestjs/common';
+import { Ctx, MessagePattern, Payload } from '@nestjs/microservices';
+import type { RmqContext } from '@nestjs/microservices';
+import type { Channel, ConsumeMessage } from 'amqplib';
+import type { CalendarSyncMessage } from '../queue/dto/calendar-sync.message';
+import {
+  CALENDAR_SYNC_MAX_RETRIES,
+  CALENDAR_SYNC_PATTERN,
+  CALENDAR_SYNC_RETRY_HEADER,
+} from '../queue/queue.constants';
+import { GoogleCalendarService } from './google-calendar.service';
+
+@Controller()
+export class CalendarSyncConsumer {
+  private readonly logger = new Logger(CalendarSyncConsumer.name);
+
+  constructor(private readonly calendarService: GoogleCalendarService) {}
+
+  @MessagePattern(CALENDAR_SYNC_PATTERN)
+  async handleSync(
+    @Payload() data: CalendarSyncMessage,
+    @Ctx() context: RmqContext,
+  ): Promise<void> {
+    const channel = context.getChannelRef() as Channel;
+    const message = context.getMessage() as ConsumeMessage;
+
+    if (!data?.appointment_id || !data?.tutor_id || !data?.action) {
+      this.logger.warn(
+        'Received calendar.sync message with missing appointment_id/tutor_id/action',
+      );
+      channel.ack(message);
+      return;
+    }
+
+    if (data.action === 'DELETE' && !data.google_event_id) {
+      this.logger.warn(
+        `DELETE message for appointment ${data.appointment_id} missing google_event_id; skipping`,
+      );
+      channel.ack(message);
+      return;
+    }
+
+    try {
+      if (data.action === 'DELETE') {
+        await this.calendarService.deleteEvent(
+          data.tutor_id,
+          data.google_event_id!,
+        );
+      } else {
+        // syncAppointment branches between createEvent/updateEvent based on
+        // the current googleEventId — handles CREATE and UPDATE uniformly.
+        await this.calendarService.syncAppointment(
+          data.tutor_id,
+          data.appointment_id,
+        );
+      }
+
+      this.logger.log(
+        `Calendar ${data.action} synced for appointment ${data.appointment_id}`,
+      );
+      channel.ack(message);
+    } catch (error) {
+      // Refresh token revoked — only the tutor can fix this by reconnecting.
+      if (this.isPermanentAuthError(error)) {
+        this.logger.warn(
+          `Calendar OAuth revoked for appointment ${data.appointment_id}; ack without retry`,
+        );
+        channel.ack(message);
+        return;
+      }
+
+      // Event already gone on the Google side — UPDATE/DELETE are idempotent here.
+      if (data.action !== 'CREATE' && this.isNotFoundError(error)) {
+        this.logger.warn(
+          `Calendar event missing for appointment ${data.appointment_id} (${data.action}); treating as success`,
+        );
+        channel.ack(message);
+        return;
+      }
+
+      const reason = error instanceof Error ? error.message : String(error);
+      await this.retryOrDlq(
+        data.appointment_id,
+        data.action,
+        reason,
+        channel,
+        message,
+      );
+    }
+  }
+
+  private async retryOrDlq(
+    appointmentId: string,
+    action: string,
+    reason: string,
+    channel: Channel,
+    message: ConsumeMessage,
+  ): Promise<void> {
+    const retryCount = this.getRetryCount(message);
+
+    if (retryCount < CALENDAR_SYNC_MAX_RETRIES) {
+      this.logger.warn(
+        `Retry ${retryCount + 1}/${CALENDAR_SYNC_MAX_RETRIES} for appointment ${appointmentId} (${action}): ${reason}`,
+      );
+      channel.publish('', message.fields.routingKey, message.content, {
+        ...message.properties,
+        headers: {
+          ...message.properties.headers,
+          [CALENDAR_SYNC_RETRY_HEADER]: retryCount + 1,
+        },
+      });
+      channel.ack(message);
+      return Promise.resolve();
+    }
+
+    this.logger.error(
+      `Exhausted retries for appointment ${appointmentId} (${action}): ${reason}; routing to DLQ`,
+    );
+    channel.nack(message, false, false);
+    return Promise.resolve();
+  }
+
+  private isPermanentAuthError(error: unknown): boolean {
+    if (this.extractStatus(error) === 401) return true;
+    if (!(error instanceof Error)) return false;
+    const message = error.message.toLowerCase();
+    return (
+      message.includes('invalid_grant') ||
+      message.includes('token has been expired or revoked')
+    );
+  }
+
+  private isNotFoundError(error: unknown): boolean {
+    return this.extractStatus(error) === 404;
+  }
+
+  private extractStatus(error: unknown): number | undefined {
+    if (typeof error !== 'object' || error === null) return undefined;
+    const err = error as { code?: unknown; response?: { status?: unknown } };
+    if (typeof err.code === 'number') return err.code;
+    const status = err.response?.status;
+    return typeof status === 'number' ? status : undefined;
+  }
+
+  private getRetryCount(message: ConsumeMessage): number {
+    const raw: unknown =
+      message.properties.headers?.[CALENDAR_SYNC_RETRY_HEADER];
+    return typeof raw === 'number' ? raw : 0;
+  }
+}

--- a/src/modules/calendar/calendar.module.ts
+++ b/src/modules/calendar/calendar.module.ts
@@ -2,11 +2,12 @@ import { Module } from '@nestjs/common';
 import { AuthModule } from '../auth/auth.module';
 import { PrismaModule } from '../../prisma/prisma.module';
 import { CalendarController } from './calendar.controller';
+import { CalendarSyncConsumer } from './calendar-sync.consumer';
 import { GoogleCalendarService } from './google-calendar.service';
 
 @Module({
   imports: [AuthModule, PrismaModule],
-  controllers: [CalendarController],
+  controllers: [CalendarController, CalendarSyncConsumer],
   providers: [GoogleCalendarService],
   exports: [GoogleCalendarService],
 })

--- a/src/modules/calendar/google-calendar.service.ts
+++ b/src/modules/calendar/google-calendar.service.ts
@@ -158,6 +158,7 @@ export class GoogleCalendarService {
           syncError: error instanceof Error ? error.message : 'Unknown error',
         },
       });
+      throw error;
     }
   }
 
@@ -229,29 +230,25 @@ export class GoogleCalendarService {
           syncError: error instanceof Error ? error.message : 'Unknown error',
         },
       });
+      throw error;
     }
   }
 
-  async deleteEvent(tutorId: string, appointmentId: string): Promise<void> {
-    const appointment = await this.prisma.appointment.findUnique({
-      where: { id: appointmentId },
-    });
-    if (!appointment?.googleEventId) return;
-
+  async deleteEvent(tutorId: string, googleEventId: string): Promise<void> {
     const calendar = await this.getCalendarClient(tutorId);
     if (!calendar) return;
 
     try {
       await calendar.events.delete({
         calendarId: 'primary',
-        eventId: appointment.googleEventId,
+        eventId: googleEventId,
       });
     } catch (error) {
-      this.logger.warn(
-        `Failed to delete calendar event for appointment ${appointmentId}: ${
-          error instanceof Error ? error.message : error
-        }`,
+      this.logger.error(
+        `Failed to delete calendar event ${googleEventId}`,
+        error instanceof Error ? error.stack : error,
       );
+      throw error;
     }
   }
 
@@ -289,7 +286,16 @@ export class GoogleCalendarService {
     });
 
     for (const appointment of pending) {
-      await this.syncAppointment(tutorId, appointment.id);
+      try {
+        await this.syncAppointment(tutorId, appointment.id);
+      } catch (error) {
+        // syncStatus=FAILED is already persisted inside createEvent/updateEvent.
+        this.logger.warn(
+          `Sync failed for appointment ${appointment.id}: ${
+            error instanceof Error ? error.message : error
+          }`,
+        );
+      }
     }
 
     return pending.length;

--- a/src/modules/queue/__tests__/calendar-sync.publisher.spec.ts
+++ b/src/modules/queue/__tests__/calendar-sync.publisher.spec.ts
@@ -1,0 +1,48 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { of, throwError } from 'rxjs';
+import { CalendarSyncPublisher } from '../calendar-sync.publisher';
+import type { CalendarSyncMessage } from '../dto/calendar-sync.message';
+import {
+  CALENDAR_SYNC_CLIENT,
+  CALENDAR_SYNC_PATTERN,
+} from '../queue.constants';
+
+const baseMessage: CalendarSyncMessage = {
+  action: 'CREATE',
+  appointment_id: 'appt-1',
+  tutor_id: 'tutor-1',
+};
+
+describe('CalendarSyncPublisher', () => {
+  let publisher: CalendarSyncPublisher;
+  let client: { emit: jest.Mock };
+
+  beforeEach(async () => {
+    client = { emit: jest.fn().mockReturnValue(of(undefined)) };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CalendarSyncPublisher,
+        { provide: CALENDAR_SYNC_CLIENT, useValue: client as unknown },
+      ],
+    }).compile();
+
+    publisher = module.get<CalendarSyncPublisher>(CalendarSyncPublisher);
+  });
+
+  it('emits a calendar.sync event with the full message payload', async () => {
+    await publisher.publish(baseMessage);
+
+    expect(client.emit).toHaveBeenCalledWith(
+      CALENDAR_SYNC_PATTERN,
+      baseMessage,
+    );
+  });
+
+  it('rethrows publish errors so the caller can react', async () => {
+    const cause = new Error('rmq down');
+    client.emit.mockReturnValue(throwError(() => cause));
+
+    await expect(publisher.publish(baseMessage)).rejects.toThrow(cause);
+  });
+});

--- a/src/modules/queue/calendar-sync.publisher.ts
+++ b/src/modules/queue/calendar-sync.publisher.ts
@@ -1,0 +1,26 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { ClientProxy } from '@nestjs/microservices';
+import { lastValueFrom } from 'rxjs';
+import type { CalendarSyncMessage } from './dto/calendar-sync.message';
+import { CALENDAR_SYNC_CLIENT, CALENDAR_SYNC_PATTERN } from './queue.constants';
+
+@Injectable()
+export class CalendarSyncPublisher {
+  private readonly logger = new Logger(CalendarSyncPublisher.name);
+
+  constructor(
+    @Inject(CALENDAR_SYNC_CLIENT) private readonly client: ClientProxy,
+  ) {}
+
+  async publish(message: CalendarSyncMessage): Promise<void> {
+    try {
+      await lastValueFrom(this.client.emit(CALENDAR_SYNC_PATTERN, message));
+    } catch (error) {
+      this.logger.error(
+        `Failed to publish calendar.sync (${message.action}) for appointment ${message.appointment_id}`,
+        error instanceof Error ? error.stack : error,
+      );
+      throw error;
+    }
+  }
+}

--- a/src/modules/queue/dto/calendar-sync.message.ts
+++ b/src/modules/queue/dto/calendar-sync.message.ts
@@ -1,0 +1,9 @@
+export type CalendarSyncAction = 'CREATE' | 'UPDATE' | 'DELETE';
+
+export interface CalendarSyncMessage {
+  action: CalendarSyncAction;
+  appointment_id: string;
+  tutor_id: string;
+  // Required for DELETE: the appointment row is gone by the time the worker runs.
+  google_event_id?: string;
+}

--- a/src/modules/queue/queue.constants.ts
+++ b/src/modules/queue/queue.constants.ts
@@ -13,3 +13,11 @@ export const NOTIFICATION_PUSH_DLX = 'notification.push.dlx';
 export const NOTIFICATION_PUSH_DLQ_ROUTING_KEY = 'dead';
 export const NOTIFICATION_PUSH_RETRY_HEADER = 'x-retry-count';
 export const NOTIFICATION_PUSH_MAX_RETRIES = 3;
+
+export const CALENDAR_SYNC_CLIENT = 'CALENDAR_SYNC_CLIENT';
+export const CALENDAR_SYNC_PATTERN = 'calendar.sync';
+
+export const CALENDAR_SYNC_DLX = 'calendar.sync.dlx';
+export const CALENDAR_SYNC_DLQ_ROUTING_KEY = 'dead';
+export const CALENDAR_SYNC_RETRY_HEADER = 'x-retry-count';
+export const CALENDAR_SYNC_MAX_RETRIES = 3;

--- a/src/modules/queue/queue.module.ts
+++ b/src/modules/queue/queue.module.ts
@@ -3,10 +3,14 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { ClientsModule, Transport } from '@nestjs/microservices';
 import { CardModule } from '../card/card.module';
 import { UploadModule } from '../upload/upload.module';
+import { CalendarSyncPublisher } from './calendar-sync.publisher';
 import { NotificationPushPublisher } from './notification-push.publisher';
 import { QrCodeConsumer } from './qr-code.consumer';
 import { QrCodePublisher } from './qr-code.publisher';
 import {
+  CALENDAR_SYNC_CLIENT,
+  CALENDAR_SYNC_DLQ_ROUTING_KEY,
+  CALENDAR_SYNC_DLX,
   NOTIFICATION_PUSH_CLIENT,
   NOTIFICATION_PUSH_DLQ_ROUTING_KEY,
   NOTIFICATION_PUSH_DLX,
@@ -62,14 +66,35 @@ import { RabbitMqTopologyService } from './rabbitmq-topology.service';
           },
         }),
       },
+      {
+        name: CALENDAR_SYNC_CLIENT,
+        imports: [ConfigModule],
+        inject: [ConfigService],
+        useFactory: (config: ConfigService) => ({
+          transport: Transport.RMQ,
+          options: {
+            urls: [config.get<string>('rabbitmq.url')!],
+            queue: config.get<string>('rabbitmq.calendarSyncQueue')!,
+            queueOptions: {
+              durable: true,
+              arguments: {
+                'x-dead-letter-exchange': CALENDAR_SYNC_DLX,
+                'x-dead-letter-routing-key': CALENDAR_SYNC_DLQ_ROUTING_KEY,
+              },
+            },
+            persistent: true,
+          },
+        }),
+      },
     ]),
   ],
   controllers: [QrCodeConsumer],
   providers: [
     QrCodePublisher,
     NotificationPushPublisher,
+    CalendarSyncPublisher,
     RabbitMqTopologyService,
   ],
-  exports: [QrCodePublisher, NotificationPushPublisher],
+  exports: [QrCodePublisher, NotificationPushPublisher, CalendarSyncPublisher],
 })
 export class QueueModule {}

--- a/src/modules/queue/rabbitmq-topology.service.ts
+++ b/src/modules/queue/rabbitmq-topology.service.ts
@@ -2,6 +2,8 @@ import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import * as amqp from 'amqplib';
 import {
+  CALENDAR_SYNC_DLQ_ROUTING_KEY,
+  CALENDAR_SYNC_DLX,
   NOTIFICATION_PUSH_DLQ_ROUTING_KEY,
   NOTIFICATION_PUSH_DLX,
   QR_CODE_DLQ_ROUTING_KEY,
@@ -19,6 +21,9 @@ export class RabbitMqTopologyService implements OnModuleInit {
     const qrCodeDlq = this.config.get<string>('rabbitmq.qrCodeDlq')!;
     const notificationPushDlq = this.config.get<string>(
       'rabbitmq.notificationPushDlq',
+    )!;
+    const calendarSyncDlq = this.config.get<string>(
+      'rabbitmq.calendarSyncDlq',
     )!;
 
     const connection = await amqp.connect(url);
@@ -43,6 +48,19 @@ export class RabbitMqTopologyService implements OnModuleInit {
       );
       this.logger.log(
         `DLX/DLQ ready (exchange=${NOTIFICATION_PUSH_DLX}, queue=${notificationPushDlq})`,
+      );
+
+      await channel.assertExchange(CALENDAR_SYNC_DLX, 'direct', {
+        durable: true,
+      });
+      await channel.assertQueue(calendarSyncDlq, { durable: true });
+      await channel.bindQueue(
+        calendarSyncDlq,
+        CALENDAR_SYNC_DLX,
+        CALENDAR_SYNC_DLQ_ROUTING_KEY,
+      );
+      this.logger.log(
+        `DLX/DLQ ready (exchange=${CALENDAR_SYNC_DLX}, queue=${calendarSyncDlq})`,
       );
 
       await channel.close();

--- a/test/cards-public.e2e-spec.ts
+++ b/test/cards-public.e2e-spec.ts
@@ -1,14 +1,3 @@
-jest.mock('jwks-rsa', () => ({
-  passportJwtSecret:
-    () =>
-    (
-      _req: unknown,
-      _token: unknown,
-      done: (err: Error | null, key: string) => void,
-    ) =>
-      done(null, 'test-secret'),
-}));
-
 process.env.PUBLIC_CARD_THROTTLE_TTL_SECONDS = '60';
 process.env.PUBLIC_CARD_THROTTLE_LIMIT = '3';
 

--- a/test/cruds-mvp1.e2e-spec.ts
+++ b/test/cruds-mvp1.e2e-spec.ts
@@ -1,15 +1,4 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-jest.mock('jwks-rsa', () => ({
-  passportJwtSecret:
-    () =>
-    (
-      _req: unknown,
-      _token: unknown,
-      done: (err: Error | null, key: string) => void,
-    ) =>
-      done(null, 'test-secret'),
-}));
-
 import { INestApplication, ValidationPipe } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import request from 'supertest';
@@ -27,13 +16,13 @@ type Ctx = {
 };
 
 const tutorCtx: Ctx = {
-  sub: 'auth0|tutor-1',
+  sub: '22222222-2222-4222-8222-222222222222',
   email: 'tutor@petcard.com',
   role: 'TUTOR',
   permissions: ['TUTOR'],
 };
 const vetCtx: Ctx = {
-  sub: 'auth0|vet-1',
+  sub: '33333333-3333-4333-8333-333333333333',
   email: 'vet@petcard.com',
   role: 'VET',
   permissions: ['VET'],
@@ -231,7 +220,7 @@ describe('CRUDs MVP1 (e2e)', () => {
         .expect((res) => expect(res.body.name).toBe('Alice B'));
 
       expect(mockPrisma.tutor.update).toHaveBeenCalledWith({
-        where: { auth0Id: 'auth0|tutor-1' },
+        where: { id: tutor1.id },
         data: { name: 'Alice B' },
       });
     });

--- a/test/devices.e2e-spec.ts
+++ b/test/devices.e2e-spec.ts
@@ -1,15 +1,4 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-jest.mock('jwks-rsa', () => ({
-  passportJwtSecret:
-    () =>
-    (
-      _req: unknown,
-      _token: unknown,
-      done: (err: Error | null, key: string) => void,
-    ) =>
-      done(null, 'test-secret'),
-}));
-
 import { INestApplication, ValidationPipe } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import request from 'supertest';
@@ -27,7 +16,7 @@ type Ctx = {
   permissions: string[];
 };
 const tutorCtx: Ctx = {
-  sub: 'auth0|tutor-1',
+  sub: '22222222-2222-4222-8222-222222222222',
   email: 'tutor@petcard.com',
   role: 'TUTOR',
   permissions: ['TUTOR'],
@@ -104,8 +93,8 @@ describe('DevicesController (e2e)', () => {
     jest.clearAllMocks();
     currentUser = tutorCtx;
     mockPrisma.tutor.findUnique.mockImplementation(
-      ({ where }: { where: { auth0Id?: string } }) =>
-        where.auth0Id === 'auth0|tutor-1'
+      ({ where }: { where: { id?: string } }) =>
+        where.id === tutor1.id
           ? Promise.resolve(tutor1)
           : Promise.resolve(null),
     );


### PR DESCRIPTION
## Resumo

Move a sincronização com o Google Calendar para uma fila `calendar.sync` (DLX/DLQ + retry) consumida por um worker, substituindo o `fire-and-forget` síncrono que existia no `AppointmentService` (create/update/delete).

Fecha a issue **PC-069** (#33). Atende ADR-002 #3 ("fila para todo outbound de volume") e ADR-002 #7 (degradação graceful — request do tutor não é mais derrubada por instabilidade do Google).

## O que mudou

### Camada de fila
- Nova fila `calendar.sync` com exchange `calendar.sync.dlx` + DLQ `calendar.sync.dlq` (mesmo padrão de `notification.push`).
- `CalendarSyncMessage` com discriminador `action: 'CREATE' | 'UPDATE' | 'DELETE'`. DELETE carrega `google_event_id` porque a row do appointment é removida do banco antes do worker rodar.
- `CalendarSyncPublisher` exportado pelo `QueueModule` (global).
- `RabbitMqTopologyService` declara o DLX/DLQ no boot.
- Terceiro `connectMicroservice` no `main.ts` para consumir `calendar.sync`.

### `AppointmentService`
- `create`/`update`: publica em vez de chamar `calendarService.syncAppointment` direto.
- `remove`: lê `googleEventId` da row, publica `DELETE` (se houver evento), depois deleta a row.
- Removida a dependência de `CalendarModule` (consumer agora vive lá; publisher é injetado pelo `QueueModule` global).

### `GoogleCalendarService`
- `createEvent`/`updateEvent`/`deleteEvent`: persistem `syncStatus=FAILED` antes de **re-throw** — o consumer decide entre retry e DLQ.
- `deleteEvent` agora recebe `googleEventId` direto (sem leitura do banco), já que a row pode não existir mais.
- `syncAllPending` envolve cada `syncAppointment` em try/catch para continuar iterando mesmo se uma falhar (o endpoint manual `POST /calendar/sync` segue síncrono).

### `CalendarSyncConsumer`
- **Erros permanentes** (ack sem retry): `invalid_grant` / 401 (token revogado), `404` em UPDATE/DELETE (evento já não existe — idempotência).
- **Erros transientes**: retry até `CALENDAR_SYNC_MAX_RETRIES=3` via republish com `x-retry-count++`, depois `nack(false, false)` → DLQ.
- **No-op** (ack silencioso): tutor sem `google_oauth_token` (caminho coberto dentro de `getCalendarClient`).

## Testes

- `calendar-sync.publisher.spec.ts` — 2 testes (emite o pattern correto, propaga erro de publish).
- `calendar-sync.consumer.spec.ts` — 9 testes (CREATE/UPDATE/DELETE sucesso, mensagem inválida, token revogado, 404 idempotente, retry, DLQ esgotado).
- Suíte completa: **111/111 unit tests passando**. E2E precisa do docker compose (testar localmente antes de mergear).

## Test plan

- [ ] `docker compose -f docker/docker-compose.yml up -d`
- [ ] `npm run test:e2e` — confirmar 33/33 passando (ou contagem atual)
- [ ] `npm run start:dev` — boot loga 3 DLX/DLQ ready, incluindo `calendar.sync.dlx`
- [ ] `POST /appointments` autenticado com tutor conectado ao Google → ver log `Calendar CREATE synced for appointment <id>`
- [ ] `PATCH /appointments/:id` → log `Calendar UPDATE synced`
- [ ] `DELETE /appointments/:id` → log `Calendar DELETE synced`, evento some do Calendar do tutor
- [ ] `rabbitmqctl list_queues` mostra `calendar.sync` e `calendar.sync.dlq`
- [ ] Simular token revogado (revogar acesso na conta Google) → próxima publish termina com ack sem retry e log `Calendar OAuth revoked`

## Pontos de atenção para o revisor

- `deleteEvent` mudou de assinatura (`(tutorId, appointmentId)` → `(tutorId, googleEventId)`). Não existem outros call sites além de `CalendarSyncConsumer`, mas vale conferir.
- O `enum AppointmentSyncStatus.PENDING_DELETE` continua sem uso real (a row é apagada antes do worker rodar) — não removido nesta PR para evitar migration; pode virar chore separado se quiser limpar.
- `package-lock.json` tinha deriva de versões de npm em `develop` — não foi incluído nesta PR para manter o diff focado em PC-069.