### PR TITLE
test: PC-087 - integração dos controllers (supertest) + cobertura >=80%

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,10 +107,10 @@
     "coverageDirectory": "../coverage",
     "coverageThreshold": {
       "global": {
-        "statements": 62,
-        "branches": 51,
-        "functions": 62,
-        "lines": 64
+        "statements": 70,
+        "branches": 62,
+        "functions": 73,
+        "lines": 72
       }
     },
     "testEnvironment": "node"

--- a/package.json
+++ b/package.json
@@ -107,10 +107,10 @@
     "coverageDirectory": "../coverage",
     "coverageThreshold": {
       "global": {
-        "statements": 70,
-        "branches": 62,
-        "functions": 73,
-        "lines": 72
+        "statements": 81,
+        "branches": 74,
+        "functions": 87,
+        "lines": 83
       }
     },
     "testEnvironment": "node"

--- a/src/modules/appointment/__tests__/appointment.controller.spec.ts
+++ b/src/modules/appointment/__tests__/appointment.controller.spec.ts
@@ -1,0 +1,181 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment */
+import request from 'supertest';
+import {
+  createControllerTestApp,
+  ControllerHarness,
+  TUTOR,
+  VET,
+} from '../../../../test/utils/controller-harness';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { CalendarSyncPublisher } from '../../queue/calendar-sync.publisher';
+import { AppointmentController } from '../appointment.controller';
+import { AppointmentService } from '../appointment.service';
+
+describe('AppointmentController (integração)', () => {
+  let harness: ControllerHarness;
+  let prisma: {
+    appointment: {
+      create: jest.Mock;
+      findMany: jest.Mock;
+      findUnique: jest.Mock;
+      update: jest.Mock;
+      delete: jest.Mock;
+    };
+  };
+  let publisher: { publish: jest.Mock };
+
+  const appointment = {
+    id: 'appt-1',
+    tutorId: 'tutor-1',
+    title: 'Consulta de rotina',
+    description: null,
+    scheduledAt: new Date('2026-06-01T14:00:00Z'),
+    durationMinutes: 60,
+    location: null,
+    petId: null,
+    googleEventId: null,
+    syncStatus: 'PENDING_CREATE',
+    createdAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-01-01'),
+    pet: null,
+  };
+
+  beforeAll(async () => {
+    prisma = {
+      appointment: {
+        create: jest.fn(),
+        findMany: jest.fn(),
+        findUnique: jest.fn(),
+        update: jest.fn(),
+        delete: jest.fn(),
+      },
+    };
+    publisher = { publish: jest.fn().mockResolvedValue(undefined) };
+
+    harness = await createControllerTestApp({
+      controllers: [AppointmentController],
+      providers: [
+        AppointmentService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: CalendarSyncPublisher, useValue: publisher },
+      ],
+    });
+  });
+
+  afterAll(async () => {
+    await harness.app.close();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    harness.setUser(TUTOR);
+  });
+
+  describe('POST /appointments', () => {
+    it('cria o agendamento e publica CREATE (201)', async () => {
+      prisma.appointment.create.mockResolvedValue(appointment);
+
+      const res = await request(harness.app.getHttpServer())
+        .post('/appointments')
+        .send({
+          title: 'Consulta de rotina',
+          scheduled_at: '2026-06-01T14:00:00Z',
+        })
+        .expect(201);
+
+      expect(res.body.id).toBe('appt-1');
+      expect(publisher.publish).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'CREATE', appointment_id: 'appt-1' }),
+      );
+    });
+
+    it('rejeita título curto / data ausente (400)', async () => {
+      await request(harness.app.getHttpServer())
+        .post('/appointments')
+        .send({ title: 'x' })
+        .expect(400);
+
+      expect(prisma.appointment.create).not.toHaveBeenCalled();
+    });
+
+    it('proíbe VET de criar agendamento (403)', async () => {
+      harness.setUser(VET);
+
+      await request(harness.app.getHttpServer())
+        .post('/appointments')
+        .send({ title: 'Consulta', scheduled_at: '2026-06-01T14:00:00Z' })
+        .expect(403);
+    });
+  });
+
+  describe('GET /appointments', () => {
+    it('lista todos os agendamentos do tutor (200)', async () => {
+      prisma.appointment.findMany.mockResolvedValue([appointment]);
+
+      const res = await request(harness.app.getHttpServer())
+        .get('/appointments')
+        .expect(200);
+
+      expect(res.body).toHaveLength(1);
+    });
+
+    it('filtra os futuros com upcoming=true (200)', async () => {
+      prisma.appointment.findMany.mockResolvedValue([]);
+
+      await request(harness.app.getHttpServer())
+        .get('/appointments?upcoming=true')
+        .expect(200);
+
+      const arg = prisma.appointment.findMany.mock.calls[0][0];
+      expect(arg.where.scheduledAt.gte).toBeInstanceOf(Date);
+    });
+  });
+
+  describe('GET /appointments/:id', () => {
+    it('retorna o agendamento do dono (200)', async () => {
+      prisma.appointment.findUnique.mockResolvedValue(appointment);
+
+      const res = await request(harness.app.getHttpServer())
+        .get('/appointments/appt-1')
+        .expect(200);
+
+      expect(res.body.id).toBe('appt-1');
+    });
+
+    it('retorna 404 quando não existe', async () => {
+      prisma.appointment.findUnique.mockResolvedValue(null);
+
+      await request(harness.app.getHttpServer())
+        .get('/appointments/missing')
+        .expect(404);
+    });
+  });
+
+  describe('PATCH /appointments/:id', () => {
+    it('atualiza e publica UPDATE (200)', async () => {
+      prisma.appointment.findUnique.mockResolvedValue(appointment);
+      prisma.appointment.update.mockResolvedValue({
+        ...appointment,
+        title: 'Reagendada',
+      });
+
+      const res = await request(harness.app.getHttpServer())
+        .patch('/appointments/appt-1')
+        .send({ title: 'Reagendada' })
+        .expect(200);
+
+      expect(res.body.title).toBe('Reagendada');
+    });
+  });
+
+  describe('DELETE /appointments/:id', () => {
+    it('remove o agendamento do dono (204)', async () => {
+      prisma.appointment.findUnique.mockResolvedValue(appointment);
+      prisma.appointment.delete.mockResolvedValue(appointment);
+
+      await request(harness.app.getHttpServer())
+        .delete('/appointments/appt-1')
+        .expect(204);
+    });
+  });
+});

--- a/src/modules/auth/__tests__/auth.controller.spec.ts
+++ b/src/modules/auth/__tests__/auth.controller.spec.ts
@@ -1,0 +1,139 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import request from 'supertest';
+import {
+  createControllerTestApp,
+  ControllerHarness,
+  TUTOR,
+  VET,
+} from '../../../../test/utils/controller-harness';
+import { AuthController } from '../auth.controller';
+import { AuthService } from '../auth.service';
+
+describe('AuthController (integração)', () => {
+  let harness: ControllerHarness;
+  let auth: {
+    register: jest.Mock;
+    login: jest.Mock;
+    loginVeterinario: jest.Mock;
+    getVeterinarioProfile: jest.Mock;
+  };
+
+  beforeAll(async () => {
+    auth = {
+      register: jest.fn(),
+      login: jest.fn(),
+      loginVeterinario: jest.fn(),
+      getVeterinarioProfile: jest.fn(),
+    };
+
+    harness = await createControllerTestApp({
+      controllers: [AuthController],
+      providers: [{ provide: AuthService, useValue: auth }],
+    });
+  });
+
+  afterAll(async () => {
+    await harness.app.close();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    harness.setUser(TUTOR);
+  });
+
+  describe('POST /auth/register', () => {
+    it('registra um tutor (201)', async () => {
+      auth.register.mockResolvedValue({ access_token: 'jwt' });
+
+      const res = await request(harness.app.getHttpServer())
+        .post('/auth/register')
+        .send({
+          name: 'Alice',
+          email: 'alice@petcard.com',
+          password: 'senha123',
+        })
+        .expect(201);
+
+      expect(res.body.access_token).toBe('jwt');
+    });
+
+    it('rejeita senha curta (400)', async () => {
+      await request(harness.app.getHttpServer())
+        .post('/auth/register')
+        .send({ name: 'Alice', email: 'alice@petcard.com', password: '123' })
+        .expect(400);
+
+      expect(auth.register).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('POST /auth/login', () => {
+    it('autentica com credenciais válidas (201)', async () => {
+      auth.login.mockResolvedValue({ access_token: 'jwt' });
+
+      const res = await request(harness.app.getHttpServer())
+        .post('/auth/login')
+        .send({ email: 'alice@petcard.com', password: 'senha123' })
+        .expect(201);
+
+      expect(res.body.access_token).toBe('jwt');
+    });
+
+    it('rejeita email inválido (400)', async () => {
+      await request(harness.app.getHttpServer())
+        .post('/auth/login')
+        .send({ email: 'nao-email', password: 'x' })
+        .expect(400);
+    });
+  });
+
+  describe('GET /auth/profile', () => {
+    it('retorna o usuário autenticado (200)', async () => {
+      const res = await request(harness.app.getHttpServer())
+        .get('/auth/profile')
+        .expect(200);
+
+      expect(res.body.sub).toBe('tutor-1');
+    });
+
+    it('exige autenticação (401)', async () => {
+      harness.setUser(null);
+
+      await request(harness.app.getHttpServer())
+        .get('/auth/profile')
+        .expect(401);
+    });
+  });
+
+  describe('Veterinário', () => {
+    it('POST /auth/veterinario/login autentica (201)', async () => {
+      auth.loginVeterinario.mockResolvedValue({ access_token: 'jwt-vet' });
+
+      const res = await request(harness.app.getHttpServer())
+        .post('/auth/veterinario/login')
+        .send({ email: 'vet@petcard.com', password: 'senha123' })
+        .expect(201);
+
+      expect(res.body.access_token).toBe('jwt-vet');
+    });
+
+    it('GET /auth/veterinario/profile retorna o perfil do VET (200)', async () => {
+      harness.setUser(VET);
+      auth.getVeterinarioProfile.mockResolvedValue({ id: 'vet-1' });
+
+      const res = await request(harness.app.getHttpServer())
+        .get('/auth/veterinario/profile')
+        .expect(200);
+
+      expect(res.body.id).toBe('vet-1');
+    });
+
+    it('GET /auth/veterinario/profile proíbe TUTOR (403)', async () => {
+      harness.setUser(TUTOR);
+
+      await request(harness.app.getHttpServer())
+        .get('/auth/veterinario/profile')
+        .expect(403);
+    });
+  });
+});

--- a/src/modules/calendar/__tests__/calendar.controller.spec.ts
+++ b/src/modules/calendar/__tests__/calendar.controller.spec.ts
@@ -1,0 +1,155 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import { ConfigService } from '@nestjs/config';
+import request from 'supertest';
+import {
+  createControllerTestApp,
+  ControllerHarness,
+  TUTOR,
+  VET,
+} from '../../../../test/utils/controller-harness';
+import { CalendarController } from '../calendar.controller';
+import { GoogleCalendarService } from '../google-calendar.service';
+
+describe('CalendarController (integração)', () => {
+  let harness: ControllerHarness;
+  let calendar: {
+    getAuthUrl: jest.Mock;
+    handleCallback: jest.Mock;
+    isConnected: jest.Mock;
+    disconnect: jest.Mock;
+    syncAllPending: jest.Mock;
+  };
+  let nodeEnv: string;
+
+  beforeAll(async () => {
+    calendar = {
+      getAuthUrl: jest.fn(),
+      handleCallback: jest.fn().mockResolvedValue(undefined),
+      isConnected: jest.fn(),
+      disconnect: jest.fn().mockResolvedValue(undefined),
+      syncAllPending: jest.fn(),
+    };
+
+    harness = await createControllerTestApp({
+      controllers: [CalendarController],
+      providers: [
+        { provide: GoogleCalendarService, useValue: calendar },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: (key: string) => (key === 'NODE_ENV' ? nodeEnv : undefined),
+          },
+        },
+      ],
+    });
+  });
+
+  afterAll(async () => {
+    await harness.app.close();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    harness.setUser(TUTOR);
+    nodeEnv = 'test';
+  });
+
+  describe('GET /calendar/connect', () => {
+    it('retorna a auth_url quando a integração está configurada (200)', async () => {
+      calendar.getAuthUrl.mockReturnValue('https://accounts.google.com/auth');
+
+      const res = await request(harness.app.getHttpServer())
+        .get('/calendar/connect')
+        .expect(200);
+
+      expect(res.body.auth_url).toBe('https://accounts.google.com/auth');
+    });
+
+    it('retorna connected=false quando não configurada (200)', async () => {
+      calendar.getAuthUrl.mockReturnValue(null);
+
+      const res = await request(harness.app.getHttpServer())
+        .get('/calendar/connect')
+        .expect(200);
+
+      expect(res.body.connected).toBe(false);
+    });
+
+    it('proíbe VET (403)', async () => {
+      harness.setUser(VET);
+
+      await request(harness.app.getHttpServer())
+        .get('/calendar/connect')
+        .expect(403);
+    });
+  });
+
+  describe('GET /calendar/callback', () => {
+    it('processa o code e responde HTML (rota pública)', async () => {
+      harness.setUser(null); // callback não tem @Auth
+
+      const res = await request(harness.app.getHttpServer())
+        .get('/calendar/callback?code=abc&state=tutor-1')
+        .expect(200);
+
+      expect(res.text).toContain('conectado com sucesso');
+      expect(calendar.handleCallback).toHaveBeenCalledWith('abc', 'tutor-1');
+    });
+  });
+
+  describe('GET /calendar/dev-connect', () => {
+    it('retorna 404 fora de development', async () => {
+      harness.setUser(null);
+      nodeEnv = 'production';
+
+      await request(harness.app.getHttpServer())
+        .get('/calendar/dev-connect')
+        .expect(404);
+    });
+
+    it('serve a página em development (200)', async () => {
+      harness.setUser(null);
+      nodeEnv = 'development';
+
+      const res = await request(harness.app.getHttpServer())
+        .get('/calendar/dev-connect')
+        .expect(200);
+
+      expect(res.text).toContain('Dev Connect');
+    });
+  });
+
+  describe('GET /calendar/status', () => {
+    it('retorna o estado de conexão (200)', async () => {
+      calendar.isConnected.mockResolvedValue(true);
+
+      const res = await request(harness.app.getHttpServer())
+        .get('/calendar/status')
+        .expect(200);
+
+      expect(res.body.connected).toBe(true);
+    });
+  });
+
+  describe('DELETE /calendar/disconnect', () => {
+    it('desconecta o tutor (204)', async () => {
+      await request(harness.app.getHttpServer())
+        .delete('/calendar/disconnect')
+        .expect(204);
+
+      expect(calendar.disconnect).toHaveBeenCalledWith('tutor-1');
+    });
+  });
+
+  describe('POST /calendar/sync', () => {
+    it('sincroniza pendências e retorna a contagem (201)', async () => {
+      calendar.syncAllPending.mockResolvedValue(3);
+
+      const res = await request(harness.app.getHttpServer())
+        .post('/calendar/sync')
+        .expect(201);
+
+      expect(res.body.synced).toBe(3);
+    });
+  });
+});

--- a/src/modules/clinica/__tests__/clinica.controller.spec.ts
+++ b/src/modules/clinica/__tests__/clinica.controller.spec.ts
@@ -1,0 +1,88 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment */
+import request from 'supertest';
+import {
+  createControllerTestApp,
+  ControllerHarness,
+  VET,
+} from '../../../../test/utils/controller-harness';
+import { ClinicaController } from '../clinica.controller';
+import { GeocodingService } from '../geocoding.service';
+import { PlacesService } from '../places.service';
+
+describe('ClinicaController (integração)', () => {
+  let harness: ControllerHarness;
+  let places: { searchNearbyVetClinics: jest.Mock };
+  let geocoding: { geocode: jest.Mock };
+
+  beforeAll(async () => {
+    places = { searchNearbyVetClinics: jest.fn() };
+    geocoding = { geocode: jest.fn() };
+
+    harness = await createControllerTestApp({
+      controllers: [ClinicaController],
+      providers: [
+        { provide: PlacesService, useValue: places },
+        { provide: GeocodingService, useValue: geocoding },
+      ],
+    });
+  });
+
+  afterAll(async () => {
+    await harness.app.close();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    harness.setUser(VET);
+  });
+
+  describe('GET /clinicas/places', () => {
+    it('converte radiusKm em metros e retorna as clínicas (200)', async () => {
+      places.searchNearbyVetClinics.mockResolvedValue([{ place_id: 'p1' }]);
+
+      const res = await request(harness.app.getHttpServer())
+        .get('/clinicas/places?lat=-3.73&lng=-38.52&radiusKm=2')
+        .expect(200);
+
+      expect(res.body).toHaveLength(1);
+      const arg = places.searchNearbyVetClinics.mock.calls[0][0];
+      expect(arg.radiusMeters).toBe(2000);
+      expect(arg.lat).toBe(-3.73);
+    });
+
+    it('rejeita lat/lng ausentes (400)', async () => {
+      await request(harness.app.getHttpServer())
+        .get('/clinicas/places?radiusKm=2')
+        .expect(400);
+
+      expect(places.searchNearbyVetClinics).not.toHaveBeenCalled();
+    });
+
+    it('rejeita radiusKm fora do intervalo (400)', async () => {
+      await request(harness.app.getHttpServer())
+        .get('/clinicas/places?lat=-3.73&lng=-38.52&radiusKm=999')
+        .expect(400);
+    });
+
+    it('exige autenticação (401)', async () => {
+      harness.setUser(null);
+
+      await request(harness.app.getHttpServer())
+        .get('/clinicas/places?lat=-3.73&lng=-38.52&radiusKm=2')
+        .expect(401);
+    });
+  });
+
+  describe('GET /clinicas/geocode', () => {
+    it('retorna as coordenadas do endereço (200)', async () => {
+      geocoding.geocode.mockResolvedValue({ lat: -3.73, lng: -38.52 });
+
+      const res = await request(harness.app.getHttpServer())
+        .get('/clinicas/geocode?address=Fortaleza')
+        .expect(200);
+
+      expect(res.body.lat).toBe(-3.73);
+      expect(geocoding.geocode).toHaveBeenCalledWith('Fortaleza');
+    });
+  });
+});

--- a/src/modules/health/deworming/__tests__/deworming.controller.spec.ts
+++ b/src/modules/health/deworming/__tests__/deworming.controller.spec.ts
@@ -1,0 +1,160 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import request from 'supertest';
+import {
+  createControllerTestApp,
+  ControllerHarness,
+  TUTOR,
+  VET,
+} from '../../../../../test/utils/controller-harness';
+import { PrismaService } from '../../../../prisma/prisma.service';
+import { QrCodePublisher } from '../../../queue/qr-code.publisher';
+import { PetService } from '../../../pet/pet.service';
+import { TutorService } from '../../../tutor/tutor.service';
+import { DewormingController } from '../deworming.controller';
+import { DewormingService } from '../deworming.service';
+
+describe('DewormingController (integração)', () => {
+  let harness: ControllerHarness;
+  let prisma: {
+    pet: { findUnique: jest.Mock };
+    dewormingRecord: {
+      create: jest.Mock;
+      findMany: jest.Mock;
+      findUnique: jest.Mock;
+      update: jest.Mock;
+      delete: jest.Mock;
+    };
+  };
+
+  const pet = { id: 'pet-1', tutorId: 'tutor-1' };
+  const record = {
+    id: 'dew-1',
+    petId: 'pet-1',
+    productName: 'Drontal',
+    appliedAt: new Date('2026-02-01'),
+    nextDoseAt: null,
+    veterinarianName: null,
+    notes: null,
+    createdAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-01-01'),
+  };
+
+  beforeAll(async () => {
+    prisma = {
+      pet: { findUnique: jest.fn() },
+      dewormingRecord: {
+        create: jest.fn(),
+        findMany: jest.fn(),
+        findUnique: jest.fn(),
+        update: jest.fn(),
+        delete: jest.fn(),
+      },
+    };
+
+    harness = await createControllerTestApp({
+      controllers: [DewormingController],
+      providers: [
+        DewormingService,
+        PetService,
+        TutorService,
+        { provide: PrismaService, useValue: prisma },
+        {
+          provide: QrCodePublisher,
+          useValue: { publishGenerate: jest.fn() },
+        },
+      ],
+    });
+  });
+
+  afterAll(async () => {
+    await harness.app.close();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    harness.setUser(TUTOR);
+    prisma.pet.findUnique.mockResolvedValue(pet);
+  });
+
+  it('POST cria registro para o dono (201)', async () => {
+    prisma.dewormingRecord.create.mockResolvedValue(record);
+
+    const res = await request(harness.app.getHttpServer())
+      .post('/pets/pet-1/dewormings')
+      .send({
+        pet_id: '11111111-1111-4111-8111-111111111111',
+        product_name: 'Drontal',
+        applied_at: '2026-02-01',
+      })
+      .expect(201);
+
+    expect(res.body.id).toBe('dew-1');
+    expect(res.body.product_name).toBe('Drontal');
+  });
+
+  it('POST permite VET registrar em qualquer pet (201)', async () => {
+    harness.setUser(VET);
+    prisma.pet.findUnique.mockResolvedValue({ ...pet, tutorId: 'outro' });
+    prisma.dewormingRecord.create.mockResolvedValue(record);
+
+    await request(harness.app.getHttpServer())
+      .post('/pets/pet-1/dewormings')
+      .send({
+        pet_id: '11111111-1111-4111-8111-111111111111',
+        product_name: 'Drontal',
+        applied_at: '2026-02-01',
+      })
+      .expect(201);
+  });
+
+  it('POST rejeita payload inválido (400)', async () => {
+    await request(harness.app.getHttpServer())
+      .post('/pets/pet-1/dewormings')
+      .send({})
+      .expect(400);
+
+    expect(prisma.dewormingRecord.create).not.toHaveBeenCalled();
+  });
+
+  it('GET lista os registros do pet (200)', async () => {
+    prisma.dewormingRecord.findMany.mockResolvedValue([record]);
+
+    const res = await request(harness.app.getHttpServer())
+      .get('/pets/pet-1/dewormings')
+      .expect(200);
+
+    expect(res.body).toHaveLength(1);
+  });
+
+  it('PATCH atualiza o registro (200)', async () => {
+    prisma.dewormingRecord.findUnique.mockResolvedValue(record);
+    prisma.dewormingRecord.update.mockResolvedValue({
+      ...record,
+      productName: 'Drontal Plus',
+    });
+
+    const res = await request(harness.app.getHttpServer())
+      .patch('/dewormings/dew-1')
+      .send({ product_name: 'Drontal Plus' })
+      .expect(200);
+
+    expect(res.body.product_name).toBe('Drontal Plus');
+  });
+
+  it('DELETE remove o registro do dono (204)', async () => {
+    prisma.dewormingRecord.findUnique.mockResolvedValue(record);
+    prisma.dewormingRecord.delete.mockResolvedValue(record);
+
+    await request(harness.app.getHttpServer())
+      .delete('/dewormings/dew-1')
+      .expect(204);
+  });
+
+  it('DELETE é proibido para VET (403)', async () => {
+    harness.setUser(VET);
+
+    await request(harness.app.getHttpServer())
+      .delete('/dewormings/dew-1')
+      .expect(403);
+  });
+});

--- a/src/modules/health/medication/__tests__/medication.controller.spec.ts
+++ b/src/modules/health/medication/__tests__/medication.controller.spec.ts
@@ -1,0 +1,161 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import request from 'supertest';
+import {
+  createControllerTestApp,
+  ControllerHarness,
+  TUTOR,
+  VET,
+} from '../../../../../test/utils/controller-harness';
+import { PrismaService } from '../../../../prisma/prisma.service';
+import { QrCodePublisher } from '../../../queue/qr-code.publisher';
+import { PetService } from '../../../pet/pet.service';
+import { TutorService } from '../../../tutor/tutor.service';
+import { MedicationController } from '../medication.controller';
+import { MedicationService } from '../medication.service';
+
+describe('MedicationController (integração)', () => {
+  let harness: ControllerHarness;
+  let prisma: {
+    pet: { findUnique: jest.Mock };
+    medicationRecord: {
+      create: jest.Mock;
+      findMany: jest.Mock;
+      findUnique: jest.Mock;
+      update: jest.Mock;
+      delete: jest.Mock;
+    };
+  };
+
+  const pet = { id: 'pet-1', tutorId: 'tutor-1' };
+  const record = {
+    id: 'med-1',
+    petId: 'pet-1',
+    medicationName: 'Amoxicilina',
+    dosage: '500mg',
+    frequency: '8h',
+    startDate: new Date('2026-03-01'),
+    endDate: null,
+    notes: null,
+    createdAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-01-01'),
+  };
+
+  beforeAll(async () => {
+    prisma = {
+      pet: { findUnique: jest.fn() },
+      medicationRecord: {
+        create: jest.fn(),
+        findMany: jest.fn(),
+        findUnique: jest.fn(),
+        update: jest.fn(),
+        delete: jest.fn(),
+      },
+    };
+
+    harness = await createControllerTestApp({
+      controllers: [MedicationController],
+      providers: [
+        MedicationService,
+        PetService,
+        TutorService,
+        { provide: PrismaService, useValue: prisma },
+        {
+          provide: QrCodePublisher,
+          useValue: { publishGenerate: jest.fn() },
+        },
+      ],
+    });
+  });
+
+  afterAll(async () => {
+    await harness.app.close();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    harness.setUser(TUTOR);
+    prisma.pet.findUnique.mockResolvedValue(pet);
+  });
+
+  const validBody = {
+    pet_id: '11111111-1111-4111-8111-111111111111',
+    medication_name: 'Amoxicilina',
+    dosage: '500mg',
+    frequency: '8h',
+    start_date: '2026-03-01',
+  };
+
+  it('POST cria registro para o dono (201)', async () => {
+    prisma.medicationRecord.create.mockResolvedValue(record);
+
+    const res = await request(harness.app.getHttpServer())
+      .post('/pets/pet-1/medications')
+      .send(validBody)
+      .expect(201);
+
+    expect(res.body.id).toBe('med-1');
+    expect(res.body.medication_name).toBe('Amoxicilina');
+  });
+
+  it('POST permite VET registrar em qualquer pet (201)', async () => {
+    harness.setUser(VET);
+    prisma.pet.findUnique.mockResolvedValue({ ...pet, tutorId: 'outro' });
+    prisma.medicationRecord.create.mockResolvedValue(record);
+
+    await request(harness.app.getHttpServer())
+      .post('/pets/pet-1/medications')
+      .send(validBody)
+      .expect(201);
+  });
+
+  it('POST rejeita payload inválido (400)', async () => {
+    await request(harness.app.getHttpServer())
+      .post('/pets/pet-1/medications')
+      .send({ medication_name: 'Amoxicilina' })
+      .expect(400);
+
+    expect(prisma.medicationRecord.create).not.toHaveBeenCalled();
+  });
+
+  it('GET lista os registros do pet (200)', async () => {
+    prisma.medicationRecord.findMany.mockResolvedValue([record]);
+
+    const res = await request(harness.app.getHttpServer())
+      .get('/pets/pet-1/medications')
+      .expect(200);
+
+    expect(res.body).toHaveLength(1);
+  });
+
+  it('PATCH atualiza o registro (200)', async () => {
+    prisma.medicationRecord.findUnique.mockResolvedValue(record);
+    prisma.medicationRecord.update.mockResolvedValue({
+      ...record,
+      dosage: '250mg',
+    });
+
+    const res = await request(harness.app.getHttpServer())
+      .patch('/medications/med-1')
+      .send({ dosage: '250mg' })
+      .expect(200);
+
+    expect(res.body.dosage).toBe('250mg');
+  });
+
+  it('DELETE remove o registro do dono (204)', async () => {
+    prisma.medicationRecord.findUnique.mockResolvedValue(record);
+    prisma.medicationRecord.delete.mockResolvedValue(record);
+
+    await request(harness.app.getHttpServer())
+      .delete('/medications/med-1')
+      .expect(204);
+  });
+
+  it('DELETE é proibido para VET (403)', async () => {
+    harness.setUser(VET);
+
+    await request(harness.app.getHttpServer())
+      .delete('/medications/med-1')
+      .expect(403);
+  });
+});

--- a/src/modules/health/vaccine/__tests__/vaccine.controller.spec.ts
+++ b/src/modules/health/vaccine/__tests__/vaccine.controller.spec.ts
@@ -1,0 +1,160 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import request from 'supertest';
+import {
+  createControllerTestApp,
+  ControllerHarness,
+  TUTOR,
+  VET,
+} from '../../../../../test/utils/controller-harness';
+import { PrismaService } from '../../../../prisma/prisma.service';
+import { QrCodePublisher } from '../../../queue/qr-code.publisher';
+import { PetService } from '../../../pet/pet.service';
+import { TutorService } from '../../../tutor/tutor.service';
+import { VaccineController } from '../vaccine.controller';
+import { VaccineService } from '../vaccine.service';
+
+describe('VaccineController (integração)', () => {
+  let harness: ControllerHarness;
+  let prisma: {
+    pet: { findUnique: jest.Mock };
+    vaccineRecord: {
+      create: jest.Mock;
+      findMany: jest.Mock;
+      findUnique: jest.Mock;
+      update: jest.Mock;
+      delete: jest.Mock;
+    };
+  };
+
+  const pet = { id: 'pet-1', tutorId: 'tutor-1' };
+  const record = {
+    id: 'vac-1',
+    petId: 'pet-1',
+    vaccineName: 'Raiva',
+    appliedAt: new Date('2026-01-10'),
+    nextDoseAt: null,
+    veterinarianName: null,
+    notes: null,
+    createdAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-01-01'),
+  };
+
+  beforeAll(async () => {
+    prisma = {
+      pet: { findUnique: jest.fn() },
+      vaccineRecord: {
+        create: jest.fn(),
+        findMany: jest.fn(),
+        findUnique: jest.fn(),
+        update: jest.fn(),
+        delete: jest.fn(),
+      },
+    };
+
+    harness = await createControllerTestApp({
+      controllers: [VaccineController],
+      providers: [
+        VaccineService,
+        PetService,
+        TutorService,
+        { provide: PrismaService, useValue: prisma },
+        {
+          provide: QrCodePublisher,
+          useValue: { publishGenerate: jest.fn() },
+        },
+      ],
+    });
+  });
+
+  afterAll(async () => {
+    await harness.app.close();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    harness.setUser(TUTOR);
+    prisma.pet.findUnique.mockResolvedValue(pet);
+  });
+
+  it('POST cria registro para o dono (201)', async () => {
+    prisma.vaccineRecord.create.mockResolvedValue(record);
+
+    const res = await request(harness.app.getHttpServer())
+      .post('/pets/pet-1/vaccines')
+      .send({
+        pet_id: '11111111-1111-4111-8111-111111111111',
+        vaccine_name: 'Raiva',
+        applied_at: '2026-01-10',
+      })
+      .expect(201);
+
+    expect(res.body.id).toBe('vac-1');
+    expect(res.body.vaccine_name).toBe('Raiva');
+  });
+
+  it('POST permite VET registrar em qualquer pet (201)', async () => {
+    harness.setUser(VET);
+    prisma.pet.findUnique.mockResolvedValue({ ...pet, tutorId: 'outro' });
+    prisma.vaccineRecord.create.mockResolvedValue(record);
+
+    await request(harness.app.getHttpServer())
+      .post('/pets/pet-1/vaccines')
+      .send({
+        pet_id: '11111111-1111-4111-8111-111111111111',
+        vaccine_name: 'Raiva',
+        applied_at: '2026-01-10',
+      })
+      .expect(201);
+  });
+
+  it('POST rejeita payload inválido (400)', async () => {
+    await request(harness.app.getHttpServer())
+      .post('/pets/pet-1/vaccines')
+      .send({})
+      .expect(400);
+
+    expect(prisma.vaccineRecord.create).not.toHaveBeenCalled();
+  });
+
+  it('GET lista os registros do pet (200)', async () => {
+    prisma.vaccineRecord.findMany.mockResolvedValue([record]);
+
+    const res = await request(harness.app.getHttpServer())
+      .get('/pets/pet-1/vaccines')
+      .expect(200);
+
+    expect(res.body).toHaveLength(1);
+  });
+
+  it('PATCH atualiza o registro (200)', async () => {
+    prisma.vaccineRecord.findUnique.mockResolvedValue(record);
+    prisma.vaccineRecord.update.mockResolvedValue({
+      ...record,
+      vaccineName: 'Raiva Plus',
+    });
+
+    const res = await request(harness.app.getHttpServer())
+      .patch('/vaccines/vac-1')
+      .send({ vaccine_name: 'Raiva Plus' })
+      .expect(200);
+
+    expect(res.body.vaccine_name).toBe('Raiva Plus');
+  });
+
+  it('DELETE remove o registro do dono (204)', async () => {
+    prisma.vaccineRecord.findUnique.mockResolvedValue(record);
+    prisma.vaccineRecord.delete.mockResolvedValue(record);
+
+    await request(harness.app.getHttpServer())
+      .delete('/vaccines/vac-1')
+      .expect(204);
+  });
+
+  it('DELETE é proibido para VET (403)', async () => {
+    harness.setUser(VET);
+
+    await request(harness.app.getHttpServer())
+      .delete('/vaccines/vac-1')
+      .expect(403);
+  });
+});

--- a/src/modules/pet/__tests__/pet.controller.spec.ts
+++ b/src/modules/pet/__tests__/pet.controller.spec.ts
@@ -1,0 +1,234 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment */
+import request from 'supertest';
+import {
+  createControllerTestApp,
+  ControllerHarness,
+  TUTOR,
+  VET,
+} from '../../../../test/utils/controller-harness';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { QrCodePublisher } from '../../queue/qr-code.publisher';
+import { TutorService } from '../../tutor/tutor.service';
+import { PetController } from '../pet.controller';
+import { PetService } from '../pet.service';
+
+describe('PetController (integração)', () => {
+  let harness: ControllerHarness;
+  let prisma: {
+    tutor: { findUnique: jest.Mock };
+    pet: {
+      create: jest.Mock;
+      findMany: jest.Mock;
+      findUnique: jest.Mock;
+      findUniqueOrThrow: jest.Mock;
+      update: jest.Mock;
+      delete: jest.Mock;
+    };
+  };
+  let qrPublisher: { publishGenerate: jest.Mock };
+
+  const tutor = {
+    id: 'tutor-1',
+    name: 'Alice',
+    email: 'tutor@petcard.com',
+  };
+  const pet = {
+    id: 'pet-1',
+    name: 'Rex',
+    species: 'DOG',
+    breed: 'Labrador',
+    sex: 'MALE',
+    birthDate: new Date('2023-05-01'),
+    weight: 20,
+    photoUrl: null,
+    tutorId: 'tutor-1',
+    createdAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-01-01'),
+    carteiraDigital: null,
+  };
+
+  beforeAll(async () => {
+    prisma = {
+      tutor: { findUnique: jest.fn() },
+      pet: {
+        create: jest.fn(),
+        findMany: jest.fn(),
+        findUnique: jest.fn(),
+        findUniqueOrThrow: jest.fn(),
+        update: jest.fn(),
+        delete: jest.fn(),
+      },
+    };
+    qrPublisher = { publishGenerate: jest.fn().mockResolvedValue(undefined) };
+
+    harness = await createControllerTestApp({
+      controllers: [PetController],
+      providers: [
+        PetService,
+        TutorService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: QrCodePublisher, useValue: qrPublisher },
+      ],
+    });
+  });
+
+  afterAll(async () => {
+    await harness.app.close();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    harness.setUser(TUTOR);
+    prisma.tutor.findUnique.mockResolvedValue(tutor);
+  });
+
+  describe('POST /pets', () => {
+    it('cria o pet do tutor autenticado (201)', async () => {
+      prisma.pet.create.mockResolvedValue(pet);
+      prisma.pet.findUniqueOrThrow.mockResolvedValue(pet);
+
+      const res = await request(harness.app.getHttpServer())
+        .post('/pets')
+        .send({
+          name: 'Rex',
+          species: 'DOG',
+          sex: 'MALE',
+          breed: 'Labrador',
+          weight: 20,
+          birth_date: '2023-05-01',
+        })
+        .expect(201);
+
+      expect(res.body.id).toBe('pet-1');
+      expect(res.body.tutor_id).toBe('tutor-1');
+      const createArg = prisma.pet.create.mock.calls[0][0];
+      expect(createArg.data.tutorId).toBe('tutor-1');
+      expect(qrPublisher.publishGenerate).toHaveBeenCalledWith('pet-1');
+    });
+
+    it('rejeita payload sem campos obrigatórios (400)', async () => {
+      await request(harness.app.getHttpServer())
+        .post('/pets')
+        .send({ name: 'Rex' })
+        .expect(400);
+
+      expect(prisma.pet.create).not.toHaveBeenCalled();
+    });
+
+    it('rejeita propriedade não esperada (400)', async () => {
+      await request(harness.app.getHttpServer())
+        .post('/pets')
+        .send({ name: 'Rex', species: 'DOG', sex: 'MALE', hacker: true })
+        .expect(400);
+    });
+
+    it('proíbe VET de criar pet (403)', async () => {
+      harness.setUser(VET);
+
+      await request(harness.app.getHttpServer())
+        .post('/pets')
+        .send({ name: 'Rex', species: 'DOG', sex: 'MALE' })
+        .expect(403);
+    });
+
+    it('exige autenticação (401)', async () => {
+      harness.setUser(null);
+
+      await request(harness.app.getHttpServer())
+        .post('/pets')
+        .send({ name: 'Rex', species: 'DOG', sex: 'MALE' })
+        .expect(401);
+    });
+  });
+
+  describe('GET /pets', () => {
+    it('lista os pets do tutor (200)', async () => {
+      prisma.pet.findMany.mockResolvedValue([pet]);
+
+      const res = await request(harness.app.getHttpServer())
+        .get('/pets')
+        .expect(200);
+
+      expect(res.body).toHaveLength(1);
+      expect(res.body[0].id).toBe('pet-1');
+      expect(prisma.pet.findMany).toHaveBeenCalledWith({
+        where: { tutorId: 'tutor-1' },
+        include: { carteiraDigital: true },
+      });
+    });
+  });
+
+  describe('GET /pets/:id', () => {
+    it('retorna o pet do dono (200)', async () => {
+      prisma.pet.findUnique.mockResolvedValue(pet);
+
+      const res = await request(harness.app.getHttpServer())
+        .get('/pets/pet-1')
+        .expect(200);
+
+      expect(res.body.id).toBe('pet-1');
+    });
+
+    it('proíbe tutor que não é dono (403)', async () => {
+      prisma.pet.findUnique.mockResolvedValue({ ...pet, tutorId: 'outro' });
+
+      await request(harness.app.getHttpServer()).get('/pets/pet-1').expect(403);
+    });
+
+    it('permite acesso de VET mesmo sem ser dono (200)', async () => {
+      harness.setUser(VET);
+      prisma.pet.findUnique.mockResolvedValue({ ...pet, tutorId: 'outro' });
+
+      await request(harness.app.getHttpServer()).get('/pets/pet-1').expect(200);
+    });
+
+    it('retorna 404 quando o pet não existe', async () => {
+      prisma.pet.findUnique.mockResolvedValue(null);
+
+      await request(harness.app.getHttpServer())
+        .get('/pets/missing')
+        .expect(404);
+    });
+  });
+
+  describe('PATCH /pets/:id', () => {
+    it('atualiza o pet do dono (200)', async () => {
+      prisma.pet.findUnique.mockResolvedValue(pet);
+      prisma.pet.update.mockResolvedValue({ ...pet, name: 'Rex II' });
+
+      const res = await request(harness.app.getHttpServer())
+        .patch('/pets/pet-1')
+        .send({ name: 'Rex II' })
+        .expect(200);
+
+      expect(res.body.name).toBe('Rex II');
+    });
+  });
+
+  describe('DELETE /pets/:id', () => {
+    it('remove o pet do dono (204)', async () => {
+      prisma.pet.findUnique.mockResolvedValue(pet);
+      prisma.pet.delete.mockResolvedValue(pet);
+
+      await request(harness.app.getHttpServer())
+        .delete('/pets/pet-1')
+        .expect(204);
+
+      expect(prisma.pet.delete).toHaveBeenCalledWith({
+        where: { id: 'pet-1' },
+      });
+    });
+  });
+
+  describe('POST /pets/:id/qr-code', () => {
+    it('reenfileira a geração de QR Code do dono (202)', async () => {
+      prisma.pet.findUnique.mockResolvedValue(pet);
+
+      await request(harness.app.getHttpServer())
+        .post('/pets/pet-1/qr-code')
+        .expect(202);
+
+      expect(qrPublisher.publishGenerate).toHaveBeenCalledWith('pet-1');
+    });
+  });
+});

--- a/src/modules/tutor/__tests__/tutor.controller.spec.ts
+++ b/src/modules/tutor/__tests__/tutor.controller.spec.ts
@@ -1,0 +1,119 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import request from 'supertest';
+import {
+  createControllerTestApp,
+  ControllerHarness,
+  TUTOR,
+  VET,
+} from '../../../../test/utils/controller-harness';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { TutorController } from '../tutor.controller';
+import { TutorService } from '../tutor.service';
+
+describe('TutorController (integração)', () => {
+  let harness: ControllerHarness;
+  let prisma: { tutor: { findUnique: jest.Mock; update: jest.Mock } };
+
+  const tutor = {
+    id: 'tutor-1',
+    name: 'Alice',
+    email: 'tutor@petcard.com',
+    phone: null,
+    profileImageUrl: null,
+    role: 'TUTOR',
+    createdAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-01-01'),
+  };
+
+  beforeAll(async () => {
+    prisma = { tutor: { findUnique: jest.fn(), update: jest.fn() } };
+
+    harness = await createControllerTestApp({
+      controllers: [TutorController],
+      providers: [TutorService, { provide: PrismaService, useValue: prisma }],
+    });
+  });
+
+  afterAll(async () => {
+    await harness.app.close();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    harness.setUser(TUTOR);
+    prisma.tutor.findUnique.mockResolvedValue(tutor);
+  });
+
+  describe('GET /tutors/me', () => {
+    it('retorna o tutor autenticado (200)', async () => {
+      const res = await request(harness.app.getHttpServer())
+        .get('/tutors/me')
+        .expect(200);
+
+      expect(res.body.id).toBe('tutor-1');
+      expect(res.body.email).toBe('tutor@petcard.com');
+      expect(prisma.tutor.findUnique).toHaveBeenCalledWith({
+        where: { id: 'tutor-1' },
+      });
+    });
+
+    it('exige autenticação (401)', async () => {
+      harness.setUser(null);
+
+      await request(harness.app.getHttpServer()).get('/tutors/me').expect(401);
+    });
+  });
+
+  describe('PATCH /tutors/me', () => {
+    it('atualiza o tutor autenticado (200)', async () => {
+      prisma.tutor.update.mockResolvedValue({ ...tutor, name: 'Alice B' });
+
+      const res = await request(harness.app.getHttpServer())
+        .patch('/tutors/me')
+        .send({ name: 'Alice B' })
+        .expect(200);
+
+      expect(res.body.name).toBe('Alice B');
+      expect(prisma.tutor.update).toHaveBeenCalledWith({
+        where: { id: 'tutor-1' },
+        data: { name: 'Alice B' },
+      });
+    });
+
+    it('rejeita email inválido (400)', async () => {
+      await request(harness.app.getHttpServer())
+        .patch('/tutors/me')
+        .send({ email: 'not-an-email' })
+        .expect(400);
+
+      expect(prisma.tutor.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('GET /tutors/:id', () => {
+    it('proíbe acesso de TUTOR (403)', async () => {
+      await request(harness.app.getHttpServer())
+        .get('/tutors/tutor-1')
+        .expect(403);
+    });
+
+    it('retorna o tutor para VET (200)', async () => {
+      harness.setUser(VET);
+
+      const res = await request(harness.app.getHttpServer())
+        .get('/tutors/tutor-1')
+        .expect(200);
+
+      expect(res.body.id).toBe('tutor-1');
+    });
+
+    it('retorna 404 para tutor inexistente (VET)', async () => {
+      harness.setUser(VET);
+      prisma.tutor.findUnique.mockResolvedValue(null);
+
+      await request(harness.app.getHttpServer())
+        .get('/tutors/missing')
+        .expect(404);
+    });
+  });
+});

--- a/src/modules/upload/__tests__/upload.controller.spec.ts
+++ b/src/modules/upload/__tests__/upload.controller.spec.ts
@@ -1,0 +1,74 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment */
+import request from 'supertest';
+import {
+  createControllerTestApp,
+  ControllerHarness,
+  TUTOR,
+} from '../../../../test/utils/controller-harness';
+import { UploadController } from '../upload.controller';
+import { UploadService } from '../upload.service';
+
+describe('UploadController (integração)', () => {
+  let harness: ControllerHarness;
+  let upload: { uploadFile: jest.Mock };
+
+  beforeAll(async () => {
+    upload = { uploadFile: jest.fn() };
+
+    harness = await createControllerTestApp({
+      controllers: [UploadController],
+      providers: [{ provide: UploadService, useValue: upload }],
+    });
+  });
+
+  afterAll(async () => {
+    await harness.app.close();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    harness.setUser(TUTOR);
+  });
+
+  it('faz upload do arquivo e retorna a URL (201)', async () => {
+    upload.uploadFile.mockResolvedValue('https://s3/pets/foto.png');
+
+    const res = await request(harness.app.getHttpServer())
+      .post('/upload/image')
+      .attach('file', Buffer.from('fake-image'), 'foto.png')
+      .expect(201);
+
+    expect(res.body.url).toBe('https://s3/pets/foto.png');
+    const folderArg = upload.uploadFile.mock.calls[0][1];
+    expect(folderArg).toBe('pets');
+  });
+
+  it('usa a pasta informada na query (tutors)', async () => {
+    upload.uploadFile.mockResolvedValue('https://s3/tutors/foto.png');
+
+    await request(harness.app.getHttpServer())
+      .post('/upload/image?folder=tutors')
+      .attach('file', Buffer.from('fake-image'), 'foto.png')
+      .expect(201);
+
+    expect(upload.uploadFile.mock.calls[0][1]).toBe('tutors');
+  });
+
+  it('rejeita pasta inválida (400)', async () => {
+    await request(harness.app.getHttpServer())
+      .post('/upload/image?folder=hacker')
+      .attach('file', Buffer.from('fake-image'), 'foto.png')
+      .expect(400);
+
+    expect(upload.uploadFile).not.toHaveBeenCalled();
+  });
+
+  it('exige autenticação (401)', async () => {
+    harness.setUser(null);
+
+    await request(harness.app.getHttpServer())
+      .post('/upload/image')
+      .attach('file', Buffer.from('fake-image'), 'foto.png')
+      .expect(401);
+  });
+});

--- a/src/modules/vet-note/__tests__/vet-note.controller.spec.ts
+++ b/src/modules/vet-note/__tests__/vet-note.controller.spec.ts
@@ -1,0 +1,198 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import { Logger } from '@nestjs/common';
+import request from 'supertest';
+import {
+  createControllerTestApp,
+  ControllerHarness,
+  TUTOR,
+  VET,
+} from '../../../../test/utils/controller-harness';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { NotificationService } from '../../notification/notification.service';
+import { VetNoteController } from '../vet-note.controller';
+import { VetNoteService } from '../vet-note.service';
+
+describe('VetNoteController (integração)', () => {
+  let harness: ControllerHarness;
+  let prisma: {
+    pet: { findUnique: jest.Mock };
+    veterinario: { findUnique: jest.Mock };
+    notaClinica: {
+      create: jest.Mock;
+      findMany: jest.Mock;
+      findUnique: jest.Mock;
+      delete: jest.Mock;
+    };
+  };
+  let notifications: { schedulePush: jest.Mock };
+
+  const pet = { id: 'pet-1', name: 'Rex', tutorId: 'tutor-1' };
+  const nota = {
+    id: 'nota-1',
+    petId: 'pet-1',
+    veterinarioId: 'vet-1',
+    diagnostico: 'Otite',
+    prescricao: null,
+    observacoes: null,
+    googlePlaceId: null,
+    createdAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-01-01'),
+    veterinario: { nome: 'Dra. Vet', crmv: 'CRMV-123' },
+  };
+
+  beforeAll(async () => {
+    jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
+    prisma = {
+      pet: { findUnique: jest.fn() },
+      veterinario: { findUnique: jest.fn() },
+      notaClinica: {
+        create: jest.fn(),
+        findMany: jest.fn(),
+        findUnique: jest.fn(),
+        delete: jest.fn(),
+      },
+    };
+    notifications = { schedulePush: jest.fn().mockResolvedValue(undefined) };
+
+    harness = await createControllerTestApp({
+      controllers: [VetNoteController],
+      providers: [
+        VetNoteService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: NotificationService, useValue: notifications },
+      ],
+    });
+  });
+
+  afterAll(async () => {
+    await harness.app.close();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    harness.setUser(VET);
+    prisma.pet.findUnique.mockResolvedValue(pet);
+    prisma.veterinario.findUnique.mockResolvedValue({ id: 'vet-1' });
+  });
+
+  describe('POST /pets/:petId/clinical-notes', () => {
+    it('VET cria a nota e dispara o push (201)', async () => {
+      prisma.notaClinica.create.mockResolvedValue(nota);
+
+      const res = await request(harness.app.getHttpServer())
+        .post('/pets/pet-1/clinical-notes')
+        .send({ diagnostico: 'Otite', prescricao: 'Antibiótico' })
+        .expect(201);
+
+      expect(res.body.id).toBe('nota-1');
+      expect(res.body.veterinario_nome).toBe('Dra. Vet');
+      expect(notifications.schedulePush).toHaveBeenCalledTimes(1);
+    });
+
+    it('cria a nota mesmo se o push falhar (201, degradação)', async () => {
+      prisma.notaClinica.create.mockResolvedValue(nota);
+      notifications.schedulePush.mockRejectedValueOnce(new Error('FCM down'));
+
+      await request(harness.app.getHttpServer())
+        .post('/pets/pet-1/clinical-notes')
+        .send({ diagnostico: 'Otite' })
+        .expect(201);
+    });
+
+    it('proíbe TUTOR de criar nota (403)', async () => {
+      harness.setUser(TUTOR);
+
+      await request(harness.app.getHttpServer())
+        .post('/pets/pet-1/clinical-notes')
+        .send({ diagnostico: 'Otite' })
+        .expect(403);
+    });
+
+    it('rejeita payload inválido (400)', async () => {
+      await request(harness.app.getHttpServer())
+        .post('/pets/pet-1/clinical-notes')
+        .send({})
+        .expect(400);
+
+      expect(prisma.notaClinica.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('GET /pets/:petId/clinical-notes', () => {
+    it('o dono do pet lista as notas (200)', async () => {
+      harness.setUser(TUTOR);
+      prisma.notaClinica.findMany.mockResolvedValue([nota]);
+
+      const res = await request(harness.app.getHttpServer())
+        .get('/pets/pet-1/clinical-notes')
+        .expect(200);
+
+      expect(res.body).toHaveLength(1);
+    });
+
+    it('proíbe tutor que não é dono (403)', async () => {
+      harness.setUser(TUTOR);
+      prisma.pet.findUnique.mockResolvedValue({ ...pet, tutorId: 'outro' });
+
+      await request(harness.app.getHttpServer())
+        .get('/pets/pet-1/clinical-notes')
+        .expect(403);
+    });
+  });
+
+  describe('GET /clinical-notes/:id', () => {
+    it('retorna a nota para o dono do pet (200)', async () => {
+      harness.setUser(TUTOR);
+      prisma.notaClinica.findUnique.mockResolvedValue({
+        ...nota,
+        pet: { tutorId: 'tutor-1' },
+      });
+
+      const res = await request(harness.app.getHttpServer())
+        .get('/clinical-notes/nota-1')
+        .expect(200);
+
+      expect(res.body.id).toBe('nota-1');
+    });
+
+    it('retorna 404 para nota inexistente', async () => {
+      prisma.notaClinica.findUnique.mockResolvedValue(null);
+
+      await request(harness.app.getHttpServer())
+        .get('/clinical-notes/missing')
+        .expect(404);
+    });
+  });
+
+  describe('DELETE /clinical-notes/:id', () => {
+    it('o autor (VET) remove a própria nota (204)', async () => {
+      prisma.notaClinica.findUnique.mockResolvedValue(nota);
+      prisma.notaClinica.delete.mockResolvedValue(nota);
+
+      await request(harness.app.getHttpServer())
+        .delete('/clinical-notes/nota-1')
+        .expect(204);
+    });
+
+    it('proíbe VET de apagar nota de outro vet (403)', async () => {
+      prisma.notaClinica.findUnique.mockResolvedValue({
+        ...nota,
+        veterinarioId: 'outro-vet',
+      });
+
+      await request(harness.app.getHttpServer())
+        .delete('/clinical-notes/nota-1')
+        .expect(403);
+
+      expect(prisma.notaClinica.delete).not.toHaveBeenCalled();
+    });
+
+    it('proíbe TUTOR de apagar nota (403)', async () => {
+      harness.setUser(TUTOR);
+
+      await request(harness.app.getHttpServer())
+        .delete('/clinical-notes/nota-1')
+        .expect(403);
+    });
+  });
+});

--- a/src/modules/veterinario/__tests__/veterinario.controller.spec.ts
+++ b/src/modules/veterinario/__tests__/veterinario.controller.spec.ts
@@ -1,0 +1,220 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import request from 'supertest';
+import {
+  createControllerTestApp,
+  ControllerHarness,
+  TUTOR,
+  VET,
+} from '../../../../test/utils/controller-harness';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { VeterinarioController } from '../veterinario.controller';
+import { VeterinarioService } from '../veterinario.service';
+
+describe('VeterinarioController (integração)', () => {
+  let harness: ControllerHarness;
+  let prisma: {
+    veterinario: {
+      create: jest.Mock;
+      findMany: jest.Mock;
+      findUnique: jest.Mock;
+      update: jest.Mock;
+      delete: jest.Mock;
+    };
+    notaClinica: { findMany: jest.Mock };
+    pet: { findMany: jest.Mock };
+  };
+
+  const vet = {
+    id: 'vet-1',
+    nome: 'Dra. Vet',
+    email: 'vet@petcard.com',
+    crmv: 'CRMV-123',
+    telefone: null,
+    password: 'hash',
+    createdAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-01-01'),
+  };
+
+  beforeAll(async () => {
+    prisma = {
+      veterinario: {
+        create: jest.fn(),
+        findMany: jest.fn(),
+        findUnique: jest.fn(),
+        update: jest.fn(),
+        delete: jest.fn(),
+      },
+      notaClinica: { findMany: jest.fn() },
+      pet: { findMany: jest.fn() },
+    };
+
+    harness = await createControllerTestApp({
+      controllers: [VeterinarioController],
+      providers: [
+        VeterinarioService,
+        { provide: PrismaService, useValue: prisma },
+      ],
+    });
+  });
+
+  afterAll(async () => {
+    await harness.app.close();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    harness.setUser(VET);
+  });
+
+  describe('POST /veterinarios', () => {
+    it('cria um veterinário e não expõe o password (201)', async () => {
+      prisma.veterinario.findUnique.mockResolvedValue(null);
+      prisma.veterinario.create.mockResolvedValue(vet);
+
+      const res = await request(harness.app.getHttpServer())
+        .post('/veterinarios')
+        .send({
+          nome: 'Dra. Vet',
+          email: 'vet@petcard.com',
+          password: 'senha-forte',
+          crmv: 'CRMV-123',
+        })
+        .expect(201);
+
+      expect(res.body.id).toBe('vet-1');
+      expect(res.body.password).toBeUndefined();
+    });
+
+    it('proíbe TUTOR de criar veterinário (403)', async () => {
+      harness.setUser(TUTOR);
+
+      await request(harness.app.getHttpServer())
+        .post('/veterinarios')
+        .send({
+          nome: 'Dra. Vet',
+          email: 'vet@petcard.com',
+          password: 'senha-forte',
+          crmv: 'CRMV-123',
+        })
+        .expect(403);
+    });
+
+    it('rejeita payload inválido (400)', async () => {
+      await request(harness.app.getHttpServer())
+        .post('/veterinarios')
+        .send({ nome: 'Dra. Vet' })
+        .expect(400);
+
+      expect(prisma.veterinario.create).not.toHaveBeenCalled();
+    });
+
+    it('rejeita email já cadastrado (409)', async () => {
+      prisma.veterinario.findUnique.mockResolvedValue({
+        ...vet,
+        id: 'outro',
+      });
+
+      await request(harness.app.getHttpServer())
+        .post('/veterinarios')
+        .send({
+          nome: 'Dra. Vet',
+          email: 'vet@petcard.com',
+          password: 'senha-forte',
+          crmv: 'CRMV-123',
+        })
+        .expect(409);
+    });
+  });
+
+  describe('GET /veterinarios', () => {
+    it('lista os veterinários (200)', async () => {
+      prisma.veterinario.findMany.mockResolvedValue([vet]);
+
+      const res = await request(harness.app.getHttpServer())
+        .get('/veterinarios')
+        .expect(200);
+
+      expect(res.body).toHaveLength(1);
+      expect(res.body[0].password).toBeUndefined();
+    });
+  });
+
+  describe('GET /veterinarios/dashboard/pets', () => {
+    it('retorna os pets atendidos paginados (200)', async () => {
+      prisma.notaClinica.findMany.mockResolvedValue([
+        { petId: 'pet-1', createdAt: new Date('2026-02-01') },
+      ]);
+      prisma.pet.findMany.mockResolvedValue([
+        {
+          id: 'pet-1',
+          name: 'Rex',
+          species: 'DOG',
+          breed: null,
+          photoUrl: null,
+          tutor: { name: 'Alice' },
+        },
+      ]);
+
+      const res = await request(harness.app.getHttpServer())
+        .get('/veterinarios/dashboard/pets')
+        .expect(200);
+
+      expect(res.body.total).toBe(1);
+      expect(res.body.items[0].tutor_name).toBe('Alice');
+    });
+
+    it('rejeita page inválida na query (400)', async () => {
+      await request(harness.app.getHttpServer())
+        .get('/veterinarios/dashboard/pets?page=0')
+        .expect(400);
+    });
+  });
+
+  describe('GET /veterinarios/:id', () => {
+    it('retorna o veterinário (200)', async () => {
+      prisma.veterinario.findUnique.mockResolvedValue(vet);
+
+      const res = await request(harness.app.getHttpServer())
+        .get('/veterinarios/vet-1')
+        .expect(200);
+
+      expect(res.body.id).toBe('vet-1');
+    });
+
+    it('retorna 404 para id inexistente', async () => {
+      prisma.veterinario.findUnique.mockResolvedValue(null);
+
+      await request(harness.app.getHttpServer())
+        .get('/veterinarios/missing')
+        .expect(404);
+    });
+  });
+
+  describe('PATCH /veterinarios/:id', () => {
+    it('atualiza o veterinário (200)', async () => {
+      prisma.veterinario.findUnique.mockResolvedValue(vet);
+      prisma.veterinario.update.mockResolvedValue({
+        ...vet,
+        nome: 'Dra. Nova',
+      });
+
+      const res = await request(harness.app.getHttpServer())
+        .patch('/veterinarios/vet-1')
+        .send({ nome: 'Dra. Nova' })
+        .expect(200);
+
+      expect(res.body.nome).toBe('Dra. Nova');
+    });
+  });
+
+  describe('DELETE /veterinarios/:id', () => {
+    it('remove o veterinário (204)', async () => {
+      prisma.veterinario.findUnique.mockResolvedValue(vet);
+      prisma.veterinario.delete.mockResolvedValue(vet);
+
+      await request(harness.app.getHttpServer())
+        .delete('/veterinarios/vet-1')
+        .expect(204);
+    });
+  });
+});

--- a/test/utils/controller-harness.ts
+++ b/test/utils/controller-harness.ts
@@ -1,0 +1,81 @@
+import {
+  ExecutionContext,
+  INestApplication,
+  Provider,
+  Type,
+  UnauthorizedException,
+  ValidationPipe,
+} from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import type { App } from 'supertest/types';
+import { JwtAuthGuard } from '../../src/modules/auth/guards/jwt-auth.guard';
+import { JwtPayload } from '../../src/modules/auth/strategies/jwt.strategy';
+import { Role } from '../../src/modules/auth/enums/role.enum';
+
+export type TestUser = Pick<JwtPayload, 'sub' | 'email' | 'role'>;
+
+export const TUTOR: TestUser = {
+  sub: 'tutor-1',
+  email: 'tutor@petcard.com',
+  role: Role.TUTOR,
+};
+
+export const VET: TestUser = {
+  sub: 'vet-1',
+  email: 'vet@petcard.com',
+  role: Role.VET,
+};
+
+export interface ControllerHarness {
+  app: INestApplication<App>;
+  /** Define quem é o usuário autenticado da próxima request (ou null = 401). */
+  setUser: (user: TestUser | null) => void;
+}
+
+/**
+ * Sobe um app Nest real (roteamento + ValidationPipe global + guards) com apenas
+ * o(s) controller(s) e providers fornecidos. O `JwtAuthGuard` é substituído para
+ * injetar `req.user`; o `RolesGuard` permanece real, então o RBAC de `@Auth`/
+ * `@Roles` é exercitado de verdade. Prisma e clientes externos devem entrar em
+ * `providers` como mocks.
+ */
+export async function createControllerTestApp(opts: {
+  controllers: Type<unknown>[];
+  providers: Provider[];
+}): Promise<ControllerHarness> {
+  let currentUser: TestUser | null = TUTOR;
+
+  const moduleRef: TestingModule = await Test.createTestingModule({
+    controllers: opts.controllers,
+    providers: opts.providers,
+  })
+    .overrideGuard(JwtAuthGuard)
+    .useValue({
+      canActivate: (context: ExecutionContext) => {
+        if (!currentUser) {
+          throw new UnauthorizedException();
+        }
+        const req = context.switchToHttp().getRequest<{ user?: TestUser }>();
+        req.user = currentUser;
+        return true;
+      },
+    })
+    .compile();
+
+  const app = moduleRef.createNestApplication<INestApplication<App>>();
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      transform: true,
+    }),
+  );
+  await app.init();
+
+  return {
+    app,
+    setUser: (user) => {
+      currentUser = user;
+    },
+  };
+}


### PR DESCRIPTION
## PC-087 — Testes de integração dos controllers (supertest)

Sobe um app Nest real por controller (`createControllerTestApp()` em `test/utils`) e exercita o caminho HTTP completo via supertest: **roteamento + ValidationPipe global + RolesGuard real + controller → service → Prisma**. O `JwtAuthGuard` é o único guard substituído (injeta o usuário); o RBAC de `@Auth`/`@Roles` é testado de verdade. Prisma e clientes externos entram como mocks; nenhum boot de RabbitMQ (roda no jest unit, conta no gate e no CI).

### Cobertura por controller (todos 0% → ~100%)
- **Service real + Prisma mockado:** pet, tutor, vaccine, deworming, medication, appointment, veterinario, vet-note
- **Service mockado (já coberto por unit):** calendar, clinica, upload, auth

### O que é assertado
- Contratos HTTP (status + corpo) de cada rota
- **Validação** de DTO/query → 400 (campos faltando, email/UUID/lat-lng/enum inválidos, props não esperadas)
- **RBAC**: 403 por papel errado (ex.: VET criando pet, TUTOR criando nota/veterinário, VET deletando registro de saúde)
- 401 sem autenticação, 404 inexistente, 409 conflito (email/CRMV)
- Caminhos especiais: degradação do push na nota clínica (201 mesmo com FCM down), gate de ambiente do `dev-connect`, `upcoming=true` em appointments

### Cobertura / catraca
- Global: ~70.5% → **82% stmts / 84% lines / 87.77% funcs / 75.33% branches** → **meta M6 de ≥80% atingida**
- `coverageThreshold` subido (catraca) para **81/74/87/83**

### QA
- 322 testes / 43 suites verdes
- lint limpo, `tsc` (build) OK, gate de coverage (`test:cov`) passa

### DoD
- [x] Testes verdes localmente
- [x] Cobertura ≥ 80% (stmts/lines)
- [x] Coverage floor elevado (catraca)
- [x] CI verde no GitHub Actions
