### PR TITLE
chore: PC-097 - Bump @petcardorg/shared para 0.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@nestjs/schedule": "^6.1.3",
         "@nestjs/swagger": "^11.4.4",
         "@nestjs/throttler": "^6.5.0",
-        "@petcardorg/shared": "^0.9.0",
+        "@petcardorg/shared": "^0.10.0",
         "@prisma/client": "^6.19.3",
         "amqp-connection-manager": "^5.0.0",
         "amqplib": "^1.0.3",
@@ -3846,9 +3846,9 @@
       }
     },
     "node_modules/@petcardorg/shared": {
-      "version": "0.9.0",
-      "resolved": "https://npm.pkg.github.com/download/@petcardorg/shared/0.9.0/3d77c7b90a05ab9f9058739a3ea70d94f807a2db",
-      "integrity": "sha512-Uz4vaqyOMw1LZ5guOHrJFxoXXDYAlcQCJndbgHpCL3pjYBDszi3vYl3PMlo1UPfnRkdURY5pFZymUh74GwLAhg==",
+      "version": "0.10.0",
+      "resolved": "https://npm.pkg.github.com/download/@petcardorg/shared/0.10.0/d1b9fc89d27263adbe889d7f356c3fa7890efcb0",
+      "integrity": "sha512-15HTnl8RQdofrbyRXSCn4pezSObP+/qzm7kyUyZXkvxlVSQezPhi/mMPYYR/pyBVJO2AGXHC5U4hSQeMe9g8MA==",
       "license": "MIT",
       "peerDependencies": {
         "class-transformer": "^0.5.1",
@@ -14632,9 +14632,9 @@
       }
     },
     "node_modules/websocket-driver": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
       "license": "Apache-2.0",
       "dependencies": {
         "http-parser-js": ">=0.5.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@nestjs/schedule": "^6.1.3",
     "@nestjs/swagger": "^11.4.4",
     "@nestjs/throttler": "^6.5.0",
-    "@petcardorg/shared": "^0.9.0",
+    "@petcardorg/shared": "^0.10.0",
     "@prisma/client": "^6.19.3",
     "amqp-connection-manager": "^5.0.0",
     "amqplib": "^1.0.3",


### PR DESCRIPTION
Passo final da PC-097 (#44): consome o `@petcardorg/shared@0.10.0` publicado hoje (petcard-shared#50), cujos DTOs trazem `_OPENAPI_METADATA_FACTORY`. Com isso os 26 schemas de request/response aparecem completos no Swagger (`/docs`) — sem este bump o #105 renderiza os schemas do shared vazios.

Aproveita e zera o `npm audit`: advisory crítico novo de hoje no `websocket-driver` (transitivo do firebase-admin) corrigido via `npm audit fix` (GHSA-mp7j-qc5w-4988).

## Verificação
- `npm run test:cov`: 345 testes verdes, cobertura 85.48/81.27/94.44/87.06 (catraca intacta)
- `npm run build` verde
- `npm audit`: 0 vulnerabilidades
- Factory presente no pacote instalado (`CarteiraDigitalPublicResponseDto` etc.)

Fecha a PC-097 junto com o #105 (já mergeado); a issue #44 pode ser fechada no merge deste PR.