### PR TITLE
feat: cadastro público de veterinário com verificação de CRMV (#124)

### DIFF
--- a/src/modules/auth/__tests__/auth.controller.spec.ts
+++ b/src/modules/auth/__tests__/auth.controller.spec.ts
@@ -15,6 +15,7 @@ describe('AuthController (integração)', () => {
     register: jest.Mock;
     login: jest.Mock;
     loginVeterinario: jest.Mock;
+    registerVeterinario: jest.Mock;
     getVeterinarioProfile: jest.Mock;
   };
 
@@ -23,6 +24,7 @@ describe('AuthController (integração)', () => {
       register: jest.fn(),
       login: jest.fn(),
       loginVeterinario: jest.fn(),
+      registerVeterinario: jest.fn(),
       getVeterinarioProfile: jest.fn(),
     };
 
@@ -106,6 +108,35 @@ describe('AuthController (integração)', () => {
   });
 
   describe('Veterinário', () => {
+    it('POST /auth/veterinario/register cadastra sem autenticação (201)', async () => {
+      auth.registerVeterinario.mockResolvedValue({
+        access_token: 'jwt-vet',
+        crmv_verificado: true,
+      });
+
+      const res = await request(harness.app.getHttpServer())
+        .post('/auth/veterinario/register')
+        .send({
+          nome: 'Dr. Carlos',
+          email: 'carlos@vet.com',
+          password: 'senha-forte',
+          crmv: 'CRMV-SP 12345',
+        })
+        .expect(201);
+
+      expect(res.body.access_token).toBe('jwt-vet');
+      expect(res.body.crmv_verificado).toBe(true);
+    });
+
+    it('POST /auth/veterinario/register rejeita payload inválido (400)', async () => {
+      await request(harness.app.getHttpServer())
+        .post('/auth/veterinario/register')
+        .send({ nome: 'Dr. Carlos' })
+        .expect(400);
+
+      expect(auth.registerVeterinario).not.toHaveBeenCalled();
+    });
+
     it('POST /auth/veterinario/login autentica (201)', async () => {
       auth.loginVeterinario.mockResolvedValue({ access_token: 'jwt-vet' });
 

--- a/src/modules/auth/__tests__/auth.service.spec.ts
+++ b/src/modules/auth/__tests__/auth.service.spec.ts
@@ -1,26 +1,32 @@
-import { ConflictException, UnauthorizedException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ConflictException,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { Test, TestingModule } from '@nestjs/testing';
 import * as bcrypt from 'bcrypt';
 import { PrismaService } from '../../../prisma/prisma.service';
+import { CrmvVerificationService } from '../../veterinario/crmv/crmv-verification.service';
 import { AuthService } from '../auth.service';
 
-jest.mock(
-  'bcrypt',
-  () => ({
-    hash: jest.fn(),
-    compare: jest.fn(),
-  }),
-  { virtual: true },
-);
+// Sem `virtual: true`: bcrypt existe em disco, e marcá-lo como virtual fazia o
+// Jest às vezes resolver o módulo real a partir do cache de transform. O hash
+// verdadeiro então não batia com a fixture e o login falhava em execuções
+// alternadas — a instabilidade da api#107.
+jest.mock('bcrypt', () => ({
+  hash: jest.fn(),
+  compare: jest.fn(),
+}));
 
 describe('AuthService', () => {
   let service: AuthService;
   let prisma: {
     tutor: { findUnique: jest.Mock; create: jest.Mock };
-    veterinario: { findUnique: jest.Mock };
+    veterinario: { findUnique: jest.Mock; create: jest.Mock };
   };
   let jwtService: { sign: jest.Mock };
+  let crmvVerification: { parseCrmv: jest.Mock; verify: jest.Mock };
 
   const tutorFixture = {
     id: 'tutor-1',
@@ -38,15 +44,21 @@ describe('AuthService', () => {
       },
       veterinario: {
         findUnique: jest.fn(),
+        create: jest.fn(),
       },
     };
     jwtService = { sign: jest.fn().mockReturnValue('jwt-token') };
+    crmvVerification = {
+      parseCrmv: jest.fn().mockReturnValue({ numero: '12345', uf: 'SP' }),
+      verify: jest.fn().mockResolvedValue({ verified: true }),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AuthService,
         { provide: PrismaService, useValue: prisma },
         { provide: JwtService, useValue: jwtService },
+        { provide: CrmvVerificationService, useValue: crmvVerification },
       ],
     }).compile();
 
@@ -114,6 +126,107 @@ describe('AuthService', () => {
       await expect(
         service.login({ email: 'unknown@example.com', password: '123456' }),
       ).rejects.toThrow(UnauthorizedException);
+    });
+  });
+
+  describe('registerVeterinario', () => {
+    const novoVet = {
+      nome: 'Dr. Carlos',
+      email: 'carlos@vet.com',
+      password: 'senha-forte',
+      crmv: 'CRMV-SP 12345',
+      telefone: '85999999999',
+    };
+    const vetCriado = {
+      id: 'vet-9',
+      nome: 'Dr. Carlos',
+      email: 'carlos@vet.com',
+      password: 'hashed-password',
+      crmv: 'CRMV-SP 12345',
+      telefone: '85999999999',
+    };
+
+    beforeEach(() => {
+      prisma.veterinario.findUnique.mockResolvedValue(null);
+      prisma.veterinario.create.mockResolvedValue(vetCriado);
+      (bcrypt.hash as jest.Mock).mockResolvedValue('hashed-password');
+    });
+
+    it('cria o veterinário, verifica o CRMV e devolve token', async () => {
+      const result = await service.registerVeterinario(novoVet);
+
+      expect(result.access_token).toBe('jwt-token');
+      expect(result.user.crmv).toBe('CRMV-SP 12345');
+      expect(result.user.role).toBe('VET');
+      expect(result.crmv_verificado).toBe(true);
+      expect(crmvVerification.verify).toHaveBeenCalledWith('vet-9');
+    });
+
+    it('não devolve o hash da senha', async () => {
+      const result = await service.registerVeterinario(novoVet);
+
+      expect(result.user).not.toHaveProperty('password');
+    });
+
+    it('grava a senha cifrada, nunca em texto puro', async () => {
+      await service.registerVeterinario(novoVet);
+
+      const [[chamada]] = prisma.veterinario.create.mock.calls as Array<
+        [{ data: { password: string } }]
+      >;
+      expect(chamada.data.password).toBe('hashed-password');
+      expect(chamada.data.password).not.toBe('senha-forte');
+    });
+
+    it('recusa email já cadastrado (409)', async () => {
+      prisma.veterinario.findUnique.mockResolvedValueOnce(vetCriado);
+
+      await expect(service.registerVeterinario(novoVet)).rejects.toThrow(
+        ConflictException,
+      );
+      expect(prisma.veterinario.create).not.toHaveBeenCalled();
+    });
+
+    it('recusa CRMV já cadastrado (409)', async () => {
+      prisma.veterinario.findUnique
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(vetCriado);
+
+      await expect(service.registerVeterinario(novoVet)).rejects.toThrow(
+        ConflictException,
+      );
+      expect(prisma.veterinario.create).not.toHaveBeenCalled();
+    });
+
+    it('recusa CRMV mal formatado antes de criar a conta', async () => {
+      crmvVerification.parseCrmv.mockImplementation(() => {
+        throw new BadRequestException('formato inválido');
+      });
+
+      await expect(service.registerVeterinario(novoVet)).rejects.toThrow(
+        BadRequestException,
+      );
+      // Não pode sobrar conta órfã de um CRMV que nunca será verificável.
+      expect(prisma.veterinario.create).not.toHaveBeenCalled();
+    });
+
+    it('cria a conta mesmo se o provedor de CRMV estiver fora do ar', async () => {
+      crmvVerification.verify.mockRejectedValue(
+        new Error('provedor indisponível'),
+      );
+
+      const result = await service.registerVeterinario(novoVet);
+
+      expect(result.access_token).toBe('jwt-token');
+      expect(result.crmv_verificado).toBe(false);
+    });
+
+    it('marca como não verificado quando o registro é recusado', async () => {
+      crmvVerification.verify.mockResolvedValue({ verified: false });
+
+      const result = await service.registerVeterinario(novoVet);
+
+      expect(result.crmv_verificado).toBe(false);
     });
   });
 

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -6,6 +6,7 @@ import {
   ApiTags,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
+import { CreateVeterinarioDto } from '@petcardorg/shared';
 import { AuthService } from './auth.service';
 import { CurrentUser } from './decorators/current-user.decorator';
 import { LoginDto } from './dto/login.dto';
@@ -44,6 +45,20 @@ export class AuthController {
   @ApiUnauthorizedResponse({ description: 'Token ausente ou inválido' })
   getProfile(@CurrentUser() user: JwtPayload): JwtPayload {
     return user;
+  }
+
+  @Post('veterinario/register')
+  @Public()
+  @ApiOperation({
+    summary: 'Cadastrar veterinário (JWT com role VET)',
+    description:
+      'O CRMV é validado na base externa durante o cadastro. Se o provedor ' +
+      'estiver indisponível, a conta é criada mesmo assim como não ' +
+      'verificada — veja `crmv_verificado` na resposta.',
+  })
+  @ApiConflictResponse({ description: 'Email ou CRMV já cadastrado' })
+  registerVeterinario(@Body() dto: CreateVeterinarioDto) {
+    return this.authService.registerVeterinario(dto);
   }
 
   @Post('veterinario/login')

--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -1,9 +1,10 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { APP_GUARD } from '@nestjs/core';
 import { JwtModule, type JwtModuleOptions } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
 import { PrismaModule } from '../../prisma/prisma.module';
+import { VeterinarioModule } from '../veterinario/veterinario.module';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 import { JwtAuthGuard } from './guards/jwt-auth.guard';
@@ -23,6 +24,9 @@ import { JwtStrategy } from './strategies/jwt.strategy';
       }),
     }),
     PrismaModule,
+    // O cadastro de veterinário verifica o CRMV; o módulo de veterinário, por
+    // sua vez, depende dos guards daqui. forwardRef resolve o ciclo.
+    forwardRef(() => VeterinarioModule),
   ],
   controllers: [AuthController],
   providers: [

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -1,11 +1,16 @@
 import {
   ConflictException,
+  Inject,
   Injectable,
+  Logger,
   UnauthorizedException,
+  forwardRef,
 } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import * as bcrypt from 'bcrypt';
+import { CreateVeterinarioDto } from '@petcardorg/shared';
 import { PrismaService } from '../../prisma/prisma.service';
+import { CrmvVerificationService } from '../veterinario/crmv/crmv-verification.service';
 import { LoginDto } from './dto/login.dto';
 import { RegisterDto } from './dto/register.dto';
 import { Role } from './enums/role.enum';
@@ -14,9 +19,13 @@ const BCRYPT_ROUNDS = 10;
 
 @Injectable()
 export class AuthService {
+  private readonly logger = new Logger(AuthService.name);
+
   constructor(
     private readonly prisma: PrismaService,
     private readonly jwtService: JwtService,
+    @Inject(forwardRef(() => CrmvVerificationService))
+    private readonly crmvVerification: CrmvVerificationService,
   ) {}
 
   async register(dto: RegisterDto) {
@@ -76,6 +85,73 @@ export class AuthService {
         email: tutor.email,
         role: tutor.role,
       },
+    };
+  }
+
+  /**
+   * Cadastro público de veterinário (api#124).
+   *
+   * O CRMV é validado na base externa durante o cadastro, para o veterinário
+   * já entrar liberado em vez de esbarrar no bloqueio da api#113 no primeiro
+   * atendimento.
+   */
+  async registerVeterinario(dto: CreateVeterinarioDto) {
+    const porEmail = await this.prisma.veterinario.findUnique({
+      where: { email: dto.email },
+    });
+    if (porEmail) {
+      throw new ConflictException('Email already registered');
+    }
+
+    const porCrmv = await this.prisma.veterinario.findUnique({
+      where: { crmv: dto.crmv },
+    });
+    if (porCrmv) {
+      throw new ConflictException('CRMV already registered');
+    }
+
+    // Formato irreconhecível falha aqui, antes de criar a conta: não vale
+    // cadastrar um CRMV que nunca poderá ser verificado.
+    this.crmvVerification.parseCrmv(dto.crmv);
+
+    const hashedPassword = await bcrypt.hash(dto.password, BCRYPT_ROUNDS);
+
+    const vet = await this.prisma.veterinario.create({
+      data: {
+        nome: dto.nome,
+        email: dto.email,
+        password: hashedPassword,
+        crmv: dto.crmv,
+        telefone: dto.telefone,
+      },
+    });
+
+    // A verificação é tentada, mas não pode barrar o cadastro: o provedor é
+    // externo e pago, e uma indisponibilidade dele não pode impedir alguém de
+    // criar conta. Quem nascer não verificado usa o botão de verificar depois.
+    let crmvVerificado = false;
+    try {
+      const status = await this.crmvVerification.verify(vet.id);
+      crmvVerificado = status.verified;
+    } catch (error) {
+      this.logger.warn(
+        `Cadastro de ${dto.email} concluído sem verificar o CRMV ${dto.crmv}: ${
+          error instanceof Error ? error.message : 'erro desconhecido'
+        }`,
+      );
+    }
+
+    return {
+      access_token: this.signToken(vet.id, vet.email, Role.VET),
+      user: {
+        id: vet.id,
+        nome: vet.nome,
+        email: vet.email,
+        crmv: vet.crmv,
+        telefone: vet.telefone,
+        role: Role.VET,
+      },
+      crmv_verificado: crmvVerificado,
     };
   }
 

--- a/src/modules/veterinario/__tests__/dashboard.service.spec.ts
+++ b/src/modules/veterinario/__tests__/dashboard.service.spec.ts
@@ -2,19 +2,15 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { PrismaService } from '../../../prisma/prisma.service';
 import { VeterinarioService } from '../veterinario.service';
 
-jest.mock(
-  'bcrypt',
-  () => ({
+jest.mock('bcrypt', () => ({
+  hash: jest.fn().mockResolvedValue('hashed-password'),
+  compare: jest.fn(),
+  __esModule: true,
+  default: {
     hash: jest.fn().mockResolvedValue('hashed-password'),
     compare: jest.fn(),
-    __esModule: true,
-    default: {
-      hash: jest.fn().mockResolvedValue('hashed-password'),
-      compare: jest.fn(),
-    },
-  }),
-  { virtual: true },
-);
+  },
+}));
 
 describe('VeterinarioService - findAttendedPets', () => {
   let service: VeterinarioService;

--- a/src/modules/veterinario/__tests__/veterinario.controller.spec.ts
+++ b/src/modules/veterinario/__tests__/veterinario.controller.spec.ts
@@ -3,7 +3,6 @@ import request from 'supertest';
 import {
   createControllerTestApp,
   ControllerHarness,
-  TUTOR,
   VET,
 } from '../../../../test/utils/controller-harness';
 import { PrismaService } from '../../../prisma/prisma.service';
@@ -24,6 +23,7 @@ describe('VeterinarioController (integração)', () => {
     notaClinica: { findMany: jest.Mock };
     pet: { findMany: jest.Mock };
   };
+  let crmv: { getStatus: jest.Mock; verify: jest.Mock };
 
   const vet = {
     id: 'vet-1',
@@ -48,19 +48,17 @@ describe('VeterinarioController (integração)', () => {
       notaClinica: { findMany: jest.fn() },
       pet: { findMany: jest.fn() },
     };
+    crmv = {
+      getStatus: jest.fn().mockResolvedValue({ verified: false }),
+      verify: jest.fn().mockResolvedValue({ verified: true }),
+    };
 
     harness = await createControllerTestApp({
       controllers: [VeterinarioController],
       providers: [
         VeterinarioService,
         { provide: PrismaService, useValue: prisma },
-        {
-          provide: CrmvVerificationService,
-          useValue: {
-            getStatus: jest.fn().mockResolvedValue({ verified: false }),
-            verify: jest.fn().mockResolvedValue({ verified: true }),
-          },
-        },
+        { provide: CrmvVerificationService, useValue: crmv },
       ],
     });
   });
@@ -74,63 +72,30 @@ describe('VeterinarioController (integração)', () => {
     harness.setUser(VET);
   });
 
-  describe('POST /veterinarios', () => {
-    it('cria um veterinário e não expõe o password (201)', async () => {
-      prisma.veterinario.findUnique.mockResolvedValue(null);
-      prisma.veterinario.create.mockResolvedValue(vet);
-
+  describe('CRMV do próprio veterinário', () => {
+    it('GET /veterinarios/me/crmv devolve a situação (200)', async () => {
       const res = await request(harness.app.getHttpServer())
-        .post('/veterinarios')
-        .send({
-          nome: 'Dra. Vet',
-          email: 'vet@petcard.com',
-          password: 'senha-forte',
-          crmv: 'CRMV-123',
-        })
-        .expect(201);
+        .get('/veterinarios/me/crmv')
+        .expect(200);
 
-      expect(res.body.id).toBe('vet-1');
-      expect(res.body.password).toBeUndefined();
+      expect(res.body.verified).toBe(false);
     });
 
-    it('proíbe TUTOR de criar veterinário (403)', async () => {
-      harness.setUser(TUTOR);
+    it('POST /veterinarios/me/crmv/verificar dispara a consulta (200)', async () => {
+      const res = await request(harness.app.getHttpServer())
+        .post('/veterinarios/me/crmv/verificar')
+        .expect(200);
 
-      await request(harness.app.getHttpServer())
-        .post('/veterinarios')
-        .send({
-          nome: 'Dra. Vet',
-          email: 'vet@petcard.com',
-          password: 'senha-forte',
-          crmv: 'CRMV-123',
-        })
-        .expect(403);
+      expect(res.body.verified).toBe(true);
+      expect(crmv.verify).toHaveBeenCalledWith('vet-1', false);
     });
 
-    it('rejeita payload inválido (400)', async () => {
+    it('POST .../verificar?force=true reconsulta mesmo dentro do prazo', async () => {
       await request(harness.app.getHttpServer())
-        .post('/veterinarios')
-        .send({ nome: 'Dra. Vet' })
-        .expect(400);
+        .post('/veterinarios/me/crmv/verificar?force=true')
+        .expect(200);
 
-      expect(prisma.veterinario.create).not.toHaveBeenCalled();
-    });
-
-    it('rejeita email já cadastrado (409)', async () => {
-      prisma.veterinario.findUnique.mockResolvedValue({
-        ...vet,
-        id: 'outro',
-      });
-
-      await request(harness.app.getHttpServer())
-        .post('/veterinarios')
-        .send({
-          nome: 'Dra. Vet',
-          email: 'vet@petcard.com',
-          password: 'senha-forte',
-          crmv: 'CRMV-123',
-        })
-        .expect(409);
+      expect(crmv.verify).toHaveBeenCalledWith('vet-1', true);
     });
   });
 

--- a/src/modules/veterinario/__tests__/veterinario.service.spec.ts
+++ b/src/modules/veterinario/__tests__/veterinario.service.spec.ts
@@ -3,22 +3,19 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { PrismaService } from '../../../prisma/prisma.service';
 import { VeterinarioService } from '../veterinario.service';
 
-// bcrypt is not installed in the local node_modules (native dependency —
-// same issue as auth.service.spec.ts). We mock the entire module so the
-// test suite can run without the native binary.
-jest.mock(
-  'bcrypt',
-  () => ({
+// Mock do bcrypt para o teste não pagar o custo do hash real.
+// Sem `virtual: true`: bcrypt existe em disco, e marcá-lo como virtual fazia o
+// Jest às vezes resolver o módulo real a partir do cache de transform, o que
+// derrubava os testes em execuções alternadas (api#107).
+jest.mock('bcrypt', () => ({
+  hash: jest.fn().mockResolvedValue('hashed-password'),
+  compare: jest.fn(),
+  __esModule: true,
+  default: {
     hash: jest.fn().mockResolvedValue('hashed-password'),
     compare: jest.fn(),
-    __esModule: true,
-    default: {
-      hash: jest.fn().mockResolvedValue('hashed-password'),
-      compare: jest.fn(),
-    },
-  }),
-  { virtual: true },
-);
+  },
+}));
 
 describe('VeterinarioService', () => {
   let service: VeterinarioService;
@@ -62,53 +59,6 @@ describe('VeterinarioService', () => {
     }).compile();
 
     service = module.get<VeterinarioService>(VeterinarioService);
-  });
-
-  describe('create', () => {
-    it('should create a veterinario and omit password from response', async () => {
-      prisma.veterinario.findUnique.mockResolvedValue(null);
-      prisma.veterinario.create.mockResolvedValue(vetFixture);
-
-      const result = await service.create({
-        nome: 'Dr. Carlos',
-        email: 'carlos@vet.com',
-        password: 'secret123',
-        crmv: 'CRMV-CE-12345',
-        telefone: '85999999999',
-      });
-
-      expect(result).not.toHaveProperty('password');
-      expect(result.nome).toBe('Dr. Carlos');
-      expect(result.crmv).toBe('CRMV-CE-12345');
-    });
-
-    it('should throw ConflictException when email is duplicated', async () => {
-      prisma.veterinario.findUnique.mockResolvedValueOnce(vetFixture);
-
-      await expect(
-        service.create({
-          nome: 'Dr. Ana',
-          email: 'carlos@vet.com',
-          password: 'secret123',
-          crmv: 'CRMV-CE-99999',
-        }),
-      ).rejects.toThrow(ConflictException);
-    });
-
-    it('should throw ConflictException when CRMV is duplicated', async () => {
-      prisma.veterinario.findUnique
-        .mockResolvedValueOnce(null)
-        .mockResolvedValueOnce(vetFixture);
-
-      await expect(
-        service.create({
-          nome: 'Dr. Ana',
-          email: 'ana@vet.com',
-          password: 'secret123',
-          crmv: 'CRMV-CE-12345',
-        }),
-      ).rejects.toThrow(ConflictException);
-    });
   });
 
   describe('findAll', () => {

--- a/src/modules/veterinario/veterinario.controller.ts
+++ b/src/modules/veterinario/veterinario.controller.ts
@@ -20,7 +20,7 @@ import { Auth } from '../auth/decorators/auth.decorator';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { Role } from '../auth/enums/role.enum';
 import type { JwtPayload } from '../auth/strategies/jwt.strategy';
-import { CreateVeterinarioDto, UpdateVeterinarioDto } from '@petcardorg/shared';
+import { UpdateVeterinarioDto } from '@petcardorg/shared';
 import { DashboardQueryDto } from './dto/dashboard-query.dto';
 import {
   CrmvVerificationService,
@@ -40,15 +40,6 @@ export class VeterinarioController {
     private readonly veterinarioService: VeterinarioService,
     private readonly crmvVerification: CrmvVerificationService,
   ) {}
-
-  @Post()
-  @Auth(Role.VET)
-  @ApiOperation({ summary: 'Cadastrar veterinário' })
-  async create(
-    @Body() dto: CreateVeterinarioDto,
-  ): Promise<VeterinarioResponse> {
-    return this.veterinarioService.create(dto);
-  }
 
   // Declaradas antes de @Get(':id'), senão "me" seria capturado como id.
   @Get('me/crmv')

--- a/src/modules/veterinario/veterinario.service.ts
+++ b/src/modules/veterinario/veterinario.service.ts
@@ -5,7 +5,7 @@ import {
 } from '@nestjs/common';
 import { Prisma, Veterinario } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
-import { CreateVeterinarioDto, UpdateVeterinarioDto } from '@petcardorg/shared';
+import { UpdateVeterinarioDto } from '@petcardorg/shared';
 import { DashboardQueryDto } from './dto/dashboard-query.dto';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -43,24 +43,6 @@ function toResponse(vet: Veterinario): VeterinarioResponse {
 @Injectable()
 export class VeterinarioService {
   constructor(private readonly prisma: PrismaService) {}
-
-  async create(dto: CreateVeterinarioDto): Promise<VeterinarioResponse> {
-    await this.assertUniqueFields(dto.email, dto.crmv);
-
-    const hashedPassword = await bcrypt.hash(dto.password, BCRYPT_ROUNDS);
-
-    const vet = await this.prisma.veterinario.create({
-      data: {
-        nome: dto.nome,
-        email: dto.email,
-        password: hashedPassword,
-        crmv: dto.crmv,
-        telefone: dto.telefone,
-      },
-    });
-
-    return toResponse(vet);
-  }
 
   async findAll(): Promise<VeterinarioResponse[]> {
     const vets = await this.prisma.veterinario.findMany({

--- a/test/e2e/auth.e2e-spec.ts
+++ b/test/e2e/auth.e2e-spec.ts
@@ -83,6 +83,77 @@ describe('Auth (e2e)', () => {
   });
 
   describe('Veterinário', () => {
+    const novoVet = {
+      nome: 'Dr. Carlos',
+      email: 'carlos@vet.com',
+      password: 'senha-forte',
+      crmv: 'CRMV-SP 12345',
+    };
+
+    it('cadastra sem autenticação, já verificado, e acessa a área do vet', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/auth/veterinario/register')
+        .send(novoVet)
+        .expect(201);
+
+      // O stub aprova qualquer CRMV bem formado, então o cadastro já sai
+      // verificado e o vet não esbarra no bloqueio da api#113.
+      expect(res.body.crmv_verificado).toBe(true);
+      expect(res.body.user.password).toBeUndefined();
+
+      const profile = await request(app.getHttpServer())
+        .get('/auth/veterinario/profile')
+        .set('Authorization', `Bearer ${res.body.access_token as string}`)
+        .expect(200);
+      expect(profile.body.crmv).toBe('CRMV-SP 12345');
+    });
+
+    it('cadastra como não verificado quando o CRMV é recusado', async () => {
+      // 00000 é o número reservado que o stub recusa.
+      const res = await request(app.getHttpServer())
+        .post('/auth/veterinario/register')
+        .send({ ...novoVet, crmv: 'CRMV-SP 00000' })
+        .expect(201);
+
+      expect(res.body.crmv_verificado).toBe(false);
+      expect(res.body.access_token).toBeDefined();
+    });
+
+    it('rejeita CRMV em formato irreconhecível (400)', async () => {
+      await request(app.getHttpServer())
+        .post('/auth/veterinario/register')
+        .send({ ...novoVet, crmv: 'não é um crmv' })
+        .expect(400);
+
+      expect(await prisma.veterinario.count()).toBe(0);
+    });
+
+    it('rejeita CRMV já cadastrado (409)', async () => {
+      await request(app.getHttpServer())
+        .post('/auth/veterinario/register')
+        .send(novoVet)
+        .expect(201);
+
+      await request(app.getHttpServer())
+        .post('/auth/veterinario/register')
+        .send({ ...novoVet, email: 'outro@vet.com' })
+        .expect(409);
+    });
+
+    it('faz login com a conta recém-cadastrada', async () => {
+      await request(app.getHttpServer())
+        .post('/auth/veterinario/register')
+        .send(novoVet)
+        .expect(201);
+
+      const login = await request(app.getHttpServer())
+        .post('/auth/veterinario/login')
+        .send({ email: novoVet.email, password: novoVet.password })
+        .expect(201);
+
+      expect(login.body.access_token).toBeDefined();
+    });
+
     it('faz login e acessa o perfil de vet', async () => {
       const { token, user } = await createAndLoginVet(app, prisma);
       expect(user.crmv).toBe('CRMV-CE-1234');

--- a/test/e2e/setup-env.ts
+++ b/test/e2e/setup-env.ts
@@ -16,3 +16,7 @@ process.env.FCM_ENABLED ??= 'false';
 // Geocoding/Places exigem a chave no construtor; os fluxos de clínica não são
 // exercitados no e2e, então um valor dummy só satisfaz o boot.
 process.env.GOOGLE_MAPS_API_KEY ??= 'test-google-maps-key';
+// Atribuição direta, não `??=`: a consulta de CRMV é paga por chamada, e um
+// `.env` de desenvolvimento com CRMV_PROVIDER=infosimples faria o e2e gastar
+// dinheiro de verdade. O teste nunca fala com o provedor real.
+process.env.CRMV_PROVIDER = 'stub';


### PR DESCRIPTION
Fecha #124.

## O problema

Um veterinário real não tinha como entrar no PetCard. `POST /veterinarios` exigia `@Auth(Role.VET)` — para criar um veterinário era preciso já estar logado como veterinário. O único caminho era o seed ou inserção direta no banco. O helper de e2e até documentava isso: *"não há endpoint público de cadastro de vet"*.

## O que muda

- **`POST /auth/veterinario/register`**, pública, simétrica ao `register` do tutor. Devolve `{ access_token, user, crmv_verificado }` para já entrar logado. Reusa o `CreateVeterinarioDto` do shared — sem bump nem publish.
- **O CRMV é validado no cadastro**, reaproveitando o validador da #113. A conta nasce verificada e o veterinário não esbarra no bloqueio no primeiro atendimento. Se o provedor estiver fora do ar, a conta é criada como não verificada — o cadastro não pode depender da disponibilidade de um terceiro pago.
- **CRMV mal formatado falha antes de criar a conta**, para não sobrar registro que nunca poderá ser verificado.
- **Removido `POST /veterinarios`**, que criava veterinário sem passar pela validação de CRMV — um desvio da regra que a #113 acabou de estabelecer.

## Dois achados fora do escopo original

**A instabilidade da #107 foi resolvida.** Os mocks usavam `jest.mock('bcrypt', factory, { virtual: true })`, mas `virtual: true` declara que o módulo *não existe em disco* — e bcrypt existe. O Jest às vezes resolvia o módulo real a partir do cache de transform; o hash verdadeiro não batia com a fixture `'hashed-password'` e o login falhava. Reproduzia em **~50% das execuções de `src/modules/auth`** (bem mais que o "1 em 5–6" registrado) e nunca isolado, o que explica por que parecia aleatório. Medições: com `virtual: true` 2/4 falham; sem, 6/6 verdes, e 6/6 na suíte completa.

**O e2e podia gastar dinheiro.** Um `.env` de desenvolvimento com `CRMV_PROVIDER=infosimples` fazia a suíte consultar o provedor pago de verdade. O setup do e2e agora fixa `CRMV_PROVIDER=stub` por atribuição direta, não `??=`.

## Verificação

- 421 testes unitários + 30 e2e verdes; cobertura **85.96 / 80.39 / 93.7 / 87.38** (catraca 84/80/93/85).
- Suíte completa rodada 6× seguidas sem falha.
- `npm run lint` e `npm run build` limpos.

## Nota

O `openapi.json` e a collection Postman em `petcard-docs` ficam desatualizados: ganharam uma rota e perderam outra. Regenerar com `npm run openapi:json` quando for conveniente — não bloqueia esta PR.
