### PR TITLE
docs: atualizar contexto da api após a #113, #124 e a correção da #107

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,8 +13,8 @@ Backend do PetCard (carteira digital de saúde para pets). NestJS 11 + Prisma 6 
 - **RabbitMQ** — filas com DLX/DLQ + retry (padrão `qr-code.generate`, `notification.push`).
 - **Redis** provisionado no compose, **não consumido em código** — "capacidade reservada" (decisão de narrativa da defesa).
 - **AWS S3** para mídia.
-- **Auth:** JWT próprio (HS256 + bcrypt), roles `TUTOR`/`VET` no claim `role`, logins separados (`login` / `loginVeterinario`). **Auth0 abandonado (M0-#7) — não reintroduzir.** Sem refresh token.
-- **DTOs:** `@petcardorg/shared@0.10.0` (GitHub Packages). Resolver exige `NODE_AUTH_TOKEN` (PAT com `read:packages`). DTOs locais duplicados foram removidos — não reintroduzir.
+- **Auth:** JWT próprio (HS256 + bcrypt), roles `TUTOR`/`VET` no claim `role`, logins separados (`login` / `loginVeterinario`) e cadastro de vet público em `POST /auth/veterinario/register`, que valida o CRMV na criação (api#124). **Auth0 abandonado (M0-#7) — não reintroduzir.** Sem refresh token.
+- **DTOs:** `@petcardorg/shared@0.11.0` (GitHub Packages). Resolver exige `NODE_AUTH_TOKEN` (PAT com `read:packages`). DTOs locais duplicados foram removidos — não reintroduzir.
 - **Swagger/OpenAPI:** plugin `@nestjs/swagger` em `nest-cli.json`; UI em **`GET /docs`**. Documento gerado por `npm run openapi:json` (preview mode, sem subir infra).
 
 ## Padrões da API
@@ -31,13 +31,15 @@ Backend do PetCard (carteira digital de saúde para pets). NestJS 11 + Prisma 6 
 
 - Unit para services (mock de Prisma + externos), integração para controllers (supertest), E2E (Postgres real) para fluxos.
 - **Catraca de cobertura: 84/80/93/85 — não abaixar.** Ajuste que derruba cobertura cobre junto. Feature nova entra com teste.
-- ⚠️ **Flakiness conhecida (issue api#107):** ~1 a cada 5–6 rodadas completas de `npm test`, 1–2 testes de `auth.service.spec` falham ("Invalid credentials" — mock do bcrypt perde efeito; suspeita de corrida de cache de transform do ts-jest). Isolado passa sempre; CI nunca flakou. Risco p/ o vídeo demo.
+- ✅ **Flakiness da api#107 resolvida** (2026-08-17). A causa era `jest.mock('bcrypt', factory, { virtual: true })`: a flag declara que o módulo não existe em disco, mas bcrypt existe, e o Jest às vezes resolvia o módulo real pelo cache de transform — o hash verdadeiro não batia com a fixture e o login falhava. **Não usar `virtual: true` para mockar módulo que existe.**
 
 ## Gotchas
 
 - **CLI plugin do Swagger só instrumenta no build real** (`nest build`/`nest start`), **não sob `ts-node`** — DTOs locais ficam com schema vazio se gerados via ts-node. Por isso `openapi:json` = `nest build && node dist/scripts/generate-openapi.js`.
 - **`preview mode`** (`NestFactory.create(AppModule, { preview: true })`) monta o grafo de módulos e lê metadados sem instanciar providers nem rodar `onModuleInit` — gera o OpenAPI sem conectar Postgres/RabbitMQ.
 - Ao adicionar bloco `permissions:` num workflow, tudo não-listado vira `none` — incluir `packages: read`, senão `npm ci` falha (403) ao baixar `@petcardorg/shared`.
+- **O publish do `@petcardorg/shared` roda só em push para `main`** daquele repo. Bumpar a versão no `develop` não publica nada, e o `npm ci` da api quebra com `ETARGET`. O shared é o único repo cuja `main` acompanha o `develop` — o hold de `develop → main` vale para api, web, mobile e docs.
+- **Consulta de CRMV é paga por chamada.** O `test/e2e/setup-env.ts` fixa `CRMV_PROVIDER=stub` por atribuição direta, justamente para um `.env` de desenvolvimento apontando para o provedor real não fazer o e2e gastar dinheiro. Não trocar para `??=`.
 
 ## Ambiente & comandos
 


### PR DESCRIPTION
Mantém o `CLAUDE.md` do repo fiel ao código:

- A flakiness da #107 deixou de ser um risco aberto — vira registro da causa (`jest.mock` com `virtual: true` num módulo que existe em disco) para ninguém reintroduzir.
- Shared em 0.11.0.
- Registra o cadastro público de veterinário (#124).
- Dois gotchas que custaram tempo nesta rodada: o publish do shared só dispara em push para `main`, e o e2e precisa fixar `CRMV_PROVIDER=stub` porque a consulta real é paga.