### PR TITLE
feat: PC-097 - Swagger/OpenAPI em /docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,18 @@ npm run start:dev
 | `npm run test:cov`  | Relatório de cobertura                 |
 | `npm run lint`      | Executa ESLint                         |
 
+## Documentação da API (Swagger / OpenAPI)
+
+Com a API rodando, a documentação interativa fica disponível em:
+
+```
+http://localhost:3000/docs
+```
+
+A interface lista os endpoints (tutor, pet, prontuário, carteira/QR, clínicas,
+agendamento/Calendar, notificações e veterinário) e permite autenticar com o
+JWT pelo botão **Authorize** (esquema Bearer).
+
 ## Infraestrutura Local (Docker)
 
 O `docker-compose.yml` sobe os seguintes serviços:

--- a/nest-cli.json
+++ b/nest-cli.json
@@ -3,6 +3,7 @@
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
   "compilerOptions": {
-    "deleteOutDir": true
+    "deleteOutDir": true,
+    "plugins": ["@nestjs/swagger"]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.0.1",
         "@nestjs/schedule": "^6.1.3",
+        "@nestjs/swagger": "^11.4.4",
         "@nestjs/throttler": "^6.5.0",
         "@petcardorg/shared": "^0.9.0",
         "@prisma/client": "^6.19.3",
@@ -3251,6 +3252,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.16.0.tgz",
+      "integrity": "sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==",
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -3580,6 +3587,26 @@
         "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
       }
     },
+    "node_modules/@nestjs/mapped-types": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.1.tgz",
+      "integrity": "sha512-SCCoMEJ6jdeI5h/N+KCVF1+pmg/hmEkNA5nHTS8Gvww7T/LCl4o1gFLinw2iQ60w7slFkszHcGLKGdazVI4F8A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0 || ^0.15.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nestjs/microservices": {
       "version": "11.1.19",
       "resolved": "https://registry.npmjs.org/@nestjs/microservices/-/microservices-11.1.19.tgz",
@@ -3701,6 +3728,39 @@
       },
       "peerDependenciesMeta": {
         "prettier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nestjs/swagger": {
+      "version": "11.4.4",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.4.4.tgz",
+      "integrity": "sha512-VaIo1ruV2G7b+f2zPzkBSUNy9a/WQ9sg8TLKhWlrTfg4O6U10M/PA7Xi6XMXadOVhwOqoesijba8jH3i/3adrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/tsdoc": "0.16.0",
+        "@nestjs/mapped-types": "2.1.1",
+        "js-yaml": "4.1.1",
+        "lodash": "4.18.1",
+        "path-to-regexp": "8.4.2",
+        "swagger-ui-dist": "5.32.6"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^8.0.0 || ^9.0.0",
+        "@nestjs/common": "^11.0.1",
+        "@nestjs/core": "^11.0.1",
+        "class-transformer": "*",
+        "class-validator": "*",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
           "optional": true
         }
       }
@@ -3996,6 +4056,13 @@
       "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause",
       "optional": true
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.49",
@@ -6297,7 +6364,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-timsort": {
@@ -10508,7 +10574,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -13335,6 +13400,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.32.6",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.6.tgz",
+      "integrity": "sha512-75ttZNaYCLoFPnozPZcTUU6mS3wKT8l7WLjU5zJSHFeJa23i5vtnze6IiCl4jDMPeQTXVXIgovq4M11NNfQvSA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
       }
     },
     "node_modules/symbol-observable": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/schedule": "^6.1.3",
+    "@nestjs/swagger": "^11.4.4",
     "@nestjs/throttler": "^6.5.0",
     "@petcardorg/shared": "^0.9.0",
     "@prisma/client": "^6.19.3",

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { ValidationPipe } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { NestFactory } from '@nestjs/core';
 import { MicroserviceOptions, Transport } from '@nestjs/microservices';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { AppModule } from './app.module';
 import {
   CALENDAR_SYNC_DLQ_ROUTING_KEY,
@@ -27,6 +28,20 @@ async function bootstrap() {
       transform: true,
     }),
   );
+
+  const swaggerConfig = new DocumentBuilder()
+    .setTitle('PetCard API')
+    .setDescription(
+      'API REST do PetCard — carteira digital de saúde para pets. ' +
+        'Autenticação via JWT (Bearer). Endpoints de tutor, pet, prontuário ' +
+        '(vacina/vermífugo/medicação), carteira digital/QR, clínicas, ' +
+        'agendamento/Calendar, notificações e interface do veterinário.',
+    )
+    .setVersion('1.0')
+    .addBearerAuth()
+    .build();
+  const document = SwaggerModule.createDocument(app, swaggerConfig);
+  SwaggerModule.setup('docs', app, document);
 
   app.connectMicroservice<MicroserviceOptions>({
     transport: Transport.RMQ,


### PR DESCRIPTION
## Contexto
PC-097 (achado #11 da auditoria): a API não tinha documentação OpenAPI. Baixo esforço, alto impacto para a banca e para o consumo dos endpoints.

## O que muda
- Adiciona `@nestjs/swagger@^11.4.4`.
- `main.ts`: monta o `SwaggerModule` em **`GET /docs`** com `DocumentBuilder` (título, descrição, versão `1.0`, **Bearer auth** para o JWT).
- `nest-cli.json`: habilita o plugin `@nestjs/swagger` para introspecção automática dos DTOs/controllers locais (sem precisar espalhar `@ApiProperty`).

## Notas
- Os DTOs vindos de `@petcardorg/shared` aparecem como referências de schema; o plugin só introspecta fontes locais (node_modules é compilado), então o corpo detalhado desses schemas é mínimo — endpoints, métodos, parâmetros e auth ficam todos documentados.
- `/docs` é público (aceitável para o escopo do TCC).

## Validação
- `npm run build` (nest build, roda o plugin) ✅
- `eslint` ✅
- `jest` ✅ 157/157