### PR TITLE
fix: cifrar tokens OAuth do Google (AES-256-GCM) + ajustes de README

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,12 @@ DATABASE_URL="postgresql://petcard:petcard123@localhost:5432/petcard_dev?schema=
 JWT_SECRET=uma_chave_secreta_segura_aqui
 JWT_EXPIRES_IN=7d
 
+# ---------- Criptografia em repouso (AES-256-GCM) ----------
+# Cifra os tokens OAuth do Google Calendar antes de persistir (ADR-002 #4).
+# Chave de 32 bytes em hexadecimal (64 caracteres). O valor abaixo é só para
+# dev local; gere um próprio com: openssl rand -hex 32
+ENCRYPTION_KEY=3e9c3ded29be54622a73784a9e5554b9ec3ae8b0c52e5a6be501b4137879faad
+
 # ---------- Storage (AWS S3) ----------
 AWS_REGION=us-east-1
 AWS_ACCESS_KEY_ID=sua_access_key

--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ Este repositório faz parte de um conjunto de 5 repos:
 
 | Camada         | Tecnologia                   |
 | -------------- | ---------------------------- |
-| Framework      | NestJS 10 + Node.js 20 LTS   |
+| Framework      | NestJS 11 + Node.js 20 LTS   |
 | Linguagem      | TypeScript 5.x (strict mode) |
 | Banco de Dados | PostgreSQL 16 + PostGIS 3.4  |
 | ORM            | Prisma 6                     |
 | Cache          | Redis 7                      |
 | Fila           | RabbitMQ 3                   |
-| Autenticação   | Auth0 (OAuth 2.0 + JWT)      |
+| Autenticação   | JWT próprio (HS256 + bcrypt) |
 | Storage        | AWS S3                       |
 | Notificações   | Firebase Cloud Messaging     |
 

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -12,6 +12,8 @@ import { googleMapsConfig } from './config/google-maps.config';
 import { rabbitmqConfig } from './config/rabbitmq.config';
 import { reminderConfig } from './config/reminder.config';
 import { googleCalendarConfig } from './config/google-calendar.config';
+import { encryptionConfig } from './config/encryption.config';
+import { CryptoModule } from './common/crypto/crypto.module';
 import { AppointmentModule } from './modules/appointment/appointment.module';
 import { AuthModule } from './modules/auth/auth.module';
 import { CalendarModule } from './modules/calendar/calendar.module';
@@ -44,9 +46,11 @@ import { PrismaModule } from './prisma/prisma.module';
         rabbitmqConfig,
         reminderConfig,
         googleCalendarConfig,
+        encryptionConfig,
       ],
     }),
     ScheduleModule.forRoot(),
+    CryptoModule,
     PrismaModule,
     AuthModule,
     AppointmentModule,

--- a/src/common/crypto/__tests__/encryption.service.spec.ts
+++ b/src/common/crypto/__tests__/encryption.service.spec.ts
@@ -1,0 +1,76 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { EncryptionService } from '../encryption.service';
+
+// Chave de teste: 32 bytes em hex (openssl rand -hex 32).
+const TEST_KEY =
+  '3e9c3ded29be54622a73784a9e5554b9ec3ae8b0c52e5a6be501b4137879faad';
+
+describe('EncryptionService', () => {
+  async function buildService(
+    key: string | undefined,
+  ): Promise<EncryptionService> {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        EncryptionService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: (path: string) =>
+              path === 'encryption.key' ? key : undefined,
+          },
+        },
+      ],
+    }).compile();
+    return module.get<EncryptionService>(EncryptionService);
+  }
+
+  it('faz round-trip de encrypt/decrypt', async () => {
+    const service = await buildService(TEST_KEY);
+    const plaintext = 'ya29.a0AfH6SMBy-refresh-token-secreto';
+
+    const encrypted = service.encrypt(plaintext);
+
+    expect(encrypted).not.toContain(plaintext);
+    expect(service.decrypt(encrypted)).toBe(plaintext);
+  });
+
+  it('gera ciphertext diferente a cada chamada (IV aleatório)', async () => {
+    const service = await buildService(TEST_KEY);
+
+    const a = service.encrypt('mesmo-valor');
+    const b = service.encrypt('mesmo-valor');
+
+    expect(a).not.toBe(b);
+    expect(service.decrypt(a)).toBe(service.decrypt(b));
+  });
+
+  it('rejeita payload adulterado (authTag inválido)', async () => {
+    const service = await buildService(TEST_KEY);
+    const [iv, , data] = service.encrypt('valor').split(':');
+    const forged = [
+      iv,
+      Buffer.from('0'.repeat(16)).toString('base64'),
+      data,
+    ].join(':');
+
+    expect(() => service.decrypt(forged)).toThrow();
+  });
+
+  it('rejeita payload malformado', async () => {
+    const service = await buildService(TEST_KEY);
+    expect(() => service.decrypt('sem-separadores')).toThrow(
+      'Payload cifrado malformado.',
+    );
+  });
+
+  it('falha quando ENCRYPTION_KEY está ausente', async () => {
+    const service = await buildService(undefined);
+    expect(() => service.encrypt('x')).toThrow('ENCRYPTION_KEY');
+  });
+
+  it('falha quando ENCRYPTION_KEY tem tamanho inválido', async () => {
+    const service = await buildService('abcd');
+    expect(() => service.encrypt('x')).toThrow('64 caracteres');
+  });
+});

--- a/src/common/crypto/crypto.module.ts
+++ b/src/common/crypto/crypto.module.ts
@@ -1,0 +1,9 @@
+import { Global, Module } from '@nestjs/common';
+import { EncryptionService } from './encryption.service';
+
+@Global()
+@Module({
+  providers: [EncryptionService],
+  exports: [EncryptionService],
+})
+export class CryptoModule {}

--- a/src/common/crypto/encryption.service.ts
+++ b/src/common/crypto/encryption.service.ts
@@ -1,0 +1,72 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { createCipheriv, createDecipheriv, randomBytes } from 'node:crypto';
+
+const ALGORITHM = 'aes-256-gcm';
+const IV_LENGTH = 12; // nonce de 96 bits, recomendado para GCM
+const KEY_LENGTH = 32; // 256 bits
+const SEPARATOR = ':';
+
+/**
+ * Cifra dados sensíveis em repouso com AES-256-GCM (ADR-002 #4 / RNF de
+ * criptografia do DAS). Usada para os tokens OAuth do Google Calendar.
+ *
+ * Formato do payload cifrado: `iv:authTag:ciphertext`, cada parte em base64.
+ * A chave (`ENCRYPTION_KEY`) é lida sob demanda para não obrigar sua presença
+ * no boot quando o Calendar não está configurado.
+ */
+@Injectable()
+export class EncryptionService {
+  constructor(private readonly configService: ConfigService) {}
+
+  private getKey(): Buffer {
+    const raw = this.configService.get<string>('encryption.key');
+    if (!raw) {
+      throw new Error(
+        'ENCRYPTION_KEY é obrigatória para cifrar/decifrar tokens OAuth.',
+      );
+    }
+    const key = Buffer.from(raw, 'hex');
+    if (key.length !== KEY_LENGTH) {
+      throw new Error(
+        `ENCRYPTION_KEY deve ter ${KEY_LENGTH} bytes em hexadecimal (64 caracteres). Gere com: openssl rand -hex 32`,
+      );
+    }
+    return key;
+  }
+
+  encrypt(plaintext: string): string {
+    const key = this.getKey();
+    const iv = randomBytes(IV_LENGTH);
+    const cipher = createCipheriv(ALGORITHM, key, iv);
+    const ciphertext = Buffer.concat([
+      cipher.update(plaintext, 'utf8'),
+      cipher.final(),
+    ]);
+    const authTag = cipher.getAuthTag();
+    return [
+      iv.toString('base64'),
+      authTag.toString('base64'),
+      ciphertext.toString('base64'),
+    ].join(SEPARATOR);
+  }
+
+  decrypt(payload: string): string {
+    const key = this.getKey();
+    const [ivB64, tagB64, dataB64] = payload.split(SEPARATOR);
+    if (!ivB64 || !tagB64 || !dataB64) {
+      throw new Error('Payload cifrado malformado.');
+    }
+    const decipher = createDecipheriv(
+      ALGORITHM,
+      key,
+      Buffer.from(ivB64, 'base64'),
+    );
+    decipher.setAuthTag(Buffer.from(tagB64, 'base64'));
+    const plaintext = Buffer.concat([
+      decipher.update(Buffer.from(dataB64, 'base64')),
+      decipher.final(),
+    ]);
+    return plaintext.toString('utf8');
+  }
+}

--- a/src/config/encryption.config.ts
+++ b/src/config/encryption.config.ts
@@ -1,0 +1,7 @@
+import { registerAs } from '@nestjs/config';
+
+export const encryptionConfig = registerAs('encryption', () => ({
+  // Chave AES-256-GCM em hexadecimal (32 bytes => 64 caracteres hex).
+  // Gere com: openssl rand -hex 32
+  key: process.env.ENCRYPTION_KEY,
+}));

--- a/src/modules/calendar/google-calendar.service.ts
+++ b/src/modules/calendar/google-calendar.service.ts
@@ -3,6 +3,7 @@ import { ConfigService } from '@nestjs/config';
 import { google, calendar_v3 } from 'googleapis';
 import { OAuth2Client } from 'google-auth-library';
 import { PrismaService } from '../../prisma/prisma.service';
+import { EncryptionService } from '../../common/crypto/encryption.service';
 
 const SCOPES = ['https://www.googleapis.com/auth/calendar.events'];
 
@@ -16,6 +17,7 @@ export class GoogleCalendarService {
   constructor(
     private readonly configService: ConfigService,
     private readonly prisma: PrismaService,
+    private readonly encryption: EncryptionService,
   ) {
     this.clientId =
       this.configService.get<string>('googleCalendar.clientId') ?? '';
@@ -56,15 +58,17 @@ export class GoogleCalendarService {
     await this.prisma.googleOAuthToken.upsert({
       where: { tutorId },
       update: {
-        accessToken: tokens.access_token!,
-        refreshToken: tokens.refresh_token ?? undefined,
+        accessToken: this.encryption.encrypt(tokens.access_token!),
+        refreshToken: tokens.refresh_token
+          ? this.encryption.encrypt(tokens.refresh_token)
+          : undefined,
         expiresAt: new Date(tokens.expiry_date!),
         scopes: SCOPES,
       },
       create: {
         tutorId,
-        accessToken: tokens.access_token!,
-        refreshToken: tokens.refresh_token!,
+        accessToken: this.encryption.encrypt(tokens.access_token!),
+        refreshToken: this.encryption.encrypt(tokens.refresh_token!),
         expiresAt: new Date(tokens.expiry_date!),
         scopes: SCOPES,
       },
@@ -311,8 +315,8 @@ export class GoogleCalendarService {
 
     const oauth2Client = this.createOAuth2Client();
     oauth2Client.setCredentials({
-      access_token: token.accessToken,
-      refresh_token: token.refreshToken,
+      access_token: this.encryption.decrypt(token.accessToken),
+      refresh_token: this.encryption.decrypt(token.refreshToken),
       expiry_date: token.expiresAt.getTime(),
     });
 
@@ -320,7 +324,10 @@ export class GoogleCalendarService {
       void this.prisma.googleOAuthToken.update({
         where: { tutorId },
         data: {
-          accessToken: newTokens.access_token ?? token.accessToken,
+          // token.accessToken já está cifrado; só re-cifra quando há novo valor.
+          accessToken: newTokens.access_token
+            ? this.encryption.encrypt(newTokens.access_token)
+            : token.accessToken,
           expiresAt: newTokens.expiry_date
             ? new Date(newTokens.expiry_date)
             : token.expiresAt,


### PR DESCRIPTION
## Contexto
Dia 4 da auditoria (Segurança e contratos), achado #2 (🔴) e #7 (consistência de docs).

## #2 — Tokens OAuth do Google em texto puro
`google_oauth_token.accessToken`/`refreshToken` eram gravados em texto puro no Postgres, contrariando o **ADR-002 #4** (AES-256-GCM) e o RNF de criptografia em repouso do DAS.

- Novo `EncryptionService` (AES-256-GCM, payload `iv:authTag:ciphertext` em base64) exposto por um `CryptoModule` global.
- `GoogleCalendarService` passa a **cifrar na escrita** (`handleCallback`) e **decifrar na leitura** (`getCalendarClient`), inclusive no refresh automático (`oauth2Client.on('tokens')`).
- Chave `ENCRYPTION_KEY` (32 bytes hex) via `encryption.config.ts`; lida sob demanda (não obriga presença no boot quando o Calendar não está configurado).
- `.env.example` ganha `ENCRYPTION_KEY` com valor de dev + instrução `openssl rand -hex 32`.
- 6 testes unitários (round-trip, IV aleatório, detecção de adulteração, payload malformado, chave ausente/inválida).

> Sem migração de dados: não há tokens em produção; os existentes são re-obtidos via OAuth.

## #7 — README (consistência)
Tabela de stack ainda dizia **Auth0** (abandonado em M0-#7) e **NestJS 10** (real: 11). Corrigido para `JWT próprio (HS256 + bcrypt)` e `NestJS 11`, alinhando com web/mobile (corrigidos no Dia 3).

## Validação
- `tsc --noEmit` ✅  `eslint` ✅
- `jest`: **157/157** (24 suites) — 151 originais + 6 novos.

Sem mudança de dependências → `npm ci` da CI permanece íntegro.