### PR TITLE
test: Subir branches de 74 para 80 no coverageThreshold

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,10 +113,10 @@
     ],
     "coverageThreshold": {
       "global": {
-        "statements": 81,
-        "branches": 74,
-        "functions": 87,
-        "lines": 83
+        "statements": 84,
+        "branches": 80,
+        "functions": 93,
+        "lines": 85
       }
     },
     "testEnvironment": "node"

--- a/src/config/__tests__/config.spec.ts
+++ b/src/config/__tests__/config.spec.ts
@@ -1,0 +1,291 @@
+import { appConfig } from '../app.config';
+import { authConfig } from '../auth.config';
+import { awsConfig } from '../aws.config';
+import { cardConfig } from '../card.config';
+import { encryptionConfig } from '../encryption.config';
+import { firebaseConfig } from '../firebase.config';
+import { googleCalendarConfig } from '../google-calendar.config';
+import { googleMapsConfig } from '../google-maps.config';
+import { rabbitmqConfig } from '../rabbitmq.config';
+import { reminderConfig } from '../reminder.config';
+
+const MANAGED_ENV_KEYS = [
+  'NODE_ENV',
+  'CORS_ORIGINS',
+  'JWT_SECRET',
+  'JWT_EXPIRES_IN',
+  'AWS_REGION',
+  'AWS_ACCESS_KEY_ID',
+  'AWS_SECRET_ACCESS_KEY',
+  'AWS_S3_BUCKET',
+  'PUBLIC_CARD_BASE_URL',
+  'PUBLIC_CARD_THROTTLE_TTL_SECONDS',
+  'PUBLIC_CARD_THROTTLE_LIMIT',
+  'ENCRYPTION_KEY',
+  'FCM_ENABLED',
+  'FIREBASE_PROJECT_ID',
+  'FIREBASE_CLIENT_EMAIL',
+  'FIREBASE_PRIVATE_KEY',
+  'GOOGLE_CALENDAR_CLIENT_ID',
+  'GOOGLE_CALENDAR_CLIENT_SECRET',
+  'GOOGLE_CALENDAR_REDIRECT_URI',
+  'GOOGLE_MAPS_API_KEY',
+  'RABBITMQ_URL',
+  'RABBITMQ_QR_CODE_QUEUE',
+  'RABBITMQ_QR_CODE_DLQ',
+  'RABBITMQ_NOTIFICATION_PUSH_QUEUE',
+  'RABBITMQ_NOTIFICATION_PUSH_DLQ',
+  'RABBITMQ_CALENDAR_SYNC_QUEUE',
+  'RABBITMQ_CALENDAR_SYNC_DLQ',
+  'DOSE_REMINDER_ENABLED',
+  'DOSE_REMINDER_WINDOW_DAYS',
+] as const;
+
+describe('config factories', () => {
+  const originalEnv: Partial<Record<string, string>> = {};
+
+  beforeAll(() => {
+    for (const key of MANAGED_ENV_KEYS) {
+      originalEnv[key] = process.env[key];
+    }
+  });
+
+  beforeEach(() => {
+    for (const key of MANAGED_ENV_KEYS) {
+      delete process.env[key];
+    }
+  });
+
+  afterAll(() => {
+    for (const key of MANAGED_ENV_KEYS) {
+      if (originalEnv[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = originalEnv[key];
+      }
+    }
+  });
+
+  describe('appConfig', () => {
+    it('should default to development with localhost CORS origins', () => {
+      const config = appConfig();
+
+      expect(config.nodeEnv).toBe('development');
+      expect(config.corsOrigins).toEqual([
+        'http://localhost:5173',
+        'http://localhost:3000',
+        'http://localhost:8081',
+        'http://localhost:19006',
+      ]);
+    });
+
+    it('should parse CORS_ORIGINS as a trimmed comma-separated list', () => {
+      process.env.NODE_ENV = 'production';
+      process.env.CORS_ORIGINS =
+        ' https://app.petcard.app , https://vet.petcard.app ,, ';
+
+      const config = appConfig();
+
+      expect(config.nodeEnv).toBe('production');
+      expect(config.corsOrigins).toEqual([
+        'https://app.petcard.app',
+        'https://vet.petcard.app',
+      ]);
+    });
+
+    it('should fall back to localhost origins when CORS_ORIGINS is blank outside production', () => {
+      process.env.CORS_ORIGINS = '   ';
+
+      const config = appConfig();
+
+      expect(config.corsOrigins).toContain('http://localhost:5173');
+    });
+
+    it('should throw in production when CORS_ORIGINS is missing', () => {
+      process.env.NODE_ENV = 'production';
+
+      expect(() => appConfig()).toThrow(
+        'CORS_ORIGINS is required in production',
+      );
+    });
+  });
+
+  describe('authConfig', () => {
+    it('should default jwtExpiresIn to 7d', () => {
+      process.env.JWT_SECRET = 'secret';
+
+      expect(authConfig()).toEqual({
+        jwtSecret: 'secret',
+        jwtExpiresIn: '7d',
+      });
+    });
+
+    it('should use JWT_EXPIRES_IN when set', () => {
+      process.env.JWT_EXPIRES_IN = '1h';
+
+      expect(authConfig().jwtExpiresIn).toBe('1h');
+    });
+  });
+
+  describe('awsConfig', () => {
+    it('should expose the AWS credentials from env', () => {
+      process.env.AWS_REGION = 'us-east-1';
+      process.env.AWS_ACCESS_KEY_ID = 'AKIA123';
+      process.env.AWS_SECRET_ACCESS_KEY = 'secret';
+      process.env.AWS_S3_BUCKET = 'petcard-uploads';
+
+      expect(awsConfig()).toEqual({
+        region: 'us-east-1',
+        accessKeyId: 'AKIA123',
+        secretAccessKey: 'secret',
+        bucket: 'petcard-uploads',
+      });
+    });
+  });
+
+  describe('cardConfig', () => {
+    it('should apply the public card defaults', () => {
+      expect(cardConfig()).toEqual({
+        publicBaseUrl: 'https://card.petcard.app/#',
+        publicThrottleTtlSeconds: 60,
+        publicThrottleLimit: 10,
+      });
+    });
+
+    it('should read overrides from env and coerce numbers', () => {
+      process.env.PUBLIC_CARD_BASE_URL = 'https://cards.example.com/#';
+      process.env.PUBLIC_CARD_THROTTLE_TTL_SECONDS = '120';
+      process.env.PUBLIC_CARD_THROTTLE_LIMIT = '5';
+
+      expect(cardConfig()).toEqual({
+        publicBaseUrl: 'https://cards.example.com/#',
+        publicThrottleTtlSeconds: 120,
+        publicThrottleLimit: 5,
+      });
+    });
+  });
+
+  describe('encryptionConfig', () => {
+    it('should expose the encryption key from env', () => {
+      process.env.ENCRYPTION_KEY = 'a'.repeat(64);
+
+      expect(encryptionConfig().key).toBe('a'.repeat(64));
+    });
+  });
+
+  describe('firebaseConfig', () => {
+    it('should default to disabled without requiring credentials', () => {
+      expect(firebaseConfig()).toEqual({
+        enabled: false,
+        projectId: undefined,
+        clientEmail: undefined,
+        privateKey: undefined,
+      });
+    });
+
+    it('should treat FCM_ENABLED=false as disabled', () => {
+      process.env.FCM_ENABLED = 'false';
+
+      expect(firebaseConfig().enabled).toBe(false);
+    });
+
+    it('should enable and unescape the private key when credentials are set', () => {
+      process.env.FCM_ENABLED = 'true';
+      process.env.FIREBASE_PROJECT_ID = 'petcard';
+      process.env.FIREBASE_CLIENT_EMAIL = 'sdk@petcard.iam.gserviceaccount.com';
+      process.env.FIREBASE_PRIVATE_KEY = '-----BEGIN\\nKEY-----';
+
+      expect(firebaseConfig()).toEqual({
+        enabled: true,
+        projectId: 'petcard',
+        clientEmail: 'sdk@petcard.iam.gserviceaccount.com',
+        privateKey: '-----BEGIN\nKEY-----',
+      });
+    });
+
+    it('should throw when enabled without complete credentials', () => {
+      process.env.FCM_ENABLED = 'true';
+      process.env.FIREBASE_PROJECT_ID = 'petcard';
+
+      expect(() => firebaseConfig()).toThrow(
+        'FCM_ENABLED=true requires FIREBASE_PROJECT_ID, FIREBASE_CLIENT_EMAIL and FIREBASE_PRIVATE_KEY to be set.',
+      );
+    });
+  });
+
+  describe('googleCalendarConfig', () => {
+    it('should default the redirect URI to localhost', () => {
+      expect(googleCalendarConfig().redirectUri).toBe(
+        'http://localhost:3000/calendar/callback',
+      );
+    });
+
+    it('should read the OAuth client from env', () => {
+      process.env.GOOGLE_CALENDAR_CLIENT_ID = 'client-id';
+      process.env.GOOGLE_CALENDAR_CLIENT_SECRET = 'client-secret';
+      process.env.GOOGLE_CALENDAR_REDIRECT_URI =
+        'https://api.petcard.app/calendar/callback';
+
+      expect(googleCalendarConfig()).toEqual({
+        clientId: 'client-id',
+        clientSecret: 'client-secret',
+        redirectUri: 'https://api.petcard.app/calendar/callback',
+      });
+    });
+  });
+
+  describe('googleMapsConfig', () => {
+    it('should expose the API key from env', () => {
+      process.env.GOOGLE_MAPS_API_KEY = 'maps-key';
+
+      expect(googleMapsConfig().apiKey).toBe('maps-key');
+    });
+  });
+
+  describe('rabbitmqConfig', () => {
+    it('should apply the local broker and queue defaults', () => {
+      expect(rabbitmqConfig()).toEqual({
+        url: 'amqp://petcard:petcard123@localhost:5672',
+        qrCodeQueue: 'qr-code.generate',
+        qrCodeDlq: 'qr-code.generate.dlq',
+        notificationPushQueue: 'notification.push',
+        notificationPushDlq: 'notification.push.dlq',
+        calendarSyncQueue: 'calendar.sync',
+        calendarSyncDlq: 'calendar.sync.dlq',
+      });
+    });
+
+    it('should read every queue name and URL from env', () => {
+      process.env.RABBITMQ_URL = 'amqp://user:pass@broker:5672';
+      process.env.RABBITMQ_QR_CODE_QUEUE = 'qr.custom';
+      process.env.RABBITMQ_QR_CODE_DLQ = 'qr.custom.dlq';
+      process.env.RABBITMQ_NOTIFICATION_PUSH_QUEUE = 'push.custom';
+      process.env.RABBITMQ_NOTIFICATION_PUSH_DLQ = 'push.custom.dlq';
+      process.env.RABBITMQ_CALENDAR_SYNC_QUEUE = 'calendar.custom';
+      process.env.RABBITMQ_CALENDAR_SYNC_DLQ = 'calendar.custom.dlq';
+
+      expect(rabbitmqConfig()).toEqual({
+        url: 'amqp://user:pass@broker:5672',
+        qrCodeQueue: 'qr.custom',
+        qrCodeDlq: 'qr.custom.dlq',
+        notificationPushQueue: 'push.custom',
+        notificationPushDlq: 'push.custom.dlq',
+        calendarSyncQueue: 'calendar.custom',
+        calendarSyncDlq: 'calendar.custom.dlq',
+      });
+    });
+  });
+
+  describe('reminderConfig', () => {
+    it('should default to enabled with a 3-day window', () => {
+      expect(reminderConfig()).toEqual({ enabled: true, windowDays: 3 });
+    });
+
+    it('should read the toggle and window from env', () => {
+      process.env.DOSE_REMINDER_ENABLED = 'false';
+      process.env.DOSE_REMINDER_WINDOW_DAYS = '7';
+
+      expect(reminderConfig()).toEqual({ enabled: false, windowDays: 7 });
+    });
+  });
+});

--- a/src/modules/card/__tests__/card.service.spec.ts
+++ b/src/modules/card/__tests__/card.service.spec.ts
@@ -202,6 +202,174 @@ describe('CardService', () => {
       });
     });
 
+    it('should map optional fields of every health record when present', async () => {
+      prisma.carteiraDigital.findUnique.mockResolvedValue(
+        makeCard({
+          pet: {
+            ...makeCard().pet,
+            vaccineRecords: [
+              {
+                id: 'v1',
+                petId: 'pet-1',
+                vaccineName: 'V8',
+                appliedAt: baseDate,
+                nextDoseAt: new Date('2026-05-01T10:00:00Z'),
+                veterinarianName: 'Dra. Camila',
+                notes: 'reforço anual',
+                createdAt: baseDate,
+                updatedAt: baseDate,
+              },
+            ],
+            dewormingRecords: [
+              {
+                id: 'd1',
+                petId: 'pet-1',
+                productName: 'Drontal',
+                appliedAt: baseDate,
+                nextDoseAt: new Date('2026-07-01T10:00:00Z'),
+                veterinarianName: 'Dra. Camila',
+                notes: 'dose única',
+                createdAt: baseDate,
+                updatedAt: baseDate,
+              },
+            ],
+            medicationRecords: [
+              {
+                id: 'm1',
+                petId: 'pet-1',
+                medicationName: 'Apoquel',
+                dosage: '16mg',
+                frequency: '1x ao dia',
+                startDate: baseDate,
+                endDate: new Date('2026-04-15T10:00:00Z'),
+                notes: 'com alimento',
+                createdAt: baseDate,
+                updatedAt: baseDate,
+              },
+            ],
+            notasClinicas: [
+              {
+                id: 'n1',
+                petId: 'pet-1',
+                veterinarioId: 'vet-1',
+                veterinario: { nome: 'Camila Ferreira', crmv: 'CRMV-SP 12345' },
+                googlePlaceId: 'place-123',
+                diagnostico: 'Dermatite',
+                prescricao: 'Apoquel 16mg',
+                observacoes: 'retorno em 15 dias',
+                createdAt: baseDate,
+                updatedAt: baseDate,
+              },
+            ],
+          },
+        }),
+      );
+
+      const result = await service.findPublicByToken('tok-abc');
+
+      expect(result.vaccines[0]).toMatchObject({
+        next_dose_at: '2026-05-01T10:00:00.000Z',
+        veterinarian_name: 'Dra. Camila',
+        notes: 'reforço anual',
+      });
+      expect(result.dewormings[0]).toMatchObject({
+        product_name: 'Drontal',
+        next_dose_at: '2026-07-01T10:00:00.000Z',
+        veterinarian_name: 'Dra. Camila',
+        notes: 'dose única',
+      });
+      expect(result.medications[0]).toMatchObject({
+        medication_name: 'Apoquel',
+        end_date: '2026-04-15T10:00:00.000Z',
+        notes: 'com alimento',
+      });
+      expect(result.clinical_notes[0]).toMatchObject({
+        veterinario_nome: 'Camila Ferreira',
+        veterinario_crmv: 'CRMV-SP 12345',
+        google_place_id: 'place-123',
+        prescricao: 'Apoquel 16mg',
+        observacoes: 'retorno em 15 dias',
+      });
+    });
+
+    it('should map absent optional fields to undefined', async () => {
+      prisma.carteiraDigital.findUnique.mockResolvedValue(
+        makeCard({
+          qrCodeUrl: null,
+          pet: {
+            ...makeCard().pet,
+            breed: null,
+            birthDate: null,
+            weight: null,
+            photoUrl: null,
+            dewormingRecords: [
+              {
+                id: 'd1',
+                petId: 'pet-1',
+                productName: 'Drontal',
+                appliedAt: baseDate,
+                nextDoseAt: null,
+                veterinarianName: null,
+                notes: null,
+                createdAt: baseDate,
+                updatedAt: baseDate,
+              },
+            ],
+            medicationRecords: [
+              {
+                id: 'm1',
+                petId: 'pet-1',
+                medicationName: 'Apoquel',
+                dosage: '16mg',
+                frequency: '1x ao dia',
+                startDate: baseDate,
+                endDate: null,
+                notes: null,
+                createdAt: baseDate,
+                updatedAt: baseDate,
+              },
+            ],
+            notasClinicas: [
+              {
+                id: 'n1',
+                petId: 'pet-1',
+                veterinarioId: 'vet-1',
+                veterinario: { nome: 'Camila Ferreira', crmv: 'CRMV-SP 12345' },
+                googlePlaceId: null,
+                diagnostico: 'Dermatite',
+                prescricao: null,
+                observacoes: null,
+                createdAt: baseDate,
+                updatedAt: baseDate,
+              },
+            ],
+          },
+        }),
+      );
+
+      const result = await service.findPublicByToken('tok-abc');
+
+      expect(result.breed).toBeUndefined();
+      expect(result.birth_date).toBeUndefined();
+      expect(result.weight).toBeUndefined();
+      expect(result.photo_url).toBeUndefined();
+      expect(result.qr_code_url).toBeUndefined();
+      expect(result.dewormings[0]).toMatchObject({
+        next_dose_at: undefined,
+        veterinarian_name: undefined,
+        notes: undefined,
+      });
+      expect(result.medications[0]).toMatchObject({
+        end_date: undefined,
+        notes: undefined,
+      });
+      expect(result.clinical_notes[0]).toMatchObject({
+        google_place_id: undefined,
+        prescricao: undefined,
+        observacoes: undefined,
+      });
+    });
+
     it('should throw NotFoundException for invalid token', async () => {
       prisma.carteiraDigital.findUnique.mockResolvedValue(null);
 


### PR DESCRIPTION
## O que muda

Fecha a dívida técnica apontada na [auditoria delta de 01/07](https://github.com/PetCardOrg/petcard-docs/blob/develop/docs/auditorias/2026-07-01-delta.md): statements/functions/lines já passavam de 80%, mas `branches: 74` ficava abaixo da meta de M6 (≥ 80% — DAS/PC-086).

## Como

- **`src/config/__tests__/config.spec.ts` (novo):** cobre as 10 factories de config, que estavam com 0% de branches (46 branches perdidas — o maior gap isolado). Inclui os comportamentos que valem contrato:
  - `CORS_ORIGINS` obrigatório em produção (falha rápida no boot);
  - `FCM_ENABLED=true` exige as três credenciais Firebase;
  - unescape de `\n` na private key;
  - defaults de fila/broker do RabbitMQ e do lembrete de dose.
- **`card.service.spec.ts`:** dois cenários novos em `findPublicByToken` — registros de saúde com todos os campos opcionais preenchidos e com todos ausentes — cobrindo os ramos `??`/`?.` dos mapeamentos de dewormings/medications/notas clínicas.

## Cobertura

| Métrica | Antes | Depois | Catraca |
|---|---|---|---|
| Statements | 82.08% | 85.33% | 81 → **84** |
| Branches | 75.33% | **81.33%** | 74 → **80** |
| Functions | 87.77% | 94.44% | 87 → **93** |
| Lines | 84.05% | 86.90% | 83 → **85** |

345 testes, 44 suites — `test:cov` verde com a catraca nova (validado em 4 execuções consecutivas).

## Checklist

- [x] `npm run test:cov` verde com o threshold elevado
- [x] `npm run lint` sem erros
- [x] Catraca só sobe, nunca desce