### PR TITLE
docs: PC-097 - Documentar API com Swagger/OpenAPI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,118 +1,99 @@
-# PetCard — Contexto para Claude Code (foco: Milestone 6 — Testes + QA)
+# PetCard — Contexto para Claude Code (foco: Milestone 7 — Documentação Final + Entrega TCC)
 
 ## Projeto
 
 PetCard — carteira digital de saúde para pets. TCC do Ricardo Temporal.
 Multirepo sob `PetCardOrg`:
 
-- `petcard-api` (NestJS + Prisma + Postgres + RabbitMQ + S3) — **maior superfície de teste desta milestone** (services, controllers, fluxos E2E)
-- `petcard-web` (SPA Vite + React) — **infra de teste nasce nesta milestone** (hoje sem nenhum teste)
-- `petcard-mobile` (React Native + Expo) — **infra de teste nasce nesta milestone** (hoje sem nenhum teste)
-- `petcard-shared` (npm `@petcardorg/shared` no GitHub Packages, **`0.9.0`**) — DTOs; sem issue de M6
-- `petcard-docs` (ADRs, board centralizado, documentação) — registrar decisões de QA/CI quando houver
+- `petcard-api` (NestJS + Prisma + Postgres + RabbitMQ + S3) — em M7: Swagger (PC-097), CD staging/produção (PC-092/093)
+- `petcard-web` (SPA Vite + React) — em M7: deploy Vercel (parte da PC-105) + screenshots/README (PC-096)
+- `petcard-mobile` (React Native + Expo) — em M7: screenshots/README (PC-096) e evidências dos UCs (PC-094)
+- `petcard-shared` (npm `@petcardorg/shared` no GitHub Packages, **`0.9.0`**) — sem issue de M7 além de release/CHANGELOG (PC-108)
+- `petcard-docs` (ADRs, board centralizado, documentação) — **concentra a M7**: 13 issues (relatório, slides, vídeo, deploy, release)
 
 **Equipe:** Álvaro Araújo (Backend), Camila Martins (DevOps/PM), Ricardo Temporal (Frontend Lead — atua na API desde M2).
 
-**Contexto de prazo:** a **Parte 1 do TCC já foi apresentada à banca**. A **Parte 2 vai até dezembro/2026** — há folga de tempo. M6 (testes/QA) e M7 (docs/deploy) são o trabalho da Parte 2. Trabalhar com qualidade, sem o regime de "reta final".
+**Contexto de prazo:** a **Parte 1 do TCC já foi apresentada à banca**. A **Parte 2 vai até dezembro/2026** — há folga de tempo. M7 é a última milestone: fecha a Parte 2 com documentação, deploy e entrega. Trabalhar com qualidade, sem regime de "reta final".
 
 ## Stack relevante
 
-- **Backend:** NestJS 11, Prisma 6, PostgreSQL 16 + PostGIS (PostGIS instalado mas sem uso após pivô para Google Places), AWS S3, RabbitMQ (filas com DLX/DLQ + retry). Redis provisionado no compose, **não consumido em código**.
-- **Web:** Vite + React 19 + TypeScript, `react-router-dom` v7, i18n (pt-BR + en-US). HTTP via `apiFetch` próprio (`src/services/api.ts`). Área autenticada do vet (login, rotas protegidas, sessão) entregue em M5: token em `localStorage` + React Context + `ProtectedRoute`.
+- **Backend:** NestJS 11, Prisma 6, PostgreSQL 16 + PostGIS (PostGIS instalado mas sem uso após pivô para Google Places), AWS S3, RabbitMQ (filas com DLX/DLQ + retry). Redis provisionado no compose, **não consumido em código** (item P3 da auditoria: manter só se a narrativa de defesa usar "capacidade reservada"; senão remover do compose).
+- **Web:** Vite + React 19 + TypeScript, `react-router-dom` v7, i18n (pt-BR + en-US). HTTP via `apiFetch` próprio (`src/services/api.ts`). Área autenticada do vet entregue em M5: token em `localStorage` + React Context + `ProtectedRoute`.
 - **Mobile:** React Native + Expo + TypeScript.
 - **Auth:** JWT próprio (HS256 + bcrypt), roles `TUTOR` e `VET`, discriminadas pelo claim `role` (logins separados `login`/`loginVeterinario`). Auth0 foi abandonado (M0-#7) — **não reintroduzir**. Sem refresh token.
-- **Shared:** DTOs em `@petcardorg/shared@0.9.0`. Após M5, api e web consomem os DTOs do vet/nota direto do shared (duplicação local removida). Resolver o pacote exige `NODE_AUTH_TOKEN` (PAT com `read:packages`).
+- **Shared:** DTOs em `@petcardorg/shared@0.9.0`. api e web consomem os DTOs direto do shared (duplicação local removida em M5). Resolver o pacote exige `NODE_AUTH_TOKEN` (PAT com `read:packages`).
 
 ## Status das milestones
 
-- **M0** ✅ Setup, GitHub Packages, ADR-001 multirepo, project board, ferramental (ESLint/Prettier/Husky/CI) nos 5 repos
-- **M1** ✅ Auth + CRUDs (Tutor, Pet, Vaccine, Deworming, Medication), upload S3, seed
-- **M2** ✅ Carteira Digital + QR Code (fila com retry/DLQ)
-- **M3** ✅ Geolocalização + Clínicas — via Google Places API (`GET /clinicas/places`); tabela `clinica` local + PostGIS descartada
-- **M4** ✅ Integrações Externas — Firebase push (FCM) + Google Calendar (unidirecional). Tokens OAuth cifrados em AES-256-GCM (`EncryptionService`)
-- **M5** ✅ Interface do Veterinário (Web) — escrita reversa (nota clínica) + dashboard do vet + login/rotas protegidas. ADR-003 Aceita. DTOs convergidos para o shared.
-- **M6** 🚧 **Testes + QA** — cobertura ≥ 80% na API, integração + E2E, e nascimento da camada de testes em web e mobile. Escopo e ordem abaixo
-- **M7** ⏳ Documentação Final + Deploy + Entrega TCC
+- **M0–M5** ✅ Setup → Auth/CRUDs → Carteira+QR → Geolocalização (Google Places) → Integrações (FCM + Google Calendar) → Interface do Vet
+- **M6** ✅ **Testes + QA — concluída em 2026-07-16** (milestones M0–M6 fechadas no GitHub nos 5 repos). Cobertura api **85.3/81.3/94.4/86.9** com catraca **84/80/93/85**; web ~82%; mobile ~15% (catraca 14/7/17/14 — telas pesadas são a próxima elevação); E2E contra Postgres real no CI; badges SVG auto-gerados nos 4 repos com código; 0 vulns de `npm audit` nos 5 repos.
+- **M7** 🚧 **Documentação Final + Deploy + Entrega TCC** — única milestone aberta. Escopo e ordem abaixo.
 
-## M6 — Testes + QA
+## M7 — Documentação Final + Entrega TCC
 
 ### Objetivo
 
-Levar o ecossistema a uma cobertura de testes confiável e automatizada no CI: subir a API de ~40% para **≥ 80%** com unit + integração + E2E, e **criar do zero** a camada de testes de web e mobile (hoje inexistente). O alvo é entregar a Parte 2 com QA verde e reproduzível.
-
-### Estado atual (linha de base)
-
-- **api:** 28 arquivos `*.spec.ts`. `coverageThreshold` rebaixado para **40/30/45/40** (statements/branches/functions/lines) — meta M6 é restaurar e subir até ≥ 80%. E2E roda por `test/jest-e2e.json` (`npm run test:e2e`). Jest configurado inline no `package.json`.
-- **web:** **0 testes, 0 infra** — sem Vitest/Jest, sem React Testing Library, sem jsdom. Tudo nasce em M6.
-- **mobile:** **0 testes, 0 infra** — sem runner, sem RN Testing Library. Tudo nasce em M6.
-- **shared:** sem issue de M6 (DTOs simples; testar só se algo concreto exigir).
+Entregar a Parte 2: API documentada (Swagger + Postman), sistema em produção (ECS + Vercel), evidências de QA (execução dos 16 UCs + screenshots), relatório ABNT + slides + vídeo, ADRs finais e release v1.0.0 nos 5 repos.
 
 ### Escopo por repositório
 
-**`petcard-api`** (milestone `M6 - Testes + QA`)
+**`petcard-api`** (milestone `M7 - Documentacao Final + Entrega TCC`)
 
-| Issue  | Título                                                 | Resumo                                                                     |
-| ------ | ------------------------------------------------------ | -------------------------------------------------------------------------- |
-| PC-086 | Testes unitários dos services (Jest) — cobertura ≥ 80% | Cobrir services mockando Prisma + clientes externos; subir o threshold     |
-| PC-087 | Testes de integração dos controllers (supertest)       | Controllers ponta-a-ponta com app Nest real + Prisma de teste              |
-| PC-088 | Testes E2E dos fluxos principais                       | Fluxos críticos (auth tutor/vet, pet, carteira, nota clínica) com Postgres |
-| PC-092 | Workflow de CD para staging (ECS Fargate)              | Deploy automatizado — **flavor de deploy, pode deslizar p/ M7**            |
-| PC-093 | Workflow de CD para produção (manual approval)         | Deploy com aprovação manual — **flavor de deploy, pode deslizar p/ M7**    |
+| Issue  | GitHub | Título                                         | Resumo                                                                          |
+| ------ | ------ | ---------------------------------------------- | ------------------------------------------------------------------------------- |
+| PC-097 | api#44 | Documentar API com Swagger/OpenAPI             | Decorators nos controllers; UI + schemas completos. **Quita o P3 da auditoria** |
+| PC-092 | api#42 | Workflow de CD para staging (ECS Fargate)      | Movida de M6 (decisão 2026-07-16); par da PC-105                                |
+| PC-093 | api#43 | Workflow de CD para produção (manual approval) | Movida de M6; depende da PC-092                                                 |
 
-> ⚠️ PC-092/PC-093 estão rotuladas em M6 no GitHub, mas são **CD/deploy** (par natural de M7 com `petcard-infra`/Terraform). Em M6 o foco real é testes (PC-086/087/088); tratar CD junto do deploy de M7, salvo decisão em contrário do Ricardo.
+**`petcard-docs`** (13 issues — board centralizado da entrega)
 
-**`petcard-web`**
-
-| Issue  | Título                                        | Resumo                                                                |
-| ------ | --------------------------------------------- | --------------------------------------------------------------------- |
-| PC-089 | Testes de componentes (React Testing Library) | Bootstrap de Vitest + RTL + jsdom; cobrir login, rotas e form de nota |
-
-**`petcard-mobile`**
-
-| Issue  | Título                                               | Resumo                                                          |
-| ------ | ---------------------------------------------------- | --------------------------------------------------------------- |
-| PC-090 | Testes de componentes (React Native Testing Library) | Bootstrap de jest-expo + RN Testing Library; cobrir telas-chave |
+| Issue  | GitHub  | Título                                                                                                                    |
+| ------ | ------- | ------------------------------------------------------------------------------------------------------------------------- |
+| PC-094 | docs#10 | Execução manual dos 16 UCs com evidências (re-escopada de M6; roteiro já entregue em `docs/qa/roteiro-testes-manuais.md`) |
+| PC-096 | docs#12 | READMEs finais com screenshots (badges já ok em todos)                                                                    |
+| PC-098 | docs#13 | Collection Postman com todos os endpoints                                                                                 |
+| PC-099 | docs#14 | Exportar diagramas finais do DAS em alta resolução                                                                        |
+| PC-100 | docs#15 | Capítulo de Metodologia (relatório TCC)                                                                                   |
+| PC-101 | docs#16 | Capítulo de Resultados e Discussão                                                                                        |
+| PC-102 | docs#17 | Capítulo de Conclusão                                                                                                     |
+| PC-103 | docs#18 | Revisar e formatar relatório final (ABNT)                                                                                 |
+| PC-104 | docs#19 | Apresentação de defesa (slides)                                                                                           |
+| PC-105 | docs#20 | Deploy final em produção (AWS ECS + Vercel)                                                                               |
+| PC-106 | docs#21 | Vídeo demonstrativo do sistema                                                                                            |
+| PC-107 | docs#22 | ADRs finais                                                                                                               |
+| PC-108 | docs#23 | Tag de release v1.0.0 + CHANGELOG em cada repo                                                                            |
 
 ### Ordem de execução ideal
 
-**Entre repositórios** (do mais alavancado/maduro ao mais novo):
+Quatro trilhas, da mais autocontida à mais dependente:
 
-1. **`petcard-api` primeiro.** Já tem Jest e a maior superfície de risco. É onde se firmam os padrões (mocks de Prisma, helpers de E2E, Postgres no CI) que servem de referência. Maior ganho de cobertura por esforço.
-2. **`petcard-web` em seguida.** Bootstrap da infra (Vitest + RTL) e PC-089. Independe da API, mas vem depois para reaproveitar as decisões de padrão de teste.
-3. **`petcard-mobile` por último.** Bootstrap (jest-expo + RN Testing Library) e PC-090. Menor acoplamento, maior atrito de tooling (Expo/Metro) — fazer com a infra de teste já amadurecida nos outros repos.
-4. **`petcard-shared`** não tem trabalho em M6.
+1. **Documentação da API** — PC-097 (Swagger) primeiro: autocontida, melhora a defesa, quita o P3 da auditoria. PC-098 (Postman) logo depois, aproveitando o OpenAPI pronto.
+2. **Deploy** — PC-092 (CD staging) → PC-093 (CD produção) → PC-105 (deploy final ECS + Vercel). Trilha da Camila (DevOps) por afinidade, mas sem dono rígido.
+3. **Evidências de QA** — PC-094 (executar os 16 UCs, idealmente contra staging já no ar) gera as evidências que alimentam PC-096 (screenshots nos READMEs) e PC-106 (vídeo demo, reusa o roteiro). Fazer depois do deploy para gravar contra ambiente real.
+4. **Texto e entrega** — PC-107 (ADRs) e PC-099 (diagramas DAS) primeiro (insumos do relatório); depois PC-100→101→102 (capítulos em ordem), PC-103 (ABNT), PC-104 (slides). **PC-108 (release v1.0.0 + CHANGELOG) é sempre a última**, com develop→main final nos 5 repos.
 
-**Dentro de `petcard-api`** (ordem dependente):
+As trilhas 1 e 2 são paralelizáveis; a 3 depende da 2; a 4 pode andar em paralelo mas fecha por último.
 
-1. **PC-086 — unit dos services.** Cobrir service a service mockando `PrismaService` e clientes externos (S3, Firebase, Google, RabbitMQ). A cada faixa de cobertura ganha, **subir o `coverageThreshold`** em degraus (nunca rebaixar) até ≥ 80%.
-2. **PC-087 — integração de controllers (supertest).** App Nest real com `ValidationPipe`, guards e DTOs do shared; Prisma apontando para um banco de teste. Valida wiring, RBAC (`@Auth`/`@Roles`) e contratos HTTP.
-3. **PC-088 — E2E dos fluxos principais.** Postgres real no CI (service container ou testcontainers), migrations aplicadas, fluxos: login tutor + login vet, CRUD de pet, carteira/QR, criação de nota clínica (escrita reversa). Reusar helpers de PC-087.
-4. **CI:** garantir `test`, `test:e2e` e `test:cov` no workflow com Postgres provisionado e o gate de cobertura. PC-092/093 (CD) só depois de tudo verde — preferencialmente em M7.
+### PC-097 — linha de base (levantada 2026-07-16)
 
-**Dentro de `petcard-web`** (PC-089):
+- `nest-cli.json` já tem `plugins: ["@nestjs/swagger"]` (CLI plugin infere tipos de DTOs/retornos).
+- `src/main.ts` já monta `DocumentBuilder` + `SwaggerModule.setup('docs', ...)` — UI em **`/docs`**.
+- ⚠️ O critério de aceite da issue diz `/api/docs`; o código serve em `/docs`. Alinhar com o Ricardo: mover a rota ou corrigir a issue.
+- **Zero decorators** (`@ApiTags/@ApiOperation/@ApiResponse/@ApiBearerAuth`) nos **15 controllers** (`find src -name "*.controller.ts"`). O trabalho é: tags por módulo, operation/response por endpoint (incl. códigos de erro), bearer auth nos protegidos, e conferir que DTOs do shared aparecem nos schemas.
 
-1. Bootstrap: adicionar Vitest + `@testing-library/react` + `@testing-library/jest-dom` + `jsdom`, script `test`, config (Vite `test` block) e setup file.
-2. Testar primeiro o que é crítico e estável: fluxo de **login**, **`ProtectedRoute`** (redirect sem token) e **submit do form de nota clínica** (validação client + chamada de service mockada).
-3. Subir gradualmente para dashboard e perfil do pet.
+### Padrões específicos de M7
 
-**Dentro de `petcard-mobile`** (PC-090):
-
-1. Bootstrap: `jest-expo` como preset + `@testing-library/react-native` + `jest` config; script `test`.
-2. Cobrir telas/fluxos-chave (ex.: carteira do pet, scanner, render das listas de saúde) com mocks de navegação e de chamadas de API.
-
-### Padrões específicos de M6
-
-- **Subir o piso, nunca abaixar.** O `coverageThreshold` da API é um catraca: a cada PR que melhora cobertura, elevar o floor no mesmo PR. Meta final 80/.../80.
-- **Banco de teste isolado.** Integração/E2E não tocam o banco de dev. Usar Postgres dedicado (service container no CI; local via compose com DB próprio) + migrations + reset entre suites. Nada de mock de Prisma em E2E — o objetivo é exercitar o caminho real.
-- **Determinismo.** Sem dependência de relógio/rede real. Mockar tempo onde a lógica depende de datas; clientes externos (S3, FCM, Google, RabbitMQ) sempre mockados em unit e integração.
-- **Reaproveitar fixtures/helpers.** Um único `createTestApp()` + factories de dados para api; um `renderWithProviders()` (router + i18n + context) para web/mobile. Não duplicar setup por arquivo.
-- **i18n no web/mobile.** Renderizar componentes dentro do provider de i18n; asserir por papel/rótulo acessível, não por string crua de um idioma.
-- **CI verde é o DoD.** Toda issue de M6 só fecha com o teste rodando no GitHub Actions, não só localmente.
+- **Evidência é entregável.** UC executado sem screenshot/registro não conta; planilha de execução do roteiro (`docs/qa/roteiro-testes-manuais.md`) é a fonte de verdade da PC-094.
+- **Contas do seed para demo/UCs:** tutores `ana.silva@example.com` / `bruno.costa@example.com`, vet `camila.ferreira@vet.example.com`, senha `petcard123`.
+- **Docs canônicos em `petcard-docs/docs/`** (tap.md, das.md, auditorias/, qa/) — editar lá via PR; a pasta local `tcc/docs/` foi removida, não recriar.
+- **Catracas de cobertura não abaixam** por causa de trabalho de M7 (api 84/80/93/85). Se um ajuste de código derrubar cobertura, cobrir junto.
+- **Deploy com aprovação manual em produção** (PC-093) — nunca CD direto para prod.
+- **Limitações conhecidas a declarar na demo/relatório:** Calendar unidirecional; alertas por janela de dose; push exige `FCM_ENABLED` + device físico.
 
 ## Padrões a seguir (gerais)
 
-- **Investigar antes de codar.** Ler o módulo/serviço alvo e seus testes vizinhos antes de escrever novos. No api, espelhar o estilo dos `*.spec.ts` existentes (ex.: `pet.service.spec.ts`, módulo de notificação).
-- **DTOs no `@petcardorg/shared`.** Toda request/response nova vai como DTO no shared (bump minor + publish), consumida por api/web/mobile. Em M5 a duplicação local foi removida — não reintroduzir DTOs locais que já existem no shared.
+- **Investigar antes de codar.** Ler o módulo/serviço alvo e seus testes vizinhos antes de escrever novos.
+- **DTOs no `@petcardorg/shared`.** Toda request/response nova vai como DTO no shared (bump minor + publish). Não reintroduzir DTOs locais que já existem no shared.
 - **Testes.** Unit para services (mock de Prisma + externos), integração para controllers (supertest), E2E para fluxos. Cobertura é catraca crescente.
 - **Migrations.** `npx prisma migrate dev --name <descricao_snake_case>`. Para SQL fora do Prisma, `--create-only` + edição manual.
 - **Auth (api).** `@Auth()` + `@Roles(Role.VET)`/`Role.TUTOR`; usuário via `@CurrentUser()` — nunca ler claim JWT direto no controller.
@@ -122,25 +103,26 @@ Levar o ecossistema a uma cobertura de testes confiável e automatizada no CI: s
 ## Convenções gerais
 
 - **Branches:** `feat/pc-XXX-descricao`, `fix/pc-XXX-...`, `chore/...`, `test/pc-XXX-...`, `docs/...`
-- **Commits:** Conventional Commits (`test(vet): cobrir VetNoteService`)
+- **Commits:** Conventional Commits (`docs(api): PC-097 - decorators Swagger nos controllers`)
 - **PRs:** mirar `develop`; título `tipo: PC-XXX - Descrição`, com checklist de DoD
 - **DTOs compartilhados:** sempre em `@petcardorg/shared`, bump minor para feature, patch para fix de tipo
 - **ADRs:** decisões arquiteturais relevantes em `petcard-docs/architecture/adr/` antes de mergear
+- **Recorrente:** `main` fica para trás de `develop` — mergear develop→main a cada marco (PR head=develop base=main). Antes, verificar que main não tem commit de conteúdo exclusivo (`git log --no-merges origin/develop..origin/main`).
 
 ## Princípios de trabalho
 
-- **YAGNI.** Não montar infra de teste além do necessário (sem E2E de browser real no web se RTL cobre; sem testcontainers se service container do Actions resolve).
-- **Reutilizar antes de criar.** Antes de novo helper/factory, procurar equivalente no repo e nos outros.
-- **Falha de serviço externo não derruba a API.** Manter os caminhos de degradação cobertos por teste (ex.: push falho não invalida criação de nota).
-- **Validação na borda.** `ValidationPipe` global + `class-validator` nos DTOs; cobrir os casos de rejeição nos testes de integração.
+- **YAGNI.** Documentar/deployar o que existe; sem infra nova além do necessário para PC-092/093/105.
+- **Reutilizar antes de criar.** O roteiro de UCs, o DAS e as auditorias já existem — o relatório e o vídeo os consomem, não os recriam.
+- **CI verde é o DoD.** Issue de M7 com código só fecha com o CI passando; issue de doc só fecha com o artefato versionado no petcard-docs.
+- **Board sincronizado com o código.** Fechar issue no merge, referenciando commit/PR — o board já dessincronizou mais de uma vez (PC-070, PC-110).
 
 ## Escopo fora desta milestone (não fazer agora)
 
-- Reintroduzir Auth0 (abandonado em M0-#7) ou DTOs locais já no shared
-- Deploy de produção / `petcard-infra` / Terraform e o relatório/slides da Parte 2 (é M7; PC-092/093 vão junto)
+- Features novas de produto (M7 é documentação, deploy e entrega)
+- Reintroduzir Auth0, DTOs locais já no shared, ou tabela `clinica` local + PostGIS
 - Sync bidirecional do Google Calendar (PC-065, futuro)
-- Reintroduzir tabela `clinica` local + PostGIS (descartado em 2026-05-12)
-- Refactors amplos não relacionados a teste/QA
+- Elevar cobertura do mobile além da catraca atual (registrado como próxima elevação, não é M7)
+- Refactors amplos não relacionados à entrega
 
 ## Ambiente de desenvolvimento
 
@@ -148,35 +130,31 @@ Levar o ecossistema a uma cobertura de testes confiável e automatizada no CI: s
 - Web: `npm run dev` (Vite :5173). `VITE_API_URL` aponta para a API (default `http://localhost:3000`)
 - Resolver `@petcardorg/shared` do GitHub Packages exige `NODE_AUTH_TOKEN` (PAT com `read:packages`)
 - API obriga `CORS_ORIGINS` em produção; em dev usa defaults de localhost (Vite :5173, API :3000, Expo :8081/:19006)
-- Swagger/OpenAPI da API em `GET /docs` (M5/PC-097)
+- Swagger/OpenAPI da API em `GET /docs`
 
 ## Comandos úteis
 
 ```bash
-# API — testes
+# API
 npm test                       # unit (jest, *.spec.ts)
-npm run test:cov               # com cobertura (verifica o coverageThreshold)
+npm run test:cov               # com cobertura (verifica a catraca 84/80/93/85)
 npm run test:e2e               # E2E (test/jest-e2e.json) — precisa de Postgres
-docker compose -f docker/docker-compose.yml up -d   # subir Postgres/RabbitMQ para E2E local
-npx prisma migrate deploy      # aplicar migrations no banco de teste
+npm run start:dev              # Swagger UI em http://localhost:3000/docs
+docker compose -f docker/docker-compose.yml up -d   # Postgres/RabbitMQ locais
 
-# Web (no petcard-web) — após bootstrap de Vitest
-npm test
-npm run build                  # tsc -b && vite build
-npm run lint
+# Web / Mobile
+npm test                       # vitest (web) / jest-expo (mobile)
+npm run build                  # web: tsc -b && vite build
 
-# Mobile (no petcard-mobile) — após bootstrap de jest-expo
-npm test
-npm run typecheck
-
-# Issues da M6 (por repo)
-gh issue list --repo PetCardOrg/petcard-api    --milestone "M6 - Testes + QA" --state all
-gh issue list --repo PetCardOrg/petcard-web    --milestone "M6 - Testes + QA" --state all
-gh issue list --repo PetCardOrg/petcard-mobile --milestone "M6 - Testes + QA" --state all
+# Issues da M7 (por repo)
+gh issue list --repo PetCardOrg/petcard-api  --milestone "M7 - Documentacao Final + Entrega TCC" --state all
+gh issue list --repo PetCardOrg/petcard-docs --milestone "M7 - Documentacao Final + Entrega TCC" --state all
 ```
 
 ## Última atualização
 
-2026-06-19 — **PC-088 (E2E dos fluxos principais) concluída.** Suíte E2E reescrita contra **Postgres real** (mockando só infra externa). Causa raiz do e2e antigo quebrado: o boot do `AppModule` conectava no RabbitMQ (`RabbitMqTopologyService.onModuleInit`) e no banco (`PrismaService.$connect`); os specs antigos (`cruds-mvp1`/`cards-public`/`devices`) ainda mockavam Prisma (integração disfarçada, já coberta por PC-087) e foram **removidos**. Nova infra em `test/utils/e2e-app.ts` (`createE2EApp()` sobe o AppModule real, faz override de `RabbitMqTopologyService`→no-op e dos 3 publishers de fila→mock, Prisma real) + `test/utils/e2e-db.ts` (`resetDb` via `TRUNCATE … CASCADE`, helpers `registerTutor`/`createAndLoginVet`) + `test/e2e/setup-env.ts` (defaults de env, `??=`) + `test/e2e/global-setup.ts` (`prisma migrate deploy`). Fluxos cobertos (24 testes, 5 suites): auth tutor/vet com **JWT real**, CRUD de pet + prontuário, nota clínica (escrita reversa + device/push), carteira pública por token, smoke. `test:e2e` agora roda `--runInBand` (banco compartilhado). CI (`ci.yml`) ganhou **service container Postgres** e passo `npm run test:e2e`. Local: `docker compose -f docker/docker-compose.yml up -d postgres` + DB `petcard_test` (o `globalSetup` aplica as migrations). Unit segue 322 verde; cobertura intacta (e2e roda em config separado, fora da catraca). **Frente de testes da API encerrada** (PC-086 unit + PC-087 integração + PC-088 e2e). Próximo: web PC-089 (Vitest+RTL).
+2026-07-16 — **Início da M7 (Documentação Final + Entrega TCC).** CLAUDE.md refocado de M6 para M7. M6 concluída e milestones M0–M6 fechadas no GitHub nos 5 repos: cobertura api 85.3/81.3/94.4/86.9 (catraca 84/80/93/85, dívida "branches ≥80" quitada via api#104 — `src/config/__tests__/config.spec.ts` + opcionais do card.service), web ~82%, mobile ~15%, badges SVG auto-gerados, 0 vulns. Backlog P2 da auditoria delta todo concluído (commit 8c4acd9 no docs); restam 2 P3 que vivem dentro da M7 (Swagger→PC-097; Redis sem uso→decisão na narrativa da defesa). Escopo de M7 levantado das issues reais: api PC-097/092/093; docs PC-094 (execução dos UCs, re-escopada de M6), PC-096, PC-098–108. Ordem definida em 4 trilhas (docs da API → deploy → evidências de QA → texto/entrega; release v1.0.0 por último). Primeira issue em execução: **PC-097** (linha de base: plugin + UI em `/docs` ativos, zero decorators nos 15 controllers; divergência `/docs` vs `/api/docs` do critério de aceite a alinhar).
 
-2026-06-17 — **Início da M6 (Testes + QA).** CLAUDE.md refocado de M5 para M6. M5 marcada concluída (escrita reversa, dashboard do vet, login/rotas protegidas, ADR-003 Aceita, DTOs convergidos para o shared, Swagger em `/docs`). Escopo de M6 levantado das issues reais: api PC-086 (unit ≥80%), PC-087 (integração/supertest), PC-088 (E2E); web PC-089 (RTL); mobile PC-090 (RN Testing Library); PC-092/093 (CD) ficam rotuladas em M6 mas são deploy (par de M7). Linha de base registrada: api com 28 specs e threshold 40/30/45/40; web e mobile **sem nenhuma infra de teste**. Ordem de execução ideal definida — entre repos (api → web → mobile; shared sem trabalho) e dentro da api (PC-086 → PC-087 → PC-088 → CI/cobertura). Contexto de prazo: Parte 1 já apresentada, Parte 2 até dezembro/2026.
+2026-06-19 — **PC-088 (E2E dos fluxos principais) concluída.** Suíte E2E reescrita contra Postgres real (mockando só infra externa); infra em `test/utils/e2e-app.ts` + `test/utils/e2e-db.ts`; 24 testes/5 suites; CI com service container Postgres. Frente de testes da API encerrada (PC-086/087/088).
+
+2026-06-17 — **Início da M6 (Testes + QA).** Linha de base: api com 28 specs e threshold 40/30/45/40; web e mobile sem infra de teste. Ordem entre repos api → web → mobile executada conforme planejado.

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,11 +1,14 @@
 import { Controller, Get } from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { AppService } from './app.service';
 
+@ApiTags('health')
 @Controller()
 export class AppController {
   constructor(private readonly appService: AppService) {}
 
   @Get()
+  @ApiOperation({ summary: 'Health check da API' })
   getHello(): string {
     return this.appService.getHello();
   }

--- a/src/modules/appointment/appointment.controller.ts
+++ b/src/modules/appointment/appointment.controller.ts
@@ -10,6 +10,12 @@ import {
   Post,
   Query,
 } from '@nestjs/common';
+import {
+  ApiNotFoundResponse,
+  ApiOperation,
+  ApiQuery,
+  ApiTags,
+} from '@nestjs/swagger';
 import { Auth } from '../auth/decorators/auth.decorator';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { Role } from '../auth/enums/role.enum';
@@ -18,12 +24,16 @@ import { AppointmentResponse, AppointmentService } from './appointment.service';
 import { CreateAppointmentDto } from './dto/create-appointment.dto';
 import { UpdateAppointmentDto } from './dto/update-appointment.dto';
 
+@ApiTags('appointments')
 @Controller('appointments')
 export class AppointmentController {
   constructor(private readonly appointmentService: AppointmentService) {}
 
   @Post()
   @Auth(Role.TUTOR)
+  @ApiOperation({
+    summary: 'Agendar compromisso do pet (sincroniza com Google Calendar)',
+  })
   async create(
     @CurrentUser() user: JwtPayload,
     @Body() dto: CreateAppointmentDto,
@@ -33,6 +43,12 @@ export class AppointmentController {
 
   @Get()
   @Auth(Role.TUTOR)
+  @ApiOperation({ summary: 'Listar compromissos do tutor autenticado' })
+  @ApiQuery({
+    name: 'upcoming',
+    required: false,
+    description: "Se 'true', retorna apenas compromissos futuros",
+  })
   async findAll(
     @CurrentUser() user: JwtPayload,
     @Query('upcoming') upcoming?: string,
@@ -45,6 +61,8 @@ export class AppointmentController {
 
   @Get(':id')
   @Auth(Role.TUTOR)
+  @ApiOperation({ summary: 'Buscar compromisso por id' })
+  @ApiNotFoundResponse({ description: 'Compromisso não encontrado' })
   async findOne(
     @Param('id') id: string,
     @CurrentUser() user: JwtPayload,
@@ -54,6 +72,8 @@ export class AppointmentController {
 
   @Patch(':id')
   @Auth(Role.TUTOR)
+  @ApiOperation({ summary: 'Atualizar compromisso' })
+  @ApiNotFoundResponse({ description: 'Compromisso não encontrado' })
   async update(
     @Param('id') id: string,
     @CurrentUser() user: JwtPayload,
@@ -65,6 +85,8 @@ export class AppointmentController {
   @Delete(':id')
   @Auth(Role.TUTOR)
   @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Cancelar compromisso' })
+  @ApiNotFoundResponse({ description: 'Compromisso não encontrado' })
   async remove(
     @Param('id') id: string,
     @CurrentUser() user: JwtPayload,

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -1,4 +1,11 @@
 import { Body, Controller, Get, Post, UseGuards } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiConflictResponse,
+  ApiOperation,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
 import { AuthService } from './auth.service';
 import { CurrentUser } from './decorators/current-user.decorator';
 import { LoginDto } from './dto/login.dto';
@@ -8,33 +15,44 @@ import { Role } from './enums/role.enum';
 import { JwtAuthGuard } from './guards/jwt-auth.guard';
 import type { JwtPayload } from './strategies/jwt.strategy';
 
+@ApiTags('auth')
 @Controller('auth')
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
   @Post('register')
+  @ApiOperation({ summary: 'Registrar novo tutor' })
+  @ApiConflictResponse({ description: 'Email já cadastrado' })
   register(@Body() dto: RegisterDto) {
     return this.authService.register(dto);
   }
 
   @Post('login')
+  @ApiOperation({ summary: 'Login do tutor (JWT com role TUTOR)' })
+  @ApiUnauthorizedResponse({ description: 'Credenciais inválidas' })
   login(@Body() dto: LoginDto) {
     return this.authService.login(dto);
   }
 
   @Get('profile')
   @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Payload do JWT do usuário autenticado' })
+  @ApiUnauthorizedResponse({ description: 'Token ausente ou inválido' })
   getProfile(@CurrentUser() user: JwtPayload): JwtPayload {
     return user;
   }
 
   @Post('veterinario/login')
+  @ApiOperation({ summary: 'Login do veterinário (JWT com role VET)' })
+  @ApiUnauthorizedResponse({ description: 'Credenciais inválidas' })
   loginVeterinario(@Body() dto: LoginDto) {
     return this.authService.loginVeterinario(dto);
   }
 
   @Get('veterinario/profile')
   @Auth(Role.VET)
+  @ApiOperation({ summary: 'Perfil do veterinário autenticado' })
   getVeterinarioProfile(@CurrentUser() user: JwtPayload) {
     return this.authService.getVeterinarioProfile(user.sub);
   }

--- a/src/modules/auth/decorators/auth.decorator.ts
+++ b/src/modules/auth/decorators/auth.decorator.ts
@@ -1,8 +1,23 @@
 import { applyDecorators, UseGuards } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiForbiddenResponse,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
 import { JwtAuthGuard } from '../guards/jwt-auth.guard';
 import { RolesGuard } from '../guards/roles.guard';
 import { Role } from '../enums/role.enum';
 import { Roles } from './roles.decorator';
 
 export const Auth = (...roles: Role[]): ReturnType<typeof applyDecorators> =>
-  applyDecorators(Roles(...roles), UseGuards(JwtAuthGuard, RolesGuard));
+  applyDecorators(
+    Roles(...roles),
+    UseGuards(JwtAuthGuard, RolesGuard),
+    ApiBearerAuth(),
+    ApiUnauthorizedResponse({ description: 'Token ausente ou inválido' }),
+    ApiForbiddenResponse({
+      description: roles.length
+        ? `Requer papel ${roles.join(' ou ')}`
+        : 'Papel sem permissão para este recurso',
+    }),
+  );

--- a/src/modules/calendar/calendar.controller.ts
+++ b/src/modules/calendar/calendar.controller.ts
@@ -9,6 +9,12 @@ import {
   Res,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import {
+  ApiExcludeEndpoint,
+  ApiOperation,
+  ApiQuery,
+  ApiTags,
+} from '@nestjs/swagger';
 import type { Response } from 'express';
 import { Auth } from '../auth/decorators/auth.decorator';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
@@ -16,6 +22,7 @@ import { Role } from '../auth/enums/role.enum';
 import type { JwtPayload } from '../auth/strategies/jwt.strategy';
 import { GoogleCalendarService } from './google-calendar.service';
 
+@ApiTags('calendar')
 @Controller('calendar')
 export class CalendarController {
   constructor(
@@ -25,6 +32,9 @@ export class CalendarController {
 
   @Get('connect')
   @Auth(Role.TUTOR)
+  @ApiOperation({
+    summary: 'Obter URL de autorização OAuth do Google Calendar',
+  })
   connect(@CurrentUser() user: JwtPayload) {
     const url = this.googleCalendarService.getAuthUrl(user.sub);
     if (!url) {
@@ -37,6 +47,11 @@ export class CalendarController {
   }
 
   @Get('callback')
+  @ApiOperation({
+    summary: 'Callback OAuth do Google (redirecionamento do consentimento)',
+  })
+  @ApiQuery({ name: 'code', description: 'Código de autorização do Google' })
+  @ApiQuery({ name: 'state', description: 'Id do tutor originador do fluxo' })
   async callback(
     @Query('code') code: string,
     @Query('state') tutorId: string,
@@ -49,6 +64,7 @@ export class CalendarController {
   }
 
   @Get('dev-connect')
+  @ApiExcludeEndpoint()
   devConnect(@Res() res: Response) {
     if (this.configService.get('NODE_ENV') !== 'development') {
       res.status(404).send('Not found');
@@ -110,6 +126,7 @@ async function login() {
 
   @Get('status')
   @Auth(Role.TUTOR)
+  @ApiOperation({ summary: 'Status da conexão com o Google Calendar' })
   async status(@CurrentUser() user: JwtPayload) {
     const connected = await this.googleCalendarService.isConnected(user.sub);
     return { connected };
@@ -118,12 +135,18 @@ async function login() {
   @Delete('disconnect')
   @Auth(Role.TUTOR)
   @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({
+    summary: 'Desconectar Google Calendar (remove tokens do tutor)',
+  })
   async disconnect(@CurrentUser() user: JwtPayload) {
     await this.googleCalendarService.disconnect(user.sub);
   }
 
   @Post('sync')
   @Auth(Role.TUTOR)
+  @ApiOperation({
+    summary: 'Sincronizar compromissos pendentes com o Google Calendar',
+  })
   async sync(@CurrentUser() user: JwtPayload) {
     const count = await this.googleCalendarService.syncAllPending(user.sub);
     return { synced: count };

--- a/src/modules/card/card.controller.ts
+++ b/src/modules/card/card.controller.ts
@@ -1,6 +1,13 @@
 import { Controller, Get, Param, UseGuards } from '@nestjs/common';
 import { Throttle, ThrottlerGuard } from '@nestjs/throttler';
 import {
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+  ApiTooManyRequestsResponse,
+} from '@nestjs/swagger';
+import {
   CarteiraDigitalPublicResponseDto,
   CarteiraDigitalResponseDto,
 } from '@petcardorg/shared';
@@ -10,12 +17,16 @@ import { Role } from '../auth/enums/role.enum';
 import type { JwtPayload } from '../auth/strategies/jwt.strategy';
 import { CardService } from './card.service';
 
+@ApiTags('cards')
 @Controller('cards')
 export class CardController {
   constructor(private readonly cardService: CardService) {}
 
   @Get('pets/:petId')
   @Auth(Role.TUTOR)
+  @ApiOperation({ summary: 'Carteira digital do pet (visão do tutor dono)' })
+  @ApiOkResponse({ type: CarteiraDigitalResponseDto })
+  @ApiNotFoundResponse({ description: 'Pet não encontrado' })
   async getCardByPetId(
     @Param('petId') petId: string,
     @CurrentUser() user: JwtPayload,
@@ -26,6 +37,12 @@ export class CardController {
   @Get(':token')
   @UseGuards(ThrottlerGuard)
   @Throttle({ 'public-card': {} })
+  @ApiOperation({
+    summary: 'Carteira pública por token do QR Code (sem autenticação)',
+  })
+  @ApiOkResponse({ type: CarteiraDigitalPublicResponseDto })
+  @ApiNotFoundResponse({ description: 'Carteira não encontrada' })
+  @ApiTooManyRequestsResponse({ description: 'Limite de requisições excedido' })
   async getPublicCard(
     @Param('token') token: string,
   ): Promise<CarteiraDigitalPublicResponseDto> {

--- a/src/modules/clinica/clinica.controller.ts
+++ b/src/modules/clinica/clinica.controller.ts
@@ -1,5 +1,12 @@
 import { Controller, Get, Query } from '@nestjs/common';
 import {
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiQuery,
+  ApiTags,
+} from '@nestjs/swagger';
+import {
   FindNearbyPlacesQueryDto,
   GeocodeResponseDto,
   PlacesClinicResponseDto,
@@ -9,6 +16,7 @@ import { Role } from '../auth/enums/role.enum';
 import { GeocodingService } from './geocoding.service';
 import { PlacesService } from './places.service';
 
+@ApiTags('clinicas')
 @Controller('clinicas')
 export class ClinicaController {
   constructor(
@@ -18,6 +26,10 @@ export class ClinicaController {
 
   @Get('places')
   @Auth(Role.TUTOR, Role.VET)
+  @ApiOperation({
+    summary: 'Buscar clínicas veterinárias próximas (Google Places)',
+  })
+  @ApiOkResponse({ type: PlacesClinicResponseDto, isArray: true })
   async findNearbyPlaces(
     @Query() query: FindNearbyPlacesQueryDto,
   ): Promise<PlacesClinicResponseDto[]> {
@@ -32,6 +44,10 @@ export class ClinicaController {
 
   @Get('geocode')
   @Auth(Role.TUTOR, Role.VET)
+  @ApiOperation({ summary: 'Geocodificar endereço em lat/lng' })
+  @ApiOkResponse({ type: GeocodeResponseDto })
+  @ApiQuery({ name: 'address', description: 'Endereço a geocodificar' })
+  @ApiNotFoundResponse({ description: 'Endereço não encontrado' })
   async geocode(
     @Query('address') address: string,
   ): Promise<GeocodeResponseDto> {

--- a/src/modules/health/deworming/deworming.controller.ts
+++ b/src/modules/health/deworming/deworming.controller.ts
@@ -10,6 +10,13 @@ import {
   Post,
 } from '@nestjs/common';
 import {
+  ApiCreatedResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
+import {
   CreateDewormingRecordDto,
   DewormingRecordResponseDto,
   UpdateDewormingRecordDto,
@@ -20,12 +27,16 @@ import { Role } from '../../auth/enums/role.enum';
 import type { JwtPayload } from '../../auth/strategies/jwt.strategy';
 import { DewormingService } from './deworming.service';
 
+@ApiTags('dewormings')
 @Controller()
 export class DewormingController {
   constructor(private readonly dewormingService: DewormingService) {}
 
   @Post('pets/:petId/dewormings')
   @Auth(Role.TUTOR, Role.VET)
+  @ApiOperation({ summary: 'Registrar vermífugo no prontuário do pet' })
+  @ApiCreatedResponse({ type: DewormingRecordResponseDto })
+  @ApiNotFoundResponse({ description: 'Pet não encontrado' })
   async create(
     @Param('petId') petId: string,
     @CurrentUser() user: JwtPayload,
@@ -37,6 +48,9 @@ export class DewormingController {
 
   @Get('pets/:petId/dewormings')
   @Auth(Role.TUTOR, Role.VET)
+  @ApiOperation({ summary: 'Listar vermífugos do pet' })
+  @ApiOkResponse({ type: DewormingRecordResponseDto, isArray: true })
+  @ApiNotFoundResponse({ description: 'Pet não encontrado' })
   async findAll(
     @Param('petId') petId: string,
     @CurrentUser() user: JwtPayload,
@@ -47,6 +61,9 @@ export class DewormingController {
 
   @Patch('dewormings/:id')
   @Auth(Role.TUTOR, Role.VET)
+  @ApiOperation({ summary: 'Atualizar registro de vermífugo' })
+  @ApiOkResponse({ type: DewormingRecordResponseDto })
+  @ApiNotFoundResponse({ description: 'Registro não encontrado' })
   async update(
     @Param('id') id: string,
     @CurrentUser() user: JwtPayload,
@@ -59,6 +76,8 @@ export class DewormingController {
   @Delete('dewormings/:id')
   @Auth(Role.TUTOR)
   @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Remover registro de vermífugo' })
+  @ApiNotFoundResponse({ description: 'Registro não encontrado' })
   async remove(
     @Param('id') id: string,
     @CurrentUser() user: JwtPayload,

--- a/src/modules/health/medication/medication.controller.ts
+++ b/src/modules/health/medication/medication.controller.ts
@@ -10,6 +10,13 @@ import {
   Post,
 } from '@nestjs/common';
 import {
+  ApiCreatedResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
+import {
   CreateMedicationRecordDto,
   MedicationRecordResponseDto,
   UpdateMedicationRecordDto,
@@ -20,12 +27,16 @@ import { Role } from '../../auth/enums/role.enum';
 import type { JwtPayload } from '../../auth/strategies/jwt.strategy';
 import { MedicationService } from './medication.service';
 
+@ApiTags('medications')
 @Controller()
 export class MedicationController {
   constructor(private readonly medicationService: MedicationService) {}
 
   @Post('pets/:petId/medications')
   @Auth(Role.TUTOR, Role.VET)
+  @ApiOperation({ summary: 'Registrar medicação no prontuário do pet' })
+  @ApiCreatedResponse({ type: MedicationRecordResponseDto })
+  @ApiNotFoundResponse({ description: 'Pet não encontrado' })
   async create(
     @Param('petId') petId: string,
     @CurrentUser() user: JwtPayload,
@@ -37,6 +48,9 @@ export class MedicationController {
 
   @Get('pets/:petId/medications')
   @Auth(Role.TUTOR, Role.VET)
+  @ApiOperation({ summary: 'Listar medicações do pet' })
+  @ApiOkResponse({ type: MedicationRecordResponseDto, isArray: true })
+  @ApiNotFoundResponse({ description: 'Pet não encontrado' })
   async findAll(
     @Param('petId') petId: string,
     @CurrentUser() user: JwtPayload,
@@ -47,6 +61,9 @@ export class MedicationController {
 
   @Patch('medications/:id')
   @Auth(Role.TUTOR, Role.VET)
+  @ApiOperation({ summary: 'Atualizar registro de medicação' })
+  @ApiOkResponse({ type: MedicationRecordResponseDto })
+  @ApiNotFoundResponse({ description: 'Registro não encontrado' })
   async update(
     @Param('id') id: string,
     @CurrentUser() user: JwtPayload,
@@ -59,6 +76,8 @@ export class MedicationController {
   @Delete('medications/:id')
   @Auth(Role.TUTOR)
   @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Remover registro de medicação' })
+  @ApiNotFoundResponse({ description: 'Registro não encontrado' })
   async remove(
     @Param('id') id: string,
     @CurrentUser() user: JwtPayload,

--- a/src/modules/health/vaccine/vaccine.controller.ts
+++ b/src/modules/health/vaccine/vaccine.controller.ts
@@ -10,6 +10,13 @@ import {
   Post,
 } from '@nestjs/common';
 import {
+  ApiCreatedResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
+import {
   CreateVaccineRecordDto,
   UpdateVaccineRecordDto,
   VaccineRecordResponseDto,
@@ -20,12 +27,16 @@ import { Role } from '../../auth/enums/role.enum';
 import type { JwtPayload } from '../../auth/strategies/jwt.strategy';
 import { VaccineService } from './vaccine.service';
 
+@ApiTags('vaccines')
 @Controller()
 export class VaccineController {
   constructor(private readonly vaccineService: VaccineService) {}
 
   @Post('pets/:petId/vaccines')
   @Auth(Role.TUTOR, Role.VET)
+  @ApiOperation({ summary: 'Registrar vacina no prontuário do pet' })
+  @ApiCreatedResponse({ type: VaccineRecordResponseDto })
+  @ApiNotFoundResponse({ description: 'Pet não encontrado' })
   async create(
     @Param('petId') petId: string,
     @CurrentUser() user: JwtPayload,
@@ -37,6 +48,9 @@ export class VaccineController {
 
   @Get('pets/:petId/vaccines')
   @Auth(Role.TUTOR, Role.VET)
+  @ApiOperation({ summary: 'Listar vacinas do pet' })
+  @ApiOkResponse({ type: VaccineRecordResponseDto, isArray: true })
+  @ApiNotFoundResponse({ description: 'Pet não encontrado' })
   async findAll(
     @Param('petId') petId: string,
     @CurrentUser() user: JwtPayload,
@@ -47,6 +61,9 @@ export class VaccineController {
 
   @Patch('vaccines/:id')
   @Auth(Role.TUTOR, Role.VET)
+  @ApiOperation({ summary: 'Atualizar registro de vacina' })
+  @ApiOkResponse({ type: VaccineRecordResponseDto })
+  @ApiNotFoundResponse({ description: 'Registro não encontrado' })
   async update(
     @Param('id') id: string,
     @CurrentUser() user: JwtPayload,
@@ -59,6 +76,8 @@ export class VaccineController {
   @Delete('vaccines/:id')
   @Auth(Role.TUTOR)
   @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Remover registro de vacina' })
+  @ApiNotFoundResponse({ description: 'Registro não encontrado' })
   async remove(
     @Param('id') id: string,
     @CurrentUser() user: JwtPayload,

--- a/src/modules/notification/devices.controller.ts
+++ b/src/modules/notification/devices.controller.ts
@@ -1,4 +1,5 @@
 import { Body, Controller, Post } from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { DeviceToken } from '@prisma/client';
 import { RegisterDeviceDto } from '@petcardorg/shared';
 import { Auth } from '../auth/decorators/auth.decorator';
@@ -8,6 +9,7 @@ import type { JwtPayload } from '../auth/strategies/jwt.strategy';
 import { TutorService } from '../tutor/tutor.service';
 import { NotificationService } from './notification.service';
 
+@ApiTags('devices')
 @Controller('devices')
 export class DevicesController {
   constructor(
@@ -17,6 +19,9 @@ export class DevicesController {
 
   @Post()
   @Auth(Role.TUTOR)
+  @ApiOperation({
+    summary: 'Registrar token de device do tutor para push (FCM)',
+  })
   async register(
     @CurrentUser() user: JwtPayload,
     @Body() dto: RegisterDeviceDto,

--- a/src/modules/pet/pet.controller.ts
+++ b/src/modules/pet/pet.controller.ts
@@ -9,6 +9,13 @@ import {
   Patch,
   Post,
 } from '@nestjs/common';
+import {
+  ApiCreatedResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
 import { CreatePetDto, PetResponseDto, UpdatePetDto } from '@petcardorg/shared';
 import { Auth } from '../auth/decorators/auth.decorator';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
@@ -16,12 +23,15 @@ import { Role } from '../auth/enums/role.enum';
 import type { JwtPayload } from '../auth/strategies/jwt.strategy';
 import { PetService } from './pet.service';
 
+@ApiTags('pets')
 @Controller('pets')
 export class PetController {
   constructor(private readonly petService: PetService) {}
 
   @Post()
   @Auth(Role.TUTOR)
+  @ApiOperation({ summary: 'Cadastrar pet do tutor autenticado' })
+  @ApiCreatedResponse({ type: PetResponseDto })
   async create(
     @CurrentUser() user: JwtPayload,
     @Body() dto: CreatePetDto,
@@ -31,12 +41,17 @@ export class PetController {
 
   @Get()
   @Auth(Role.TUTOR)
+  @ApiOperation({ summary: 'Listar pets do tutor autenticado' })
+  @ApiOkResponse({ type: PetResponseDto, isArray: true })
   async findAll(@CurrentUser() user: JwtPayload): Promise<PetResponseDto[]> {
     return this.petService.findAllForTutor(user.sub);
   }
 
   @Get(':id')
   @Auth(Role.TUTOR, Role.VET)
+  @ApiOperation({ summary: 'Buscar pet por id (tutor dono ou vet)' })
+  @ApiOkResponse({ type: PetResponseDto })
+  @ApiNotFoundResponse({ description: 'Pet não encontrado' })
   async findOne(
     @Param('id') id: string,
     @CurrentUser() user: JwtPayload,
@@ -47,6 +62,9 @@ export class PetController {
 
   @Patch(':id')
   @Auth(Role.TUTOR)
+  @ApiOperation({ summary: 'Atualizar pet do tutor autenticado' })
+  @ApiOkResponse({ type: PetResponseDto })
+  @ApiNotFoundResponse({ description: 'Pet não encontrado' })
   async update(
     @Param('id') id: string,
     @CurrentUser() user: JwtPayload,
@@ -58,6 +76,8 @@ export class PetController {
   @Delete(':id')
   @Auth(Role.TUTOR)
   @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Remover pet do tutor autenticado' })
+  @ApiNotFoundResponse({ description: 'Pet não encontrado' })
   async remove(
     @Param('id') id: string,
     @CurrentUser() user: JwtPayload,
@@ -68,6 +88,10 @@ export class PetController {
   @Post(':id/qr-code')
   @Auth(Role.TUTOR)
   @HttpCode(HttpStatus.ACCEPTED)
+  @ApiOperation({
+    summary: 'Reenfileirar geração do QR Code da carteira (assíncrono)',
+  })
+  @ApiNotFoundResponse({ description: 'Pet não encontrado' })
   async regenerateQrCode(
     @Param('id') id: string,
     @CurrentUser() user: JwtPayload,

--- a/src/modules/tutor/tutor.controller.ts
+++ b/src/modules/tutor/tutor.controller.ts
@@ -1,4 +1,5 @@
 import { Body, Controller, Get, Param, Patch } from '@nestjs/common';
+import { ApiNotFoundResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { Tutor } from '@prisma/client';
 import { UpdateTutorDto } from '@petcardorg/shared';
 import { Auth } from '../auth/decorators/auth.decorator';
@@ -7,18 +8,21 @@ import { Role } from '../auth/enums/role.enum';
 import type { JwtPayload } from '../auth/strategies/jwt.strategy';
 import { TutorService } from './tutor.service';
 
+@ApiTags('tutors')
 @Controller('tutors')
 export class TutorController {
   constructor(private readonly tutorService: TutorService) {}
 
   @Get('me')
   @Auth(Role.TUTOR)
+  @ApiOperation({ summary: 'Dados do tutor autenticado' })
   async getMe(@CurrentUser() user: JwtPayload): Promise<Tutor> {
     return this.tutorService.findById(user.sub);
   }
 
   @Patch('me')
   @Auth(Role.TUTOR)
+  @ApiOperation({ summary: 'Atualizar dados do tutor autenticado' })
   async updateMe(
     @CurrentUser() user: JwtPayload,
     @Body() dto: UpdateTutorDto,
@@ -28,6 +32,8 @@ export class TutorController {
 
   @Get(':id')
   @Auth(Role.VET)
+  @ApiOperation({ summary: 'Buscar tutor por id (visão do vet)' })
+  @ApiNotFoundResponse({ description: 'Tutor não encontrado' })
   async findOne(@Param('id') id: string): Promise<Tutor> {
     return this.tutorService.findById(id);
   }

--- a/src/modules/upload/upload.controller.ts
+++ b/src/modules/upload/upload.controller.ts
@@ -7,6 +7,14 @@ import {
   UseInterceptors,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
+import {
+  ApiBadRequestResponse,
+  ApiBody,
+  ApiConsumes,
+  ApiOperation,
+  ApiQuery,
+  ApiTags,
+} from '@nestjs/swagger';
 import { Auth } from '../auth/decorators/auth.decorator';
 import { Role } from '../auth/enums/role.enum';
 import { UploadService } from './upload.service';
@@ -14,6 +22,7 @@ import { UploadService } from './upload.service';
 const ALLOWED_FOLDERS = ['pets', 'tutors'] as const;
 type AllowedFolder = (typeof ALLOWED_FOLDERS)[number];
 
+@ApiTags('upload')
 @Controller('upload')
 export class UploadController {
   constructor(private readonly uploadService: UploadService) {}
@@ -21,6 +30,27 @@ export class UploadController {
   @Post('image')
   @Auth(Role.TUTOR, Role.VET)
   @UseInterceptors(FileInterceptor('file'))
+  @ApiOperation({ summary: 'Upload de imagem para o S3 (máx. 5MB)' })
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      required: ['file'],
+      properties: {
+        file: { type: 'string', format: 'binary' },
+      },
+    },
+  })
+  @ApiQuery({
+    name: 'folder',
+    required: false,
+    enum: ALLOWED_FOLDERS,
+    description: 'Pasta de destino no bucket (padrão: pets)',
+  })
+  @ApiBadRequestResponse({
+    description:
+      'Arquivo ausente, tipo inválido, acima de 5MB ou pasta inválida',
+  })
   async uploadImage(
     @UploadedFile() file: Express.Multer.File,
     @Query('folder') folder: AllowedFolder = 'pets',

--- a/src/modules/vet-note/vet-note.controller.ts
+++ b/src/modules/vet-note/vet-note.controller.ts
@@ -8,6 +8,13 @@ import {
   Param,
   Post,
 } from '@nestjs/common';
+import {
+  ApiCreatedResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
 import { Auth } from '../auth/decorators/auth.decorator';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { Role } from '../auth/enums/role.enum';
@@ -18,12 +25,18 @@ import {
 } from '@petcardorg/shared';
 import { VetNoteService } from './vet-note.service';
 
+@ApiTags('clinical-notes')
 @Controller()
 export class VetNoteController {
   constructor(private readonly vetNoteService: VetNoteService) {}
 
   @Post('pets/:petId/clinical-notes')
   @Auth(Role.VET)
+  @ApiOperation({
+    summary: 'Criar nota clínica no prontuário do pet (escrita reversa do vet)',
+  })
+  @ApiCreatedResponse({ type: NotaClinicaResponseDto })
+  @ApiNotFoundResponse({ description: 'Pet não encontrado' })
   async create(
     @Param('petId') petId: string,
     @CurrentUser() user: JwtPayload,
@@ -34,6 +47,9 @@ export class VetNoteController {
 
   @Get('pets/:petId/clinical-notes')
   @Auth(Role.TUTOR, Role.VET)
+  @ApiOperation({ summary: 'Listar notas clínicas do pet' })
+  @ApiOkResponse({ type: NotaClinicaResponseDto, isArray: true })
+  @ApiNotFoundResponse({ description: 'Pet não encontrado' })
   async findAllForPet(
     @Param('petId') petId: string,
     @CurrentUser() user: JwtPayload,
@@ -44,6 +60,9 @@ export class VetNoteController {
 
   @Get('clinical-notes/:id')
   @Auth(Role.TUTOR, Role.VET)
+  @ApiOperation({ summary: 'Buscar nota clínica por id' })
+  @ApiOkResponse({ type: NotaClinicaResponseDto })
+  @ApiNotFoundResponse({ description: 'Nota clínica não encontrada' })
   async findOne(
     @Param('id') id: string,
     @CurrentUser() user: JwtPayload,
@@ -55,6 +74,8 @@ export class VetNoteController {
   @Delete('clinical-notes/:id')
   @Auth(Role.VET)
   @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Remover nota clínica (somente o vet autor)' })
+  @ApiNotFoundResponse({ description: 'Nota clínica não encontrada' })
   async remove(
     @Param('id') id: string,
     @CurrentUser() user: JwtPayload,

--- a/src/modules/veterinario/veterinario.controller.ts
+++ b/src/modules/veterinario/veterinario.controller.ts
@@ -10,6 +10,7 @@ import {
   Post,
   Query,
 } from '@nestjs/common';
+import { ApiNotFoundResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { Auth } from '../auth/decorators/auth.decorator';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { Role } from '../auth/enums/role.enum';
@@ -23,12 +24,14 @@ import {
   VeterinarioService,
 } from './veterinario.service';
 
+@ApiTags('veterinarios')
 @Controller('veterinarios')
 export class VeterinarioController {
   constructor(private readonly veterinarioService: VeterinarioService) {}
 
   @Post()
   @Auth(Role.VET)
+  @ApiOperation({ summary: 'Cadastrar veterinário' })
   async create(
     @Body() dto: CreateVeterinarioDto,
   ): Promise<VeterinarioResponse> {
@@ -37,6 +40,9 @@ export class VeterinarioController {
 
   @Get('dashboard/pets')
   @Auth(Role.VET)
+  @ApiOperation({
+    summary: 'Dashboard do vet: pets atendidos (paginado, com busca)',
+  })
   async dashboardPets(
     @CurrentUser() user: JwtPayload,
     @Query() query: DashboardQueryDto,
@@ -46,18 +52,23 @@ export class VeterinarioController {
 
   @Get()
   @Auth(Role.VET)
+  @ApiOperation({ summary: 'Listar veterinários' })
   async findAll(): Promise<VeterinarioResponse[]> {
     return this.veterinarioService.findAll();
   }
 
   @Get(':id')
   @Auth(Role.VET)
+  @ApiOperation({ summary: 'Buscar veterinário por id' })
+  @ApiNotFoundResponse({ description: 'Veterinário não encontrado' })
   async findOne(@Param('id') id: string): Promise<VeterinarioResponse> {
     return this.veterinarioService.findById(id);
   }
 
   @Patch(':id')
   @Auth(Role.VET)
+  @ApiOperation({ summary: 'Atualizar veterinário' })
+  @ApiNotFoundResponse({ description: 'Veterinário não encontrado' })
   async update(
     @Param('id') id: string,
     @Body() dto: UpdateVeterinarioDto,
@@ -68,6 +79,8 @@ export class VeterinarioController {
   @Delete(':id')
   @Auth(Role.VET)
   @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Remover veterinário' })
+  @ApiNotFoundResponse({ description: 'Veterinário não encontrado' })
   async remove(@Param('id') id: string): Promise<void> {
     return this.veterinarioService.remove(id);
   }


### PR DESCRIPTION
Closes #44

## O que muda

- **@ApiTags** por módulo e **@ApiOperation** (summary) em todos os endpoints dos 15 controllers — 35 rotas documentadas.
- **@Auth() composto** ganha `@ApiBearerAuth()` + respostas padrão 401/403: todos os endpoints protegidos exibem o cadeado e os erros de auth de uma vez.
- Respostas de erro relevantes por endpoint (404, 409 no register, 429 na carteira pública, 400 no upload).
- **Respostas tipadas explícitas** (`@ApiOkResponse`/`@ApiCreatedResponse`) onde o tipo vem do `@petcardorg/shared` — o CLI plugin não infere tipos de pacote externo.
- Upload documentado como `multipart/form-data`; query params soltos (`folder`, `upcoming`, `address`, `code`/`state`) com `@ApiQuery`.
- `/calendar/dev-connect` excluído da doc (`@ApiExcludeEndpoint` — helper de desenvolvimento).
- UI permanece em **`/docs`** (critério da issue ajustado — ver comentário em #44).

## Dependência

Os **schemas completos** de request/response vêm do `@petcardorg/shared@0.10.0` (PetCardOrg/petcard-shared#50), que passa a emitir metadata OpenAPI no build. Ordem:

1. Merge de petcard-shared#50 em develop
2. develop→main no shared (publica 0.10.0)
3. Commit de bump `^0.10.0` entra neste PR (aviso quando publicar)

Sem o bump o PR já compila e passa; os schemas do shared apenas ficam vazios na UI até o passo 3.

## Verificação

- App real + `/docs-json` inspecionado: 35 paths, 26 schemas **todos com propriedades** (com o shared instrumentado), bearer/401/403 nos protegidos, respostas com `$ref` correto (`PetResponseDto`, arrays, `CarteiraDigitalPublicResponseDto`...).
- `npm run test:cov` verde: 345 testes, cobertura 85.48/81.27/94.44/87.06 (catraca 84/80/93/85 intacta).
- `npm run build` e `npm run lint` verdes.

Também refoca o CLAUDE.md da M6 para a M7 (commit separado).