### PR TITLE
chore: PC-098 - script de export do contrato OpenAPI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 /generated/prisma
 
 /generated/prisma
+
+# OpenAPI gerado (snapshot versionado no petcard-docs)
+openapi.json

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "test:e2e": "jest --runInBand --config ./test/jest-e2e.json",
     "prepare": "husky",
     "postinstall": "prisma generate",
-    "db:seed": "npx prisma db seed"
+    "db:seed": "npx prisma db seed",
+    "openapi:json": "nest build && node -r reflect-metadata dist/scripts/generate-openapi.js"
   },
   "prisma": {
     "seed": "ts-node --compiler-options {\"module\":\"commonjs\",\"moduleResolution\":\"node\",\"types\":[\"node\"]} prisma/seed.ts"

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -1,0 +1,46 @@
+import { NestFactory } from '@nestjs/core';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { AppModule } from '../src/app.module';
+
+/**
+ * Gera o documento OpenAPI da API sem subir o servidor nem conectar em
+ * Postgres/RabbitMQ. Usa o `preview mode` do Nest, que monta o grafo de
+ * módulos e lê os metadados do Swagger (mesmos decorators de PC-097) sem
+ * instanciar providers nem rodar hooks de ciclo de vida.
+ *
+ * Uso: `npm run openapi:json` → escreve `openapi.json` na raiz do repo.
+ * É a fonte de verdade da collection Postman (PC-098).
+ */
+async function generate(): Promise<void> {
+  const app = await NestFactory.create(AppModule, {
+    preview: true,
+    logger: false,
+  });
+
+  const config = new DocumentBuilder()
+    .setTitle('PetCard API')
+    .setDescription(
+      'API REST do PetCard — carteira digital de saúde para pets. ' +
+        'Autenticação via JWT (Bearer). Endpoints de tutor, pet, prontuário ' +
+        '(vacina/vermífugo/medicação), carteira digital/QR, clínicas, ' +
+        'agendamento/Calendar, notificações e interface do veterinário.',
+    )
+    .setVersion('1.0')
+    .addBearerAuth()
+    .build();
+
+  const document = SwaggerModule.createDocument(app, config);
+  const outPath = resolve(process.cwd(), 'openapi.json');
+  writeFileSync(outPath, JSON.stringify(document, null, 2));
+  await app.close();
+
+  const paths = Object.keys(document.paths ?? {}).length;
+  const schemas = Object.keys(document.components?.schemas ?? {}).length;
+  console.log(
+    `OpenAPI gerado em ${outPath} — ${paths} paths, ${schemas} schemas`,
+  );
+}
+
+void generate();


### PR DESCRIPTION
Suporte à **PC-098** (collection Postman, no petcard-docs): adiciona um jeito reproduzível de exportar o contrato OpenAPI da API.

## O que muda
- `scripts/generate-openapi.ts` — gera o documento OpenAPI usando o **preview mode** do Nest (`NestFactory.create(AppModule, { preview: true })`), que monta o grafo de módulos e lê os metadados do Swagger (mesmos decorators da PC-097) **sem instanciar providers nem conectar em Postgres/RabbitMQ**.
- `npm run openapi:json` — `nest build && node -r reflect-metadata dist/scripts/generate-openapi.js`. O build é necessário para o plugin CLI do `@nestjs/swagger` instrumentar os DTOs **locais** (auth/appointment) com `_OPENAPI_METADATA_FACTORY` — sob ts-node puro eles saem sem propriedades.
- `.gitignore` — ignora o `openapi.json` gerado (o snapshot fica versionado no petcard-docs).

## Verificação
- Saída: **35 paths, 26 schemas, todos populados** (0 vazios) — bate com o `/docs-json` do app rodando na PC-097.
- ESLint limpo; build ok.

Sem dependência nova, sem mudança de runtime.