### PR TITLE
chore: bootstrap do zero — sincronizar .env.example e roteiro de instalação

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,9 @@ PORT=3000
 # (web Vite :5173, API :3000, Expo :8081/:19006).
 CORS_ORIGINS=http://localhost:5173,http://localhost:8081,http://localhost:19006
 # ---------- Banco de Dados (PostgreSQL + PostGIS) ----------
-DATABASE_URL="postgresql://USER:PASSWORD@HOST:PORT/DATABASE?schema=public"
+# Valor abaixo casa com o docker-compose local (docker/docker-compose.yml).
+# Em outro ambiente, ajuste usuário/senha/host/porta/database.
+DATABASE_URL="postgresql://petcard:petcard123@localhost:5432/petcard_dev?schema=public"
 
 # ---------- Autenticação (JWT) ----------
 JWT_SECRET=uma_chave_secreta_segura_aqui
@@ -58,6 +60,9 @@ DOSE_REMINDER_WINDOW_DAYS=3
 GOOGLE_MAPS_API_KEY=sua_api_key
 GOOGLE_CALENDAR_CLIENT_ID=seu_client_id
 GOOGLE_CALENDAR_CLIENT_SECRET=seu_client_secret
+# URI de redirect do OAuth do Google Calendar. Default do código abaixo (dev local);
+# deve bater com o autorizado no Google Cloud Console.
+GOOGLE_CALENDAR_REDIRECT_URI=http://localhost:3000/calendar/callback
 
 # ---------- Carteira Digital (Página Pública) ----------
 # URL base usada no payload do QR Code. O "#" é obrigatório quando o web usa HashRouter.
@@ -65,7 +70,3 @@ PUBLIC_CARD_BASE_URL=https://card.petcard.app/#
 # Rate-limit da rota pública GET /cards/:token
 PUBLIC_CARD_THROTTLE_TTL_SECONDS=60
 PUBLIC_CARD_THROTTLE_LIMIT=10
-
-# ---------- JWT ----------
-JWT_SECRET=uma_chave_secreta_qualquer
-JWT_EXPIRES_IN=7d

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Este repositório faz parte de um conjunto de 5 repos:
 - Node.js >= 20 LTS
 - npm >= 10
 - Docker e Docker Compose
-- Conta Auth0 (dev tenant)
+- GitHub Personal Access Token com escopo `read:packages` (para baixar `@petcardorg/shared` do GitHub Packages)
 
 ## Instalação
 
@@ -47,20 +47,28 @@ Este repositório faz parte de um conjunto de 5 repos:
 git clone https://github.com/PetCardOrg/petcard-api.git
 cd petcard-api
 
-# 2. Instale as dependências
+# 2. Autentique no GitHub Packages (necessário para @petcardorg/shared)
+# Crie um token em https://github.com/settings/tokens com escopo read:packages
+export NODE_AUTH_TOKEN=<seu_personal_access_token>
+
+# 3. Instale as dependências
 npm install
 
-# 3. Configure as variáveis de ambiente
+# 4. Configure as variáveis de ambiente
 cp .env.example .env
-# Edite o .env com suas credenciais
+# Os defaults já casam com o docker-compose local; edite só credenciais externas
+# (AWS, Firebase, Google) se for usar esses serviços.
 
-# 4. Suba os serviços de infraestrutura
+# 5. Suba os serviços de infraestrutura
 docker compose -f docker/docker-compose.yml up -d
 
-# 5. Execute as migrations do banco
+# 6. Execute as migrations do banco
 npx prisma migrate dev
 
-# 6. Inicie o servidor
+# 7. (Opcional) Popule o banco com dados de exemplo
+npm run db:seed
+
+# 8. Inicie o servidor
 npm run start:dev
 # API disponível em http://localhost:3000
 ```


### PR DESCRIPTION
## Contexto

Dia 3 do plano de ação da auditoria (reta final do TCC): **bootstrap do zero confiável**. Endereça os achados #3 e #8 e o Risco de Apresentação #2 ("setup do zero falha").

## Mudanças

`.env.example`:
- `DATABASE_URL` agora casa com o `docker-compose.yml` local (`petcard:petcard123@localhost:5432/petcard_dev`) — antes era placeholder genérico que exigia edição manual. (mesmo cred local já público no compose e na linha do RabbitMQ)
- adiciona `GOOGLE_CALENDAR_REDIRECT_URI` — **usada no código** (`google-calendar.config.ts`) mas faltava no example, quebrando o OAuth do Calendar em setup novo
- remove o bloco `JWT_SECRET`/`JWT_EXPIRES_IN` **duplicado** no fim do arquivo

`README.md`:
- pré-requisito **"Conta Auth0 (dev tenant)"** removido — Auth0 foi abandonado (M0-#7); trocado por **token `read:packages`** do GitHub Packages
- adicionada a etapa de `NODE_AUTH_TOKEN` **antes** do `npm install` (causa #1 de falha de `npm install` em máquina limpa: `@petcardorg/shared` vem do GitHub Packages)
- passo opcional de `npm run db:seed`

## Validação

- `prisma validate` ✅ schema válido
- `prisma migrate status` com o `DATABASE_URL` do example ✅ conecta no Postgres do compose e lista as migrations pendentes (o caminho que um `migrate dev` aplicaria no bootstrap limpo)
- `prisma generate` sem `DATABASE_URL` ✅ exit 0 (achado #3 **não reproduz** no estado atual — `prisma.config.ts` faz carregamento lazy do env)

## Fora de escopo (deliberado)

- `ENCRYPTION_KEY` (achado #2) e alinhamento do `@petcardorg/shared@^0.9.0` (achado #6) → **Dia 4**
- decisão Redis no docker-compose/DAS → **Dia 4**