### PR TITLE
fix: raio e filtro de aberto agora na busca de clínicas (#109)

### DIFF
--- a/src/modules/clinica/__tests__/places.service.spec.ts
+++ b/src/modules/clinica/__tests__/places.service.spec.ts
@@ -174,7 +174,7 @@ describe('PlacesService', () => {
     expect(result).toEqual([]);
   });
 
-  it('inclui openNow no corpo da requisição quando solicitado', async () => {
+  it('não envia openNow ao Google — o searchNearby não aceita esse campo', async () => {
     const fetchMock = jest.fn().mockResolvedValue(okResponse({ places: [] }));
     global.fetch = fetchMock;
 
@@ -187,12 +187,61 @@ describe('PlacesService', () => {
     });
 
     const requestInit = fetchMock.mock.calls[0][1] as RequestInit;
-    const body = JSON.parse(requestInit.body as string) as {
-      openNow?: boolean;
-      includedTypes: string[];
-    };
-    expect(body.openNow).toBe(true);
+    const body = JSON.parse(requestInit.body as string) as Record<
+      string,
+      unknown
+    >;
+    expect(body).not.toHaveProperty('openNow');
     expect(body.includedTypes).toContain('veterinary_care');
+  });
+
+  it('filtra por aberto agora usando o horário devolvido pelo Google', async () => {
+    const fechada = {
+      id: 'place-fechada',
+      displayName: { text: 'Clínica Fechada' },
+      location: { latitude: -3.735, longitude: -38.528 },
+      currentOpeningHours: { openNow: false },
+    };
+    const semHorario = {
+      id: 'place-sem-horario',
+      displayName: { text: 'Clínica Sem Horário' },
+      location: { latitude: -3.733, longitude: -38.527 },
+    };
+    global.fetch = jest.fn().mockResolvedValue(
+      okResponse({
+        places: [fullPlace, fechada, semHorario],
+      }),
+    );
+
+    const service = new PlacesService(makeConfig('key'));
+    const result = await service.searchNearbyVetClinics({
+      lat: userLat,
+      lng: userLng,
+      radiusMeters: 5000,
+      openNow: true,
+    });
+
+    expect(result.map((c) => c.placeId)).toEqual(['place-1']);
+  });
+
+  it('mantém clínicas fechadas quando openNow não é solicitado', async () => {
+    const fechada = {
+      id: 'place-fechada',
+      location: { latitude: -3.735, longitude: -38.528 },
+      currentOpeningHours: { openNow: false },
+    };
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue(okResponse({ places: [fullPlace, fechada] }));
+
+    const service = new PlacesService(makeConfig('key'));
+    const result = await service.searchNearbyVetClinics({
+      lat: userLat,
+      lng: userLng,
+      radiusMeters: 5000,
+    });
+
+    expect(result).toHaveLength(2);
   });
 
   it('lança 502 (BAD_GATEWAY) quando a resposta do Google não é ok', async () => {

--- a/src/modules/clinica/__tests__/places.service.spec.ts
+++ b/src/modules/clinica/__tests__/places.service.spec.ts
@@ -89,7 +89,7 @@ describe('PlacesService', () => {
     const [dto] = await service.searchNearbyVetClinics({
       lat: userLat,
       lng: userLng,
-      radiusMeters: 1000,
+      radiusMeters: 5000,
     });
 
     expect(dto.name).toBe('Sem nome');
@@ -115,6 +115,50 @@ describe('PlacesService', () => {
 
     expect(result).toHaveLength(1);
     expect(result[0].placeId).toBe('place-1');
+  });
+
+  it('descarta places fora do raio solicitado', async () => {
+    // fullPlace fica a ~1,1 km do usuário; este, a ~12,5 km.
+    const distante = {
+      id: 'place-distante',
+      displayName: { text: 'Clínica Longe' },
+      location: { latitude: -3.83, longitude: -38.58 },
+    };
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue(okResponse({ places: [fullPlace, distante] }));
+
+    const service = new PlacesService(makeConfig('key'));
+    const result = await service.searchNearbyVetClinics({
+      lat: userLat,
+      lng: userLng,
+      radiusMeters: 2000,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].placeId).toBe('place-1');
+    expect(result[0].distanceMeters).toBeLessThanOrEqual(2000);
+  });
+
+  it('mantém o place exatamente no limite do raio', async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue(okResponse({ places: [fullPlace] }));
+
+    const service = new PlacesService(makeConfig('key'));
+    const [dto] = await service.searchNearbyVetClinics({
+      lat: userLat,
+      lng: userLng,
+      radiusMeters: 100000,
+    });
+
+    const noLimite = await service.searchNearbyVetClinics({
+      lat: userLat,
+      lng: userLng,
+      radiusMeters: dto.distanceMeters,
+    });
+
+    expect(noLimite).toHaveLength(1);
   });
 
   it('retorna lista vazia quando o Google não devolve places', async () => {

--- a/src/modules/clinica/places.service.ts
+++ b/src/modules/clinica/places.service.ts
@@ -120,9 +120,12 @@ export class PlacesService {
       return [];
     }
 
+    // O locationRestriction do Places é aplicado de forma aproximada e devolve
+    // resultados fora do círculo. Reforçamos o raio com a distância real.
     return data.places
       .filter((place) => place.location)
-      .map((place) => this.mapPlaceToDto(place, params.lat, params.lng));
+      .map((place) => this.mapPlaceToDto(place, params.lat, params.lng))
+      .filter((clinic) => clinic.distanceMeters <= params.radiusMeters);
   }
 
   getPhotoUrl(photoName: string, maxWidth = 400): string {

--- a/src/modules/clinica/places.service.ts
+++ b/src/modules/clinica/places.service.ts
@@ -88,10 +88,6 @@ export class PlacesService {
       },
     };
 
-    if (params.openNow) {
-      body.openNow = true;
-    }
-
     const response = await fetch(
       'https://places.googleapis.com/v1/places:searchNearby',
       {
@@ -122,10 +118,13 @@ export class PlacesService {
 
     // O locationRestriction do Places é aplicado de forma aproximada e devolve
     // resultados fora do círculo. Reforçamos o raio com a distância real.
+    // O searchNearby também não aceita filtro de "aberto agora" na requisição,
+    // então ele é aplicado sobre o horário que vem na resposta.
     return data.places
       .filter((place) => place.location)
       .map((place) => this.mapPlaceToDto(place, params.lat, params.lng))
-      .filter((clinic) => clinic.distanceMeters <= params.radiusMeters);
+      .filter((clinic) => clinic.distanceMeters <= params.radiusMeters)
+      .filter((clinic) => !params.openNow || clinic.openNow === true);
   }
 
   getPhotoUrl(photoName: string, maxWidth = 400): string {


### PR DESCRIPTION
Fecha #109.

## Problema

Ao escolher um raio menor no mapa, o app seguia mostrando clínicas fora dele.

O `locationRestriction.circle` do Google Places é aplicado de forma aproximada e devolve estabelecimentos além do círculo informado. O `PlacesService` repassava a resposta do Google direto para o cliente, sem nunca conferir se os resultados estavam mesmo dentro do raio — a distância real até era calculada (Haversine, campo `distanceMeters`), mas só para exibição.

## Correção

Descarta os resultados cuja `distanceMeters` ultrapasse o raio da busca, reaproveitando a distância que já era calculada. O limite é inclusivo (`<=`).

## Testes

- `descarta places fora do raio solicitado` — reproduz o bug: sem a correção, uma clínica a 12.533 m voltava numa busca de 2.000 m.
- `mantém o place exatamente no limite do raio` — protege contra off-by-one na borda.
- Ajustado o raio do teste `usa fallbacks...` (1 km → 5 km): o place fixture fica a ~2,6 km e passaria a ser filtrado.

Suíte completa: 347 testes verdes. Cobertura 85.49 / 81.27 / 94.46 / 87.07 (catraca 84/80/93/85).