### PR TITLE
fix: tratar falhas do callback OAuth do Google Agenda (#110)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,10 +40,8 @@ lerna-debug.log*
 
 # dotenv environment variable files
 .env
-.env.development.local
-.env.test.local
-.env.production.local
-.env.local
+.env.*
+!.env.example
 
 # temp directory
 .temp

--- a/src/common/crypto/__tests__/encryption.service.spec.ts
+++ b/src/common/crypto/__tests__/encryption.service.spec.ts
@@ -73,4 +73,21 @@ describe('EncryptionService', () => {
     const service = await buildService('abcd');
     expect(() => service.encrypt('x')).toThrow('64 caracteres');
   });
+
+  describe('assertConfigured', () => {
+    it('passa quando a chave é válida', async () => {
+      const service = await buildService(TEST_KEY);
+      expect(() => service.assertConfigured()).not.toThrow();
+    });
+
+    it('acusa chave ausente sem precisar cifrar nada', async () => {
+      const service = await buildService(undefined);
+      expect(() => service.assertConfigured()).toThrow('ENCRYPTION_KEY');
+    });
+
+    it('acusa chave de tamanho inválido', async () => {
+      const service = await buildService('abcd');
+      expect(() => service.assertConfigured()).toThrow('64 caracteres');
+    });
+  });
 });

--- a/src/common/crypto/encryption.service.ts
+++ b/src/common/crypto/encryption.service.ts
@@ -35,6 +35,15 @@ export class EncryptionService {
     return key;
   }
 
+  /**
+   * Valida a configuração sem cifrar nada. Serve para falhar antes de operações
+   * irreversíveis — o código OAuth do Google é de uso único, então descobrir a
+   * chave ausente só na hora de cifrar obriga o usuário a refazer o consentimento.
+   */
+  assertConfigured(): void {
+    this.getKey();
+  }
+
   encrypt(plaintext: string): string {
     const key = this.getKey();
     const iv = randomBytes(IV_LENGTH);

--- a/src/modules/calendar/__tests__/calendar-sync.consumer.spec.ts
+++ b/src/modules/calendar/__tests__/calendar-sync.consumer.spec.ts
@@ -39,6 +39,7 @@ describe('CalendarSyncConsumer', () => {
   let calendarService: {
     syncAppointment: jest.Mock;
     deleteEvent: jest.Mock;
+    disconnect: jest.Mock;
   };
   let channel: { ack: jest.Mock; nack: jest.Mock; publish: jest.Mock };
 
@@ -46,6 +47,7 @@ describe('CalendarSyncConsumer', () => {
     calendarService = {
       syncAppointment: jest.fn().mockResolvedValue(undefined),
       deleteEvent: jest.fn().mockResolvedValue(undefined),
+      disconnect: jest.fn().mockResolvedValue(undefined),
     };
     channel = { ack: jest.fn(), nack: jest.fn(), publish: jest.fn() };
 
@@ -136,6 +138,21 @@ describe('CalendarSyncConsumer', () => {
     expect(channel.ack).toHaveBeenCalledWith(message);
     expect(channel.publish).not.toHaveBeenCalled();
     expect(channel.nack).not.toHaveBeenCalled();
+    // Token morto é descartado para o status refletir a desconexão.
+    expect(calendarService.disconnect).toHaveBeenCalledWith('tutor-1');
+  });
+
+  it('não descarta o token em erro transitório', async () => {
+    const transient = Object.assign(new Error('Service Unavailable'), {
+      code: 503,
+    });
+    calendarService.syncAppointment.mockRejectedValue(transient);
+    const payload = createMessage({ action: 'UPDATE' });
+    const { context } = buildContext(channel, payload);
+
+    await consumer.handleSync(payload, context);
+
+    expect(calendarService.disconnect).not.toHaveBeenCalled();
   });
 
   it('acks UPDATE when the event is already gone (404)', async () => {

--- a/src/modules/calendar/__tests__/calendar-sync.consumer.spec.ts
+++ b/src/modules/calendar/__tests__/calendar-sync.consumer.spec.ts
@@ -150,6 +150,26 @@ describe('CalendarSyncConsumer', () => {
     expect(channel.publish).not.toHaveBeenCalled();
   });
 
+  it('acks DELETE when the event was already deleted (410)', async () => {
+    // O Google devolve 410 "Resource has been deleted" ao apagar o que já foi
+    // apagado. Antes isso rendia 3 retries e DLQ.
+    const gone = Object.assign(new Error('Resource has been deleted'), {
+      code: 410,
+    });
+    calendarService.deleteEvent.mockRejectedValue(gone);
+    const payload = createMessage({
+      action: 'DELETE',
+      google_event_id: 'evt-1',
+    });
+    const { context, message } = buildContext(channel, payload);
+
+    await consumer.handleSync(payload, context);
+
+    expect(channel.ack).toHaveBeenCalledWith(message);
+    expect(channel.publish).not.toHaveBeenCalled();
+    expect(channel.nack).not.toHaveBeenCalled();
+  });
+
   it('retries with incremented counter on a transient error', async () => {
     const transient = Object.assign(new Error('Service Unavailable'), {
       code: 503,

--- a/src/modules/calendar/__tests__/calendar.controller.spec.ts
+++ b/src/modules/calendar/__tests__/calendar.controller.spec.ts
@@ -95,6 +95,59 @@ describe('CalendarController (integração)', () => {
       expect(res.text).toContain('conectado com sucesso');
       expect(calendar.handleCallback).toHaveBeenCalledWith('abc', 'tutor-1');
     });
+
+    it('responde 400 em página quando o usuário nega o consentimento', async () => {
+      harness.setUser(null);
+
+      const res = await request(harness.app.getHttpServer())
+        .get('/calendar/callback?error=access_denied&state=tutor-1')
+        .expect(400);
+
+      expect(res.text).toContain('Autorização não concluída');
+      expect(calendar.handleCallback).not.toHaveBeenCalled();
+    });
+
+    it('responde 400 em página quando faltam code ou state', async () => {
+      harness.setUser(null);
+
+      const res = await request(harness.app.getHttpServer())
+        .get('/calendar/callback?code=abc')
+        .expect(400);
+
+      expect(res.text).toContain('Link inválido');
+      expect(calendar.handleCallback).not.toHaveBeenCalled();
+    });
+
+    it('converte falha do serviço em página de erro, sem stack trace', async () => {
+      harness.setUser(null);
+      calendar.handleCallback.mockRejectedValue(
+        new Error(
+          'ENCRYPTION_KEY é obrigatória para cifrar/decifrar tokens OAuth.',
+        ),
+      );
+
+      const res = await request(harness.app.getHttpServer())
+        .get('/calendar/callback?code=abc&state=tutor-1')
+        .expect(500);
+
+      expect(res.text).toContain('Não foi possível conectar');
+      expect(res.text).toContain('ENCRYPTION_KEY');
+      expect(res.text).not.toContain('at GoogleCalendarService');
+    });
+
+    it('escapa HTML vindo da mensagem de erro', async () => {
+      harness.setUser(null);
+      calendar.handleCallback.mockRejectedValue(
+        new Error('<img src=x onerror=alert(1)>'),
+      );
+
+      const res = await request(harness.app.getHttpServer())
+        .get('/calendar/callback?code=abc&state=tutor-1')
+        .expect(500);
+
+      expect(res.text).not.toContain('<img src=x');
+      expect(res.text).toContain('&lt;img src=x');
+    });
   });
 
   describe('GET /calendar/dev-connect', () => {

--- a/src/modules/calendar/__tests__/google-calendar.service.spec.ts
+++ b/src/modules/calendar/__tests__/google-calendar.service.spec.ts
@@ -445,6 +445,20 @@ describe('GoogleCalendarService', () => {
         'boom',
       );
     });
+
+    it.each([
+      ['410 (evento já apagado)', 410, 'Resource has been deleted'],
+      ['404 (evento inexistente)', 404, 'Not Found'],
+    ])('trata %s como sucesso — apagar é idempotente', async (_, code, msg) => {
+      prisma.googleOAuthToken.findUnique.mockResolvedValue(tokenRow);
+      mockCalendarEvents.delete.mockRejectedValue(
+        Object.assign(new Error(msg), { code }),
+      );
+
+      await expect(
+        service.deleteEvent('tutor-1', 'evt-1'),
+      ).resolves.toBeUndefined();
+    });
   });
 
   describe('syncAppointment', () => {

--- a/src/modules/calendar/__tests__/google-calendar.service.spec.ts
+++ b/src/modules/calendar/__tests__/google-calendar.service.spec.ts
@@ -168,6 +168,43 @@ describe('GoogleCalendarService', () => {
       expect(arg.update.expiresAt).toBeInstanceOf(Date);
     });
 
+    it('dispara o catch-up dos pendentes após conectar', async () => {
+      // Sem botão de sincronizar no app, reconectar é o momento de recuperar
+      // o que ficou para trás enquanto o token estava revogado.
+      const catchUp = jest
+        .spyOn(service, 'syncAllPending')
+        .mockResolvedValue(0);
+      mockOAuth2Instance.getToken.mockResolvedValue({
+        tokens: {
+          access_token: 'at-raw',
+          refresh_token: 'rt-raw',
+          expiry_date: 1_800_000_000_000,
+        },
+      });
+
+      await service.handleCallback('auth-code', 'tutor-1');
+
+      expect(catchUp).toHaveBeenCalledWith('tutor-1');
+    });
+
+    it('conclui a conexão mesmo se o catch-up falhar', async () => {
+      jest
+        .spyOn(service, 'syncAllPending')
+        .mockRejectedValue(new Error('google fora do ar'));
+      mockOAuth2Instance.getToken.mockResolvedValue({
+        tokens: {
+          access_token: 'at-raw',
+          refresh_token: 'rt-raw',
+          expiry_date: 1_800_000_000_000,
+        },
+      });
+
+      await expect(
+        service.handleCallback('auth-code', 'tutor-1'),
+      ).resolves.toBeUndefined();
+      expect(prisma.googleOAuthToken.upsert).toHaveBeenCalled();
+    });
+
     it('não re-cifra refresh token ausente no update', async () => {
       // Reconexão: o Google só manda refresh_token no primeiro consentimento.
       prisma.googleOAuthToken.findUnique.mockResolvedValue({

--- a/src/modules/calendar/__tests__/google-calendar.service.spec.ts
+++ b/src/modules/calendar/__tests__/google-calendar.service.spec.ts
@@ -60,7 +60,11 @@ describe('GoogleCalendarService', () => {
     };
     tutor: { findUnique: jest.Mock };
   };
-  let encryption: { encrypt: jest.Mock; decrypt: jest.Mock };
+  let encryption: {
+    encrypt: jest.Mock;
+    decrypt: jest.Mock;
+    assertConfigured: jest.Mock;
+  };
 
   const tokenRow = {
     tutorId: 'tutor-1',
@@ -103,6 +107,7 @@ describe('GoogleCalendarService', () => {
     encryption = {
       encrypt: jest.fn((v: string) => `enc(${v})`),
       decrypt: jest.fn((v: string) => `dec(${v})`),
+      assertConfigured: jest.fn(),
     };
     mockOAuth2Instance.generateAuthUrl.mockReturnValue(
       'https://accounts.google.com/o/oauth2/auth?xyz',
@@ -164,6 +169,10 @@ describe('GoogleCalendarService', () => {
     });
 
     it('não re-cifra refresh token ausente no update', async () => {
+      // Reconexão: o Google só manda refresh_token no primeiro consentimento.
+      prisma.googleOAuthToken.findUnique.mockResolvedValue({
+        refreshToken: 'enc(rt-antigo)',
+      });
       mockOAuth2Instance.getToken.mockResolvedValue({
         tokens: {
           access_token: 'at-raw',
@@ -176,6 +185,77 @@ describe('GoogleCalendarService', () => {
 
       const arg = prisma.googleOAuthToken.upsert.mock.calls[0][0];
       expect(arg.update.refreshToken).toBeUndefined();
+      // O create precisa de um valor: reaproveita o que já estava salvo.
+      expect(arg.create.refreshToken).toBe('enc(rt-antigo)');
+    });
+
+    it('falha com orientação quando não há refresh token novo nem salvo', async () => {
+      prisma.googleOAuthToken.findUnique.mockResolvedValue(null);
+      mockOAuth2Instance.getToken.mockResolvedValue({
+        tokens: {
+          access_token: 'at-raw',
+          refresh_token: undefined,
+          expiry_date: 1_800_000_000_000,
+        },
+      });
+
+      await expect(
+        service.handleCallback('auth-code', 'tutor-1'),
+      ).rejects.toThrow(/refresh token/i);
+      expect(prisma.googleOAuthToken.upsert).not.toHaveBeenCalled();
+    });
+
+    it('falha quando o Google não devolve access token', async () => {
+      mockOAuth2Instance.getToken.mockResolvedValue({
+        tokens: { access_token: undefined, refresh_token: 'rt-raw' },
+      });
+
+      await expect(
+        service.handleCallback('auth-code', 'tutor-1'),
+      ).rejects.toThrow(/access token/i);
+      expect(prisma.googleOAuthToken.upsert).not.toHaveBeenCalled();
+    });
+
+    it('assume validade padrão quando o Google omite expiry_date', async () => {
+      mockOAuth2Instance.getToken.mockResolvedValue({
+        tokens: {
+          access_token: 'at-raw',
+          refresh_token: 'rt-raw',
+          expiry_date: undefined,
+        },
+      });
+
+      await service.handleCallback('auth-code', 'tutor-1');
+
+      const arg = prisma.googleOAuthToken.upsert.mock.calls[0][0];
+      const expiresAt = arg.create.expiresAt as Date;
+      expect(expiresAt).toBeInstanceOf(Date);
+      expect(Number.isNaN(expiresAt.getTime())).toBe(false);
+      expect(expiresAt.getTime()).toBeGreaterThan(Date.now());
+    });
+
+    it('valida a chave de criptografia antes de gastar o código do Google', async () => {
+      encryption.assertConfigured.mockImplementation(() => {
+        throw new Error('ENCRYPTION_KEY é obrigatória');
+      });
+
+      await expect(
+        service.handleCallback('auth-code', 'tutor-1'),
+      ).rejects.toThrow(/ENCRYPTION_KEY/);
+      expect(mockOAuth2Instance.getToken).not.toHaveBeenCalled();
+    });
+
+    it('recusa o callback quando a integração não está configurada', async () => {
+      const unconfigured = new GoogleCalendarService(
+        makeConfig(false),
+        prisma as unknown as PrismaService,
+        encryption as unknown as EncryptionService,
+      );
+
+      await expect(
+        unconfigured.handleCallback('auth-code', 'tutor-1'),
+      ).rejects.toThrow(/não está configurada/i);
+      expect(mockOAuth2Instance.getToken).not.toHaveBeenCalled();
     });
   });
 

--- a/src/modules/calendar/calendar-sync.consumer.ts
+++ b/src/modules/calendar/calendar-sync.consumer.ts
@@ -62,10 +62,14 @@ export class CalendarSyncConsumer {
       channel.ack(message);
     } catch (error) {
       // Refresh token revoked — only the tutor can fix this by reconnecting.
+      // Descarta o token morto para que /calendar/status pare de dizer que está
+      // conectado: é assim que o banner do app vira "conectar" e o tutor
+      // descobre que os agendamentos deixaram de ir para a agenda.
       if (this.isPermanentAuthError(error)) {
         this.logger.warn(
-          `Calendar OAuth revoked for appointment ${data.appointment_id}; ack without retry`,
+          `Calendar OAuth revoked for appointment ${data.appointment_id}; dropping stored token`,
         );
+        await this.calendarService.disconnect(data.tutor_id);
         channel.ack(message);
         return;
       }

--- a/src/modules/calendar/calendar-sync.consumer.ts
+++ b/src/modules/calendar/calendar-sync.consumer.ts
@@ -9,6 +9,7 @@ import {
   CALENDAR_SYNC_RETRY_HEADER,
 } from '../queue/queue.constants';
 import { GoogleCalendarService } from './google-calendar.service';
+import { extractGoogleStatus, isAlreadyGoneError } from './google-api-error';
 
 @Controller()
 export class CalendarSyncConsumer {
@@ -70,7 +71,7 @@ export class CalendarSyncConsumer {
       }
 
       // Event already gone on the Google side — UPDATE/DELETE are idempotent here.
-      if (data.action !== 'CREATE' && this.isNotFoundError(error)) {
+      if (data.action !== 'CREATE' && isAlreadyGoneError(error)) {
         this.logger.warn(
           `Calendar event missing for appointment ${data.appointment_id} (${data.action}); treating as success`,
         );
@@ -121,25 +122,13 @@ export class CalendarSyncConsumer {
   }
 
   private isPermanentAuthError(error: unknown): boolean {
-    if (this.extractStatus(error) === 401) return true;
+    if (extractGoogleStatus(error) === 401) return true;
     if (!(error instanceof Error)) return false;
     const message = error.message.toLowerCase();
     return (
       message.includes('invalid_grant') ||
       message.includes('token has been expired or revoked')
     );
-  }
-
-  private isNotFoundError(error: unknown): boolean {
-    return this.extractStatus(error) === 404;
-  }
-
-  private extractStatus(error: unknown): number | undefined {
-    if (typeof error !== 'object' || error === null) return undefined;
-    const err = error as { code?: unknown; response?: { status?: unknown } };
-    if (typeof err.code === 'number') return err.code;
-    const status = err.response?.status;
-    return typeof status === 'number' ? status : undefined;
   }
 
   private getRetryCount(message: ConsumeMessage): number {

--- a/src/modules/calendar/calendar.controller.ts
+++ b/src/modules/calendar/calendar.controller.ts
@@ -4,6 +4,7 @@ import {
   Get,
   HttpCode,
   HttpStatus,
+  Logger,
   Post,
   Query,
   Res,
@@ -22,9 +23,23 @@ import { Role } from '../auth/enums/role.enum';
 import type { JwtPayload } from '../auth/strategies/jwt.strategy';
 import { GoogleCalendarService } from './google-calendar.service';
 
+const HTML_ESCAPES: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;',
+};
+
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, (char) => HTML_ESCAPES[char]);
+}
+
 @ApiTags('calendar')
 @Controller('calendar')
 export class CalendarController {
+  private readonly logger = new Logger(CalendarController.name);
+
   constructor(
     private readonly googleCalendarService: GoogleCalendarService,
     private readonly configService: ConfigService,
@@ -52,15 +67,92 @@ export class CalendarController {
   })
   @ApiQuery({ name: 'code', description: 'Código de autorização do Google' })
   @ApiQuery({ name: 'state', description: 'Id do tutor originador do fluxo' })
+  @ApiQuery({
+    name: 'error',
+    required: false,
+    description: 'Preenchido pelo Google quando o consentimento é negado',
+  })
   async callback(
     @Query('code') code: string,
     @Query('state') tutorId: string,
+    @Query('error') error: string,
     @Res() res: Response,
   ) {
-    await this.googleCalendarService.handleCallback(code, tutorId);
-    res.send(
-      '<html><body><h2>Google Calendar conectado com sucesso!</h2><p>Pode fechar esta janela e voltar ao app.</p></body></html>',
-    );
+    // Esta rota é o retorno do navegador: qualquer falha precisa virar página,
+    // não um 500 com stack trace na cara do usuário.
+    if (error) {
+      this.logger.warn(`Consentimento negado no Google Calendar: ${error}`);
+      res
+        .status(HttpStatus.BAD_REQUEST)
+        .send(
+          this.renderCallbackPage(
+            false,
+            'Autorização não concluída',
+            'Você não autorizou o acesso ao Google Agenda. Volte ao app e tente de novo se quiser conectar.',
+          ),
+        );
+      return;
+    }
+
+    if (!code || !tutorId) {
+      this.logger.warn(
+        `Callback do Google Calendar sem parâmetros (code=${!!code}, state=${!!tutorId})`,
+      );
+      res
+        .status(HttpStatus.BAD_REQUEST)
+        .send(
+          this.renderCallbackPage(
+            false,
+            'Link inválido',
+            'Este endereço não veio de uma autorização válida do Google. Inicie a conexão pelo app.',
+          ),
+        );
+      return;
+    }
+
+    try {
+      await this.googleCalendarService.handleCallback(code, tutorId);
+      res.send(
+        this.renderCallbackPage(
+          true,
+          'Google Calendar conectado com sucesso!',
+          'Pode fechar esta janela e voltar ao app.',
+        ),
+      );
+    } catch (err) {
+      this.logger.error(
+        `Falha ao concluir o callback do Google Calendar (tutor ${tutorId})`,
+        err instanceof Error ? err.stack : err,
+      );
+      res
+        .status(HttpStatus.INTERNAL_SERVER_ERROR)
+        .send(
+          this.renderCallbackPage(
+            false,
+            'Não foi possível conectar',
+            err instanceof Error
+              ? err.message
+              : 'Erro inesperado ao conectar o Google Agenda.',
+          ),
+        );
+    }
+  }
+
+  private renderCallbackPage(
+    ok: boolean,
+    title: string,
+    message: string,
+  ): string {
+    const accent = ok ? '#06A77D' : '#E63946';
+    return `<!DOCTYPE html>
+<html lang="pt-BR"><head><meta charset="utf-8"><title>PetCard - Google Calendar</title>
+<style>
+  body { font-family: system-ui; max-width: 480px; margin: 40px auto; padding: 0 20px; background: #F6FBFE; color: #14313F; }
+  .card { background: #fff; border: 1px solid #D8EEF6; border-left: 4px solid ${accent}; border-radius: 12px; padding: 24px; }
+  h2 { color: ${accent}; margin-top: 0; }
+</style></head><body>
+<div class="card"><h2>${escapeHtml(title)}</h2><p>${escapeHtml(message)}</p></div>
+</body></html>`;
   }
 
   @Get('dev-connect')

--- a/src/modules/calendar/google-api-error.ts
+++ b/src/modules/calendar/google-api-error.ts
@@ -1,0 +1,24 @@
+/**
+ * Helpers para classificar erros da API do Google Calendar.
+ *
+ * O `googleapis` expõe o status ora em `code`, ora em `response.status`,
+ * dependendo do caminho que levantou o erro.
+ */
+export function extractGoogleStatus(error: unknown): number | undefined {
+  if (typeof error !== 'object' || error === null) return undefined;
+  const err = error as { code?: unknown; response?: { status?: unknown } };
+  if (typeof err.code === 'number') return err.code;
+  const status = err.response?.status;
+  return typeof status === 'number' ? status : undefined;
+}
+
+/**
+ * O evento não está mais lá: `404` (nunca existiu) ou `410` (existia e já foi
+ * apagado — o Google responde "Resource has been deleted"). Para UPDATE/DELETE
+ * os dois casos significam que o estado desejado já vale, então a operação é
+ * idempotente e não deve ser repetida nem mandada para a DLQ.
+ */
+export function isAlreadyGoneError(error: unknown): boolean {
+  const status = extractGoogleStatus(error);
+  return status === 404 || status === 410;
+}

--- a/src/modules/calendar/google-calendar.service.ts
+++ b/src/modules/calendar/google-calendar.service.ts
@@ -1,4 +1,9 @@
-import { Injectable, Logger } from '@nestjs/common';
+import {
+  BadGatewayException,
+  Injectable,
+  Logger,
+  ServiceUnavailableException,
+} from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { google, calendar_v3 } from 'googleapis';
 import { OAuth2Client } from 'google-auth-library';
@@ -6,6 +11,9 @@ import { PrismaService } from '../../prisma/prisma.service';
 import { EncryptionService } from '../../common/crypto/encryption.service';
 
 const SCOPES = ['https://www.googleapis.com/auth/calendar.events'];
+
+/** Validade assumida quando o Google não informa expiry_date. */
+const DEFAULT_TOKEN_TTL_MS = 3_600_000;
 
 @Injectable()
 export class GoogleCalendarService {
@@ -52,24 +60,63 @@ export class GoogleCalendarService {
   }
 
   async handleCallback(code: string, tutorId: string): Promise<void> {
+    if (!this.isConfigured) {
+      throw new ServiceUnavailableException(
+        'Integração com o Google Calendar não está configurada no servidor.',
+      );
+    }
+
+    // O código do Google é de uso único: valida a chave antes de trocá-lo, senão
+    // o usuário precisa refazer o consentimento por uma falha de configuração.
+    this.encryption.assertConfigured();
+
     const oauth2Client = this.createOAuth2Client();
     const { tokens } = await oauth2Client.getToken(code);
+
+    if (!tokens.access_token) {
+      throw new BadGatewayException(
+        'O Google não devolveu um access token para esta autorização.',
+      );
+    }
+
+    // O refresh token só vem no primeiro consentimento. Numa reconexão, o Google
+    // pode omiti-lo — nesse caso mantemos o que já está salvo.
+    const novoRefreshToken = tokens.refresh_token
+      ? this.encryption.encrypt(tokens.refresh_token)
+      : undefined;
+
+    const existente = await this.prisma.googleOAuthToken.findUnique({
+      where: { tutorId },
+      select: { refreshToken: true },
+    });
+
+    const refreshTokenParaCriar = novoRefreshToken ?? existente?.refreshToken;
+    if (!refreshTokenParaCriar) {
+      throw new BadGatewayException(
+        'O Google não devolveu um refresh token. Remova o acesso do PetCard em ' +
+          'myaccount.google.com/permissions e conecte novamente.',
+      );
+    }
+
+    const accessToken = this.encryption.encrypt(tokens.access_token);
+    const expiresAt = tokens.expiry_date
+      ? new Date(tokens.expiry_date)
+      : new Date(Date.now() + DEFAULT_TOKEN_TTL_MS);
 
     await this.prisma.googleOAuthToken.upsert({
       where: { tutorId },
       update: {
-        accessToken: this.encryption.encrypt(tokens.access_token!),
-        refreshToken: tokens.refresh_token
-          ? this.encryption.encrypt(tokens.refresh_token)
-          : undefined,
-        expiresAt: new Date(tokens.expiry_date!),
+        accessToken,
+        // undefined preserva o refresh token já salvo.
+        refreshToken: novoRefreshToken,
+        expiresAt,
         scopes: SCOPES,
       },
       create: {
         tutorId,
-        accessToken: this.encryption.encrypt(tokens.access_token!),
-        refreshToken: this.encryption.encrypt(tokens.refresh_token!),
-        expiresAt: new Date(tokens.expiry_date!),
+        accessToken,
+        refreshToken: refreshTokenParaCriar,
+        expiresAt,
         scopes: SCOPES,
       },
     });

--- a/src/modules/calendar/google-calendar.service.ts
+++ b/src/modules/calendar/google-calendar.service.ts
@@ -121,6 +121,18 @@ export class GoogleCalendarService {
         scopes: SCOPES,
       },
     });
+
+    // Recupera o que ficou para trás enquanto não havia conexão válida. Sem
+    // isso, quem reconecta depois de uma revogação nunca mais veria esses
+    // agendamentos na agenda — não há mais botão de sincronizar no app.
+    // Fora do caminho da resposta: a página de sucesso não espera o catch-up.
+    void this.syncAllPending(tutorId).catch((error: unknown) => {
+      this.logger.warn(
+        `Catch-up de sincronização falhou para o tutor ${tutorId}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    });
   }
 
   async isConnected(tutorId: string): Promise<boolean> {

--- a/src/modules/calendar/google-calendar.service.ts
+++ b/src/modules/calendar/google-calendar.service.ts
@@ -9,6 +9,7 @@ import { google, calendar_v3 } from 'googleapis';
 import { OAuth2Client } from 'google-auth-library';
 import { PrismaService } from '../../prisma/prisma.service';
 import { EncryptionService } from '../../common/crypto/encryption.service';
+import { isAlreadyGoneError } from './google-api-error';
 
 const SCOPES = ['https://www.googleapis.com/auth/calendar.events'];
 
@@ -295,6 +296,14 @@ export class GoogleCalendarService {
         eventId: googleEventId,
       });
     } catch (error) {
+      // Apagar é idempotente: se o evento já não está lá, o objetivo foi
+      // atingido. Sem isso, apagar duas vezes virava erro, 3 retries e DLQ.
+      if (isAlreadyGoneError(error)) {
+        this.logger.log(
+          `Calendar event ${googleEventId} já não existe no Google; nada a apagar`,
+        );
+        return;
+      }
       this.logger.error(
         `Failed to delete calendar event ${googleEventId}`,
         error instanceof Error ? error.stack : error,


### PR DESCRIPTION
Fecha #110.

## O 500 que aparecia

O erro reportado vinha de `ENCRYPTION_KEY` ausente no `.env` local — a variável entrou no `.env.example` depois do arquivo local ser criado. O `EncryptionService` lê a chave sob demanda (de propósito, para não exigir a variável no boot quando o Calendar não está configurado), então a API subia normalmente e só estourava no callback, na hora de cifrar os tokens.

Isso é ambiente, não código. Mas investigando o caminho apareceram defeitos reais que produzem o mesmo sintoma.

## Correções

**O callback nunca mais devolve stack trace.** É a página de retorno do consentimento no navegador; qualquer falha agora vira HTML, com o detalhe no log do servidor. Casos que antes estouravam em 500:

- **Consentimento negado** — o Google redireciona com `?error=access_denied` e sem `code`; caía em `getToken(undefined)`.
- **`code` ou `state` ausentes** — mesma coisa.
- **Integração sem client id/secret** — `getAuthUrl` já devolvia `null` nesse caso, mas `handleCallback` seguia em frente com erro opaco.
- **Google sem `access_token` ou `expiry_date`** — os `!` mascaravam; `new Date(undefined)` gerava Invalid Date e quebrava no Prisma.
- **Reconexão sem `refresh_token` novo** — o Google só o envia no primeiro consentimento. O branch `create` do upsert fazia `encrypt(tokens.refresh_token!)` com `undefined`, quebrando numa coluna obrigatória. Agora reaproveita o token já salvo; sem nenhum, orienta a revogar o acesso em `myaccount.google.com/permissions` e refazer.

**Falha antes de gastar o código OAuth.** O código do Google é de uso único. Com a chave ausente, o erro só aparecia *depois* da troca — o código queimava e o usuário tinha que refazer o consentimento inteiro. Novo `EncryptionService.assertConfigured()` valida antes.

**`.gitignore` ampliado para `.env.*`** (preservando `.env.example`): backups locais de `.env` ficavam rastreáveis, com risco de subir segredos.

## Verificação

Smoke test contra a API rodando e o Google real:

| Cenário | Antes | Agora |
| --- | --- | --- |
| `?error=access_denied` | 500 + stack | 400, "Autorização não concluída" |
| sem `code`/`state` | 500 + stack | 400, "Link inválido" |
| `code` inválido | 500 + stack | 500, "Não foi possível conectar — invalid_grant" |

Nenhuma resposta contém stack trace. O caso do `code` inválido chegou a trocar com o Google, o que confirma que a validação da chave passou.

14 testes novos (callback do controller incluindo escape de HTML, cenários de token no serviço, `assertConfigured`). Suíte: 361 verdes. Cobertura 85.75 / 81.47 / 94.56 / 87.32 (catraca 84/80/93/85).

## Para rodar em dev

`ENCRYPTION_KEY` precisa existir no `.env` — gere com `openssl rand -hex 32`. O `.env.example` já traz a entrada.