### PR TITLE
test: PC-086 - cobertura de services + gate de coverage no CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,5 +22,5 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: npm run lint
-      - run: npm run test
+      - run: npm run test:cov
       - run: npm run build

--- a/package.json
+++ b/package.json
@@ -107,10 +107,10 @@
     "coverageDirectory": "../coverage",
     "coverageThreshold": {
       "global": {
-        "statements": 40,
-        "branches": 30,
-        "functions": 45,
-        "lines": 40
+        "statements": 52,
+        "branches": 44,
+        "functions": 52,
+        "lines": 54
       }
     },
     "testEnvironment": "node"

--- a/package.json
+++ b/package.json
@@ -107,10 +107,10 @@
     "coverageDirectory": "../coverage",
     "coverageThreshold": {
       "global": {
-        "statements": 52,
-        "branches": 44,
-        "functions": 52,
-        "lines": 54
+        "statements": 57,
+        "branches": 46,
+        "functions": 57,
+        "lines": 59
       }
     },
     "testEnvironment": "node"

--- a/src/app.service.spec.ts
+++ b/src/app.service.spec.ts
@@ -1,0 +1,7 @@
+import { AppService } from './app.service';
+
+describe('AppService', () => {
+  it('getHello retorna a mensagem de saúde padrão', () => {
+    expect(new AppService().getHello()).toBe('Hello World!');
+  });
+});

--- a/src/modules/appointment/__tests__/appointment.service.spec.ts
+++ b/src/modules/appointment/__tests__/appointment.service.spec.ts
@@ -1,0 +1,252 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { CalendarSyncPublisher } from '../../queue/calendar-sync.publisher';
+import { AppointmentService } from '../appointment.service';
+import { CreateAppointmentDto } from '../dto/create-appointment.dto';
+
+describe('AppointmentService', () => {
+  let service: AppointmentService;
+  let prisma: {
+    appointment: {
+      create: jest.Mock;
+      findMany: jest.Mock;
+      findUnique: jest.Mock;
+      update: jest.Mock;
+      delete: jest.Mock;
+    };
+  };
+  let publisher: { publish: jest.Mock };
+
+  const now = new Date('2026-05-01T10:00:00Z');
+  const appointment = {
+    id: 'appt-1',
+    tutorId: 'tutor-1',
+    title: 'Consulta de rotina',
+    description: 'Check-up anual',
+    scheduledAt: new Date('2026-06-01T14:00:00Z'),
+    durationMinutes: 60,
+    location: 'Clínica VetCare',
+    petId: 'pet-1',
+    googleEventId: null,
+    syncStatus: 'PENDING_CREATE',
+    createdAt: now,
+    updatedAt: now,
+    pet: { name: 'Rex' },
+  };
+
+  beforeEach(async () => {
+    prisma = {
+      appointment: {
+        create: jest.fn(),
+        findMany: jest.fn(),
+        findUnique: jest.fn(),
+        update: jest.fn(),
+        delete: jest.fn(),
+      },
+    };
+    publisher = { publish: jest.fn().mockResolvedValue(undefined) };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AppointmentService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: CalendarSyncPublisher, useValue: publisher },
+      ],
+    }).compile();
+
+    service = module.get<AppointmentService>(AppointmentService);
+  });
+
+  describe('create', () => {
+    it('cria o agendamento do tutor e publica CREATE', async () => {
+      prisma.appointment.create.mockResolvedValue(appointment);
+
+      const dto = {
+        title: 'Consulta de rotina',
+        description: 'Check-up anual',
+        scheduled_at: '2026-06-01T14:00:00Z',
+        duration_minutes: 60,
+        location: 'Clínica VetCare',
+        pet_id: 'pet-1',
+      } as CreateAppointmentDto;
+
+      const result = await service.create('tutor-1', dto);
+
+      const createArg = prisma.appointment.create.mock.calls[0][0] as {
+        data: Record<string, unknown>;
+      };
+      expect(createArg.data).toMatchObject({
+        tutorId: 'tutor-1',
+        title: 'Consulta de rotina',
+        durationMinutes: 60,
+        petId: 'pet-1',
+      });
+      expect(createArg.data.scheduledAt).toBeInstanceOf(Date);
+      expect(publisher.publish).toHaveBeenCalledWith({
+        action: 'CREATE',
+        appointment_id: 'appt-1',
+        tutor_id: 'tutor-1',
+      });
+      expect(result).toMatchObject({
+        id: 'appt-1',
+        scheduled_at: '2026-06-01T14:00:00.000Z',
+        pet_name: 'Rex',
+        sync_status: 'PENDING_CREATE',
+      });
+    });
+
+    it('usa 60 minutos como duração padrão', async () => {
+      prisma.appointment.create.mockResolvedValue(appointment);
+
+      await service.create('tutor-1', {
+        title: 'X',
+        scheduled_at: '2026-06-01T14:00:00Z',
+      });
+
+      const createArg = prisma.appointment.create.mock.calls[0][0] as {
+        data: { durationMinutes: number };
+      };
+      expect(createArg.data.durationMinutes).toBe(60);
+    });
+  });
+
+  describe('findAllForTutor / findUpcoming', () => {
+    it('lista todos os agendamentos do tutor', async () => {
+      prisma.appointment.findMany.mockResolvedValue([appointment]);
+
+      const result = await service.findAllForTutor('tutor-1');
+
+      expect(prisma.appointment.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { tutorId: 'tutor-1' } }),
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('appt-1');
+    });
+
+    it('filtra apenas agendamentos futuros em findUpcoming', async () => {
+      prisma.appointment.findMany.mockResolvedValue([]);
+
+      await service.findUpcoming('tutor-1');
+
+      const arg = prisma.appointment.findMany.mock.calls[0][0] as {
+        where: { tutorId: string; scheduledAt: { gte: Date } };
+      };
+      expect(arg.where.tutorId).toBe('tutor-1');
+      expect(arg.where.scheduledAt.gte).toBeInstanceOf(Date);
+    });
+  });
+
+  describe('findOne', () => {
+    it('retorna o agendamento do dono', async () => {
+      prisma.appointment.findUnique.mockResolvedValue(appointment);
+
+      const result = await service.findOne('appt-1', 'tutor-1');
+
+      expect(result.id).toBe('appt-1');
+    });
+
+    it('lança NotFoundException quando não existe', async () => {
+      prisma.appointment.findUnique.mockResolvedValue(null);
+
+      await expect(service.findOne('missing', 'tutor-1')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('lança ForbiddenException para não-dono', async () => {
+      prisma.appointment.findUnique.mockResolvedValue({
+        ...appointment,
+        tutorId: 'other',
+      });
+
+      await expect(service.findOne('appt-1', 'tutor-1')).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+  });
+
+  describe('update', () => {
+    it('atualiza, marca PENDING_UPDATE e publica UPDATE', async () => {
+      prisma.appointment.findUnique.mockResolvedValue(appointment);
+      prisma.appointment.update.mockResolvedValue({
+        ...appointment,
+        title: 'Reagendada',
+        syncStatus: 'PENDING_UPDATE',
+      });
+
+      const result = await service.update('appt-1', 'tutor-1', {
+        title: 'Reagendada',
+      });
+
+      const updateArg = prisma.appointment.update.mock.calls[0][0] as {
+        data: { syncStatus: string };
+      };
+      expect(updateArg.data.syncStatus).toBe('PENDING_UPDATE');
+      expect(publisher.publish).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'UPDATE', appointment_id: 'appt-1' }),
+      );
+      expect(result.title).toBe('Reagendada');
+    });
+
+    it('recusa update de não-dono sem chamar o banco', async () => {
+      prisma.appointment.findUnique.mockResolvedValue({
+        ...appointment,
+        tutorId: 'other',
+      });
+
+      await expect(service.update('appt-1', 'tutor-1', {})).rejects.toThrow(
+        ForbiddenException,
+      );
+      expect(prisma.appointment.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('remove', () => {
+    it('publica DELETE com o google_event_id quando há evento sincronizado', async () => {
+      prisma.appointment.findUnique.mockResolvedValue({
+        ...appointment,
+        googleEventId: 'gcal-123',
+      });
+      prisma.appointment.delete.mockResolvedValue(appointment);
+
+      await service.remove('appt-1', 'tutor-1');
+
+      expect(publisher.publish).toHaveBeenCalledWith({
+        action: 'DELETE',
+        appointment_id: 'appt-1',
+        tutor_id: 'tutor-1',
+        google_event_id: 'gcal-123',
+      });
+      expect(prisma.appointment.delete).toHaveBeenCalledWith({
+        where: { id: 'appt-1' },
+      });
+    });
+
+    it('não publica DELETE quando não há evento no Google', async () => {
+      prisma.appointment.findUnique.mockResolvedValue({
+        ...appointment,
+        googleEventId: null,
+      });
+      prisma.appointment.delete.mockResolvedValue(appointment);
+
+      await service.remove('appt-1', 'tutor-1');
+
+      expect(publisher.publish).not.toHaveBeenCalled();
+      expect(prisma.appointment.delete).toHaveBeenCalled();
+    });
+
+    it('lança ForbiddenException e não deleta de não-dono', async () => {
+      prisma.appointment.findUnique.mockResolvedValue({
+        ...appointment,
+        tutorId: 'other',
+      });
+
+      await expect(service.remove('appt-1', 'tutor-1')).rejects.toThrow(
+        ForbiddenException,
+      );
+      expect(prisma.appointment.delete).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/modules/clinica/__tests__/geocoding.service.spec.ts
+++ b/src/modules/clinica/__tests__/geocoding.service.spec.ts
@@ -1,0 +1,81 @@
+/* eslint-disable @typescript-eslint/require-await, @typescript-eslint/no-unsafe-member-access */
+import { HttpException, HttpStatus } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { GeocodingService } from '../geocoding.service';
+
+const makeConfig = (key: string | undefined): ConfigService =>
+  ({ get: jest.fn().mockReturnValue(key) }) as unknown as ConfigService;
+
+async function expectHttpStatus(
+  promise: Promise<unknown>,
+  status: number,
+): Promise<void> {
+  expect.assertions(2);
+  try {
+    await promise;
+  } catch (error) {
+    expect(error).toBeInstanceOf(HttpException);
+    expect((error as HttpException).getStatus()).toBe(status);
+  }
+}
+
+describe('GeocodingService', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.clearAllMocks();
+  });
+
+  it('lança erro no boot quando GOOGLE_MAPS_API_KEY está ausente', () => {
+    expect(() => new GeocodingService(makeConfig(undefined))).toThrow(
+      'GOOGLE_MAPS_API_KEY',
+    );
+  });
+
+  it('retorna lat/lng/endereço e envia address+key na URL quando status OK', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      json: async () => ({
+        status: 'OK',
+        results: [
+          {
+            geometry: { location: { lat: -3.731, lng: -38.526 } },
+            formatted_address: 'Fortaleza - CE, Brasil',
+          },
+        ],
+      }),
+    });
+    global.fetch = fetchMock;
+
+    const service = new GeocodingService(makeConfig('key-123'));
+    const result = await service.geocode('Av. Beira Mar');
+
+    expect(result).toEqual({
+      lat: -3.731,
+      lng: -38.526,
+      formattedAddress: 'Fortaleza - CE, Brasil',
+    });
+
+    const calledUrl = fetchMock.mock.calls[0][0] as string;
+    expect(calledUrl).toContain('address=Av.+Beira+Mar');
+    expect(calledUrl).toContain('key=key-123');
+  });
+
+  it('lança 404 quando o Google retorna ZERO_RESULTS', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      json: async () => ({ status: 'ZERO_RESULTS', results: [] }),
+    });
+
+    const service = new GeocodingService(makeConfig('key'));
+    await expectHttpStatus(service.geocode('endereço inexistente'), 404);
+  });
+
+  it('lança 502 (BAD_GATEWAY) para qualquer outro status diferente de OK', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      json: async () => ({ status: 'REQUEST_DENIED', results: [] }),
+    });
+
+    const service = new GeocodingService(makeConfig('key'));
+    await expectHttpStatus(service.geocode('x'), HttpStatus.BAD_GATEWAY);
+  });
+});

--- a/src/modules/clinica/__tests__/places.service.spec.ts
+++ b/src/modules/clinica/__tests__/places.service.spec.ts
@@ -1,0 +1,180 @@
+/* eslint-disable @typescript-eslint/require-await, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment */
+import { HttpException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { PlacesService } from '../places.service';
+
+const makeConfig = (key: string | undefined): ConfigService =>
+  ({ get: jest.fn().mockReturnValue(key) }) as unknown as ConfigService;
+
+const fullPlace = {
+  id: 'place-1',
+  displayName: { text: 'Clínica VetCare' },
+  formattedAddress: 'Rua A, 100 - Fortaleza',
+  nationalPhoneNumber: '(85) 3333-3333',
+  internationalPhoneNumber: '+55 85 3333-3333',
+  rating: 4.7,
+  userRatingCount: 210,
+  currentOpeningHours: {
+    openNow: true,
+    weekdayDescriptions: ['Segunda: 08:00–18:00'],
+  },
+  location: { latitude: -3.74, longitude: -38.53 },
+  photos: [{ name: 'places/place-1/photos/abc', widthPx: 800, heightPx: 600 }],
+  types: ['veterinary_care'],
+  businessStatus: 'OPERATIONAL',
+  websiteUri: 'https://vetcare.example',
+  googleMapsUri: 'https://maps.google/?cid=1',
+};
+
+const okResponse = (body: unknown) =>
+  ({ ok: true, json: async () => body }) as unknown as Response;
+
+describe('PlacesService', () => {
+  const originalFetch = global.fetch;
+  const userLat = -3.731;
+  const userLng = -38.526;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.clearAllMocks();
+  });
+
+  it('lança erro no boot quando GOOGLE_MAPS_API_KEY está ausente', () => {
+    expect(() => new PlacesService(makeConfig(undefined))).toThrow(
+      'GOOGLE_MAPS_API_KEY',
+    );
+  });
+
+  it('mapeia um place para o DTO com distância calculada e foto', async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValue(okResponse({ places: [fullPlace] }));
+    global.fetch = fetchMock;
+
+    const service = new PlacesService(makeConfig('key-xyz'));
+    const result = await service.searchNearbyVetClinics({
+      lat: userLat,
+      lng: userLng,
+      radiusMeters: 5000,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      placeId: 'place-1',
+      name: 'Clínica VetCare',
+      address: 'Rua A, 100 - Fortaleza',
+      phone: '(85) 3333-3333',
+      rating: 4.7,
+      openNow: true,
+      coordinates: { lat: -3.74, lng: -38.53 },
+      photoUrl: expect.stringContaining(
+        'places/place-1/photos/abc/media?maxWidthPx=400&key=key-xyz',
+      ),
+      websiteUrl: 'https://vetcare.example',
+    });
+    expect(typeof result[0].distanceMeters).toBe('number');
+    expect(result[0].distanceMeters).toBeGreaterThan(0);
+  });
+
+  it('usa fallbacks quando campos opcionais estão ausentes', async () => {
+    const minimal = {
+      id: 'place-2',
+      location: { latitude: -3.75, longitude: -38.54 },
+    };
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue(okResponse({ places: [minimal] }));
+
+    const service = new PlacesService(makeConfig('key'));
+    const [dto] = await service.searchNearbyVetClinics({
+      lat: userLat,
+      lng: userLng,
+      radiusMeters: 1000,
+    });
+
+    expect(dto.name).toBe('Sem nome');
+    expect(dto.address).toBe('');
+    expect(dto.phone).toBeUndefined();
+    expect(dto.openNow).toBeUndefined();
+    expect(dto.photoUrl).toBeUndefined();
+  });
+
+  it('descarta places sem location', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      okResponse({
+        places: [fullPlace, { id: 'no-loc', displayName: { text: 'X' } }],
+      }),
+    );
+
+    const service = new PlacesService(makeConfig('key'));
+    const result = await service.searchNearbyVetClinics({
+      lat: userLat,
+      lng: userLng,
+      radiusMeters: 5000,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].placeId).toBe('place-1');
+  });
+
+  it('retorna lista vazia quando o Google não devolve places', async () => {
+    global.fetch = jest.fn().mockResolvedValue(okResponse({}));
+
+    const service = new PlacesService(makeConfig('key'));
+    const result = await service.searchNearbyVetClinics({
+      lat: userLat,
+      lng: userLng,
+      radiusMeters: 5000,
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it('inclui openNow no corpo da requisição quando solicitado', async () => {
+    const fetchMock = jest.fn().mockResolvedValue(okResponse({ places: [] }));
+    global.fetch = fetchMock;
+
+    const service = new PlacesService(makeConfig('key'));
+    await service.searchNearbyVetClinics({
+      lat: userLat,
+      lng: userLng,
+      radiusMeters: 5000,
+      openNow: true,
+    });
+
+    const requestInit = fetchMock.mock.calls[0][1] as RequestInit;
+    const body = JSON.parse(requestInit.body as string) as {
+      openNow?: boolean;
+      includedTypes: string[];
+    };
+    expect(body.openNow).toBe(true);
+    expect(body.includedTypes).toContain('veterinary_care');
+  });
+
+  it('lança 502 (BAD_GATEWAY) quando a resposta do Google não é ok', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      text: async () => 'quota exceeded',
+    });
+
+    const service = new PlacesService(makeConfig('key'));
+    expect.assertions(2);
+    try {
+      await service.searchNearbyVetClinics({
+        lat: userLat,
+        lng: userLng,
+        radiusMeters: 5000,
+      });
+    } catch (error) {
+      expect(error).toBeInstanceOf(HttpException);
+      expect((error as HttpException).getStatus()).toBe(502);
+    }
+  });
+
+  it('getPhotoUrl monta a URL de mídia com a chave e largura', () => {
+    const service = new PlacesService(makeConfig('key-photo'));
+    expect(service.getPhotoUrl('places/p/photos/x', 250)).toBe(
+      'https://places.googleapis.com/v1/places/p/photos/x/media?maxWidthPx=250&key=key-photo',
+    );
+  });
+});

--- a/src/modules/queue/__tests__/rabbitmq-topology.service.spec.ts
+++ b/src/modules/queue/__tests__/rabbitmq-topology.service.spec.ts
@@ -1,0 +1,101 @@
+/* eslint-disable @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access */
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { RabbitMqTopologyService } from '../rabbitmq-topology.service';
+import {
+  CALENDAR_SYNC_DLX,
+  NOTIFICATION_PUSH_DLX,
+  QR_CODE_DLX,
+} from '../queue.constants';
+
+const mockChannel = {
+  assertExchange: jest.fn(),
+  assertQueue: jest.fn(),
+  bindQueue: jest.fn(),
+  close: jest.fn(),
+};
+const mockConnection = {
+  createChannel: jest.fn(),
+  close: jest.fn(),
+};
+const mockConnect = jest.fn();
+
+jest.mock('amqplib', () => ({
+  connect: (url: string) => mockConnect(url),
+}));
+
+const config = {
+  get: (key: string) =>
+    (
+      ({
+        'rabbitmq.url': 'amqp://localhost:5672',
+        'rabbitmq.qrCodeDlq': 'qr-code.dlq',
+        'rabbitmq.notificationPushDlq': 'notification.push.dlq',
+        'rabbitmq.calendarSyncDlq': 'calendar.sync.dlq',
+      }) as Record<string, string>
+    )[key],
+} as unknown as ConfigService;
+
+describe('RabbitMqTopologyService', () => {
+  let service: RabbitMqTopologyService;
+
+  beforeAll(() => {
+    jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockChannel.assertExchange.mockResolvedValue(undefined);
+    mockChannel.assertQueue.mockResolvedValue(undefined);
+    mockChannel.bindQueue.mockResolvedValue(undefined);
+    mockChannel.close.mockResolvedValue(undefined);
+    mockConnection.createChannel.mockResolvedValue(mockChannel);
+    mockConnection.close.mockResolvedValue(undefined);
+    mockConnect.mockResolvedValue(mockConnection);
+    service = new RabbitMqTopologyService(config);
+  });
+
+  it('declara as 3 DLX/DLQ e fecha canal e conexão', async () => {
+    await service.onModuleInit();
+
+    expect(mockConnect).toHaveBeenCalledWith('amqp://localhost:5672');
+
+    const declaredExchanges = mockChannel.assertExchange.mock.calls.map(
+      (call) => call[0] as string,
+    );
+    expect(declaredExchanges).toEqual([
+      QR_CODE_DLX,
+      NOTIFICATION_PUSH_DLX,
+      CALENDAR_SYNC_DLX,
+    ]);
+
+    const declaredQueues = mockChannel.assertQueue.mock.calls.map(
+      (call) => call[0] as string,
+    );
+    expect(declaredQueues).toEqual([
+      'qr-code.dlq',
+      'notification.push.dlq',
+      'calendar.sync.dlq',
+    ]);
+
+    expect(mockChannel.bindQueue).toHaveBeenCalledTimes(3);
+    expect(mockChannel.close).toHaveBeenCalledTimes(1);
+    expect(mockConnection.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('declara cada exchange como direct e durável', async () => {
+    await service.onModuleInit();
+
+    for (const call of mockChannel.assertExchange.mock.calls) {
+      expect(call[1]).toBe('direct');
+      expect(call[2]).toEqual({ durable: true });
+    }
+  });
+
+  it('fecha a conexão mesmo se a topologia falhar', async () => {
+    mockChannel.assertQueue.mockRejectedValueOnce(new Error('broker down'));
+
+    await expect(service.onModuleInit()).rejects.toThrow('broker down');
+    expect(mockConnection.close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/modules/upload/__tests__/upload.service.spec.ts
+++ b/src/modules/upload/__tests__/upload.service.spec.ts
@@ -1,0 +1,172 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import {
+  BadRequestException,
+  InternalServerErrorException,
+  Logger,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { UploadService } from '../upload.service';
+
+beforeAll(() => {
+  jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
+  jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+});
+
+const mockSend = jest.fn();
+
+jest.mock('@aws-sdk/client-s3', () => ({
+  S3Client: jest.fn().mockImplementation(() => ({ send: mockSend })),
+  PutObjectCommand: jest
+    .fn()
+    .mockImplementation((input: unknown) => ({ __kind: 'Put', input })),
+  DeleteObjectCommand: jest
+    .fn()
+    .mockImplementation((input: unknown) => ({ __kind: 'Delete', input })),
+}));
+
+const FULL_AWS: Record<string, string> = {
+  'aws.region': 'us-east-1',
+  'aws.bucket': 'petcard-bucket',
+  'aws.accessKeyId': 'AKIA-test',
+  'aws.secretAccessKey': 'secret-test',
+};
+
+const makeConfig = (
+  values: Record<string, string | undefined>,
+): ConfigService =>
+  ({ get: (key: string) => values[key] }) as unknown as ConfigService;
+
+const makeFile = (
+  overrides: Partial<Express.Multer.File> = {},
+): Express.Multer.File =>
+  ({
+    originalname: 'foto do rex!.png',
+    mimetype: 'image/png',
+    size: 1024,
+    buffer: Buffer.from('binary'),
+    ...overrides,
+  }) as Express.Multer.File;
+
+describe('UploadService', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  describe('quando o S3 está configurado', () => {
+    let service: UploadService;
+    beforeEach(() => {
+      service = new UploadService(makeConfig(FULL_AWS));
+    });
+
+    it('faz upload de arquivo, sanitiza o nome e retorna a URL pública', async () => {
+      mockSend.mockResolvedValue({});
+
+      const url = await service.uploadFile(makeFile(), 'pets');
+
+      expect(url).toMatch(
+        /^https:\/\/petcard-bucket\.s3\.us-east-1\.amazonaws\.com\/pets\/[0-9a-f-]+-foto_do_rex_\.png$/,
+      );
+      expect(mockSend).toHaveBeenCalledTimes(1);
+      const command = mockSend.mock.calls[0][0] as {
+        input: { Bucket: string; ContentType: string };
+      };
+      expect(command.input.Bucket).toBe('petcard-bucket');
+      expect(command.input.ContentType).toBe('image/png');
+    });
+
+    it('rejeita arquivo ausente', async () => {
+      await expect(
+        service.uploadFile(undefined as unknown as Express.Multer.File, 'pets'),
+      ).rejects.toThrow(BadRequestException);
+      expect(mockSend).not.toHaveBeenCalled();
+    });
+
+    it('rejeita mime type não permitido', async () => {
+      await expect(
+        service.uploadFile(makeFile({ mimetype: 'application/pdf' }), 'pets'),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejeita arquivo acima de 5MB', async () => {
+      await expect(
+        service.uploadFile(makeFile({ size: 6 * 1024 * 1024 }), 'pets'),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('converte falha do S3 em InternalServerErrorException no uploadFile', async () => {
+      mockSend.mockRejectedValue(new Error('network'));
+      await expect(service.uploadFile(makeFile(), 'pets')).rejects.toThrow(
+        InternalServerErrorException,
+      );
+    });
+
+    it('faz upload de buffer e retorna a URL com a key informada', async () => {
+      mockSend.mockResolvedValue({});
+      const url = await service.uploadBuffer(
+        Buffer.from('x'),
+        'qr-codes/pet-1.png',
+        'image/png',
+      );
+      expect(url).toBe(
+        'https://petcard-bucket.s3.us-east-1.amazonaws.com/qr-codes/pet-1.png',
+      );
+    });
+
+    it('converte falha do S3 em InternalServerErrorException no uploadBuffer', async () => {
+      mockSend.mockRejectedValue(new Error('boom'));
+      await expect(
+        service.uploadBuffer(Buffer.from('x'), 'k', 'image/png'),
+      ).rejects.toThrow(InternalServerErrorException);
+    });
+
+    it('deleta arquivo extraindo a key da URL', async () => {
+      mockSend.mockResolvedValue({});
+      await service.deleteFile(
+        'https://petcard-bucket.s3.us-east-1.amazonaws.com/pets/abc-foto.png',
+      );
+      const command = mockSend.mock.calls[0][0] as {
+        input: { Key: string };
+      };
+      expect(command.input.Key).toBe('pets/abc-foto.png');
+    });
+
+    it('rejeita URL inválida no deleteFile', async () => {
+      await expect(service.deleteFile('not-a-url')).rejects.toThrow(
+        BadRequestException,
+      );
+      expect(mockSend).not.toHaveBeenCalled();
+    });
+
+    it('converte falha do S3 em InternalServerErrorException no deleteFile', async () => {
+      mockSend.mockRejectedValue(new Error('denied'));
+      await expect(
+        service.deleteFile(
+          'https://petcard-bucket.s3.us-east-1.amazonaws.com/pets/x.png',
+        ),
+      ).rejects.toThrow(InternalServerErrorException);
+    });
+  });
+
+  describe('quando o S3 NÃO está configurado', () => {
+    let service: UploadService;
+    beforeEach(() => {
+      service = new UploadService(makeConfig({ 'aws.region': 'us-east-1' }));
+    });
+
+    it('uploadFile lança InternalServerErrorException', async () => {
+      await expect(service.uploadFile(makeFile(), 'pets')).rejects.toThrow(
+        InternalServerErrorException,
+      );
+    });
+
+    it('uploadBuffer lança InternalServerErrorException', async () => {
+      await expect(
+        service.uploadBuffer(Buffer.from('x'), 'k', 'image/png'),
+      ).rejects.toThrow(InternalServerErrorException);
+    });
+
+    it('deleteFile lança InternalServerErrorException', async () => {
+      await expect(
+        service.deleteFile('https://x.s3.amazonaws.com/k'),
+      ).rejects.toThrow(InternalServerErrorException);
+    });
+  });
+});


### PR DESCRIPTION
Incrementos da **PC-086** (testes unitários de services, rumo a ≥80%).

## Services cobertos (eram 0%/baixa cobertura → 100% stmts)
- **GeocodingService** (Google Geocoding) — OK, `ZERO_RESULTS`→404, status≠OK→502, URL com address+key.
- **PlacesService** (Google Places) — mapeamento DTO + distância, fallbacks, filtro sem `location`, lista vazia, `openNow` no corpo, 502, `getPhotoUrl`.
- **UploadService** (S3) — upload arquivo/buffer, sanitização de nome, validação (mime/tamanho/ausente), deleção + extração de key, S3 não configurado, falha do S3.
- **AppointmentService** — create/update/remove com ownership (Forbidden/NotFound), publish CREATE/UPDATE/DELETE, DELETE só com `googleEventId`, duração padrão 60min, `findUpcoming` filtra futuros.
- **RabbitMqTopologyService** — declara as 3 DLX/DLQ (direct+durable) + bindings, fecha canal e conexão, e **fecha a conexão mesmo em falha** (finally).
- **AppService** — `getHello`.

## CI vira gate de verdade
`ci.yml` passa a rodar **`npm run test:cov`** (antes `npm run test`), então o `coverageThreshold` finalmente **barra PRs**.

## Coverage floor (catraca)
`coverageThreshold` global: **40/30/45/40 → 57/46/57/59**. Nunca abaixar.

## Números
- Cobertura global: **~48% → ~59%**
- **198 testes / 30 suites** verdes; lint limpo; build OK.

Mira `develop`. Próximos da PC-086: `google-calendar.service` (OAuth/encryption), depois controllers ficam para PC-087. **e2e quebrado fica para PC-088** (decisão do Ricardo).