### PR TITLE
docs: registrar a URL do QR para ambiente de desenvolvimento

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,6 +72,7 @@ GOOGLE_CALENDAR_REDIRECT_URI=http://localhost:3000/calendar/callback
 
 # ---------- Carteira Digital (Página Pública) ----------
 # URL base usada no payload do QR Code. O "#" é obrigatório quando o web usa HashRouter.
+# Em dev, aponte para o web local: http://localhost:5173/#/card
 PUBLIC_CARD_BASE_URL=https://card.petcard.app/#
 # Rate-limit da rota pública GET /cards/:token
 PUBLIC_CARD_THROTTLE_TTL_SECONDS=60


### PR DESCRIPTION
O `PUBLIC_CARD_BASE_URL` tem como default o domínio de produção (`card.petcard.app`), que não existe em dev — o QR gerado localmente aponta para o nada, e não é óbvio qual valor usar.

Registra o valor de desenvolvimento no `.env.example`. Só comentário; nenhum default muda.

Acompanha PetCardOrg/petcard-web#39, que adiciona a porta de entrada do veterinário na carteira do QR.