### PR TITLE
feat: histórico clínico imutável com trilha de ações (#117)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@nestjs/schedule": "^6.1.3",
         "@nestjs/swagger": "^11.4.4",
         "@nestjs/throttler": "^6.5.0",
-        "@petcardorg/shared": "^0.11.0",
+        "@petcardorg/shared": "^0.12.0",
         "@prisma/client": "^6.19.3",
         "amqp-connection-manager": "^5.0.0",
         "amqplib": "^1.0.3",
@@ -3846,9 +3846,9 @@
       }
     },
     "node_modules/@petcardorg/shared": {
-      "version": "0.11.0",
-      "resolved": "https://npm.pkg.github.com/download/@petcardorg/shared/0.11.0/9d42a658107a41ee453361c347200359c9dfc03e",
-      "integrity": "sha512-zxPZ92rbcjqIbvZAA7rNi9JF/tNo0gqlFtrOzHvWHWRUU7gNmQH/93+Nqrq65rPZWzQTx4ivIjOh86mupsWF4Q==",
+      "version": "0.12.0",
+      "resolved": "https://npm.pkg.github.com/download/@petcardorg/shared/0.12.0/3ed8464acbf967c44fd55a200f4e5b2a403fd491",
+      "integrity": "sha512-jD0rZ/wTZdy4QJUQEK3he75/OwlViZp5MOQfRsA4gwEZQShc1EFLmZO2rR55NXP85UCwQdwquxb52v+jvVaSKQ==",
       "license": "MIT",
       "peerDependencies": {
         "class-transformer": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@nestjs/schedule": "^6.1.3",
     "@nestjs/swagger": "^11.4.4",
     "@nestjs/throttler": "^6.5.0",
-    "@petcardorg/shared": "^0.11.0",
+    "@petcardorg/shared": "^0.12.0",
     "@prisma/client": "^6.19.3",
     "amqp-connection-manager": "^5.0.0",
     "amqplib": "^1.0.3",

--- a/prisma/migrations/20260818131835_historico_clinico_e_trilha_de_acoes/migration.sql
+++ b/prisma/migrations/20260818131835_historico_clinico_e_trilha_de_acoes/migration.sql
@@ -1,0 +1,64 @@
+-- CreateEnum
+CREATE TYPE "AcaoClinicaTipo" AS ENUM ('CRIACAO', 'EDICAO', 'EXCLUSAO');
+
+-- CreateEnum
+CREATE TYPE "EntidadeClinica" AS ENUM ('NOTA_CLINICA', 'VACINA', 'VERMIFUGO', 'MEDICACAO');
+
+-- AlterTable
+ALTER TABLE "deworming_record" ADD COLUMN     "deleted_at" TIMESTAMP(3),
+ADD COLUMN     "veterinario_id" TEXT;
+
+-- AlterTable
+ALTER TABLE "medication_record" ADD COLUMN     "deleted_at" TIMESTAMP(3),
+ADD COLUMN     "veterinario_id" TEXT;
+
+-- AlterTable
+ALTER TABLE "nota_clinica" ADD COLUMN     "deleted_at" TIMESTAMP(3);
+
+-- AlterTable
+ALTER TABLE "vaccine_record" ADD COLUMN     "deleted_at" TIMESTAMP(3),
+ADD COLUMN     "veterinario_id" TEXT;
+
+-- CreateTable
+CREATE TABLE "acao_clinica" (
+    "id" TEXT NOT NULL,
+    "pet_id" TEXT NOT NULL,
+    "tipo" "AcaoClinicaTipo" NOT NULL,
+    "entidade" "EntidadeClinica" NOT NULL,
+    "entidade_id" TEXT NOT NULL,
+    "autor_tipo" "Role" NOT NULL,
+    "autor_id" TEXT NOT NULL,
+    "autor_nome" TEXT NOT NULL,
+    "autor_crmv" TEXT,
+    "detalhes" JSONB,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "acao_clinica_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "acao_clinica_pet_id_created_at_idx" ON "acao_clinica"("pet_id", "created_at");
+
+-- CreateIndex
+CREATE INDEX "acao_clinica_entidade_entidade_id_idx" ON "acao_clinica"("entidade", "entidade_id");
+
+-- CreateIndex
+CREATE INDEX "deworming_record_veterinario_id_idx" ON "deworming_record"("veterinario_id");
+
+-- CreateIndex
+CREATE INDEX "medication_record_veterinario_id_idx" ON "medication_record"("veterinario_id");
+
+-- CreateIndex
+CREATE INDEX "vaccine_record_veterinario_id_idx" ON "vaccine_record"("veterinario_id");
+
+-- AddForeignKey
+ALTER TABLE "vaccine_record" ADD CONSTRAINT "vaccine_record_veterinario_id_fkey" FOREIGN KEY ("veterinario_id") REFERENCES "veterinario"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "deworming_record" ADD CONSTRAINT "deworming_record_veterinario_id_fkey" FOREIGN KEY ("veterinario_id") REFERENCES "veterinario"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "medication_record" ADD CONSTRAINT "medication_record_veterinario_id_fkey" FOREIGN KEY ("veterinario_id") REFERENCES "veterinario"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "acao_clinica" ADD CONSTRAINT "acao_clinica_pet_id_fkey" FOREIGN KEY ("pet_id") REFERENCES "pet"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -37,6 +37,19 @@ enum DevicePlatform {
   ANDROID
 }
 
+enum AcaoClinicaTipo {
+  CRIACAO
+  EDICAO
+  EXCLUSAO
+}
+
+enum EntidadeClinica {
+  NOTA_CLINICA
+  VACINA
+  VERMIFUGO
+  MEDICACAO
+}
+
 enum NotificationKind {
   DOSE_REMINDER
   APPOINTMENT_REMINDER
@@ -117,6 +130,7 @@ model Pet {
   dewormingRecords  DewormingRecord[]
   medicationRecords MedicationRecord[]
   carteiraDigital   CarteiraDigital?
+  acoesClinicas     AcaoClinica[]
   appointments      Appointment[]
   notasClinicas     NotaClinica[]
 
@@ -142,13 +156,19 @@ model VaccineRecord {
   appliedAt        DateTime  @map("applied_at")
   nextDoseAt       DateTime? @map("next_dose_at")
   lastNotifiedAt   DateTime? @map("last_notified_at")
+  /// Preenchido quando quem registra é um veterinário do PetCard.
+  veterinarioId    String?   @map("veterinario_id")
+  /// Texto livre: registros antigos e profissionais fora do PetCard.
   veterinarianName String?   @map("veterinarian_name")
   notes            String?
   createdAt        DateTime  @default(now()) @map("created_at")
   updatedAt        DateTime  @updatedAt @map("updated_at")
+  deletedAt        DateTime? @map("deleted_at")
 
-  pet Pet @relation(fields: [petId], references: [id], onDelete: Cascade)
+  pet         Pet          @relation(fields: [petId], references: [id], onDelete: Cascade)
+  veterinario Veterinario? @relation(fields: [veterinarioId], references: [id], onDelete: SetNull)
 
+  @@index([veterinarioId])
   @@map("vaccine_record")
 }
 
@@ -159,13 +179,19 @@ model DewormingRecord {
   appliedAt        DateTime  @map("applied_at")
   nextDoseAt       DateTime? @map("next_dose_at")
   lastNotifiedAt   DateTime? @map("last_notified_at")
+  /// Preenchido quando quem registra é um veterinário do PetCard.
+  veterinarioId    String?   @map("veterinario_id")
+  /// Texto livre: registros antigos e profissionais fora do PetCard.
   veterinarianName String?   @map("veterinarian_name")
   notes            String?
   createdAt        DateTime  @default(now()) @map("created_at")
   updatedAt        DateTime  @updatedAt @map("updated_at")
+  deletedAt        DateTime? @map("deleted_at")
 
-  pet Pet @relation(fields: [petId], references: [id], onDelete: Cascade)
+  pet         Pet          @relation(fields: [petId], references: [id], onDelete: Cascade)
+  veterinario Veterinario? @relation(fields: [veterinarioId], references: [id], onDelete: SetNull)
 
+  @@index([veterinarioId])
   @@map("deworming_record")
 }
 
@@ -178,12 +204,17 @@ model MedicationRecord {
   startDate      DateTime  @map("start_date")
   endDate        DateTime? @map("end_date")
   lastNotifiedAt DateTime? @map("last_notified_at")
+  /// Preenchido quando quem prescreve é um veterinário do PetCard.
+  veterinarioId  String?   @map("veterinario_id")
   notes          String?
   createdAt      DateTime  @default(now()) @map("created_at")
   updatedAt      DateTime  @updatedAt @map("updated_at")
+  deletedAt      DateTime? @map("deleted_at")
 
-  pet Pet @relation(fields: [petId], references: [id], onDelete: Cascade)
+  pet         Pet          @relation(fields: [petId], references: [id], onDelete: Cascade)
+  veterinario Veterinario? @relation(fields: [veterinarioId], references: [id], onDelete: SetNull)
 
+  @@index([veterinarioId])
   @@map("medication_record")
 }
 
@@ -251,7 +282,10 @@ model Veterinario {
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
 
-  notasClinicas NotaClinica[]
+  notasClinicas     NotaClinica[]
+  vacinas           VaccineRecord[]
+  vermifugos        DewormingRecord[]
+  medicacoes        MedicationRecord[]
 
   @@map("veterinario")
 }
@@ -264,8 +298,11 @@ model NotaClinica {
   diagnostico   String
   prescricao    String?
   observacoes   String?
-  createdAt     DateTime @default(now()) @map("created_at")
-  updatedAt     DateTime @updatedAt @map("updated_at")
+  createdAt     DateTime  @default(now()) @map("created_at")
+  updatedAt     DateTime  @updatedAt @map("updated_at")
+  /// Exclusão lógica (api#117): o registro sai da visualização mas o
+  /// histórico clínico preserva o que o veterinário orientou.
+  deletedAt     DateTime? @map("deleted_at")
 
   veterinario Veterinario @relation(fields: [veterinarioId], references: [id], onDelete: Cascade)
   pet         Pet         @relation(fields: [petId], references: [id], onDelete: Cascade)
@@ -274,4 +311,35 @@ model NotaClinica {
   @@index([petId])
   @@index([googlePlaceId])
   @@map("nota_clinica")
+}
+
+
+/// Trilha de auditoria das ações sobre registros clínicos (api#117).
+///
+/// Nenhuma FK para autor ou entidade: a trilha é um log append-only e precisa
+/// sobreviver à exclusão de quem a originou. Nome e CRMV ficam gravados aqui,
+/// não por referência — uma evidência que some junto com a conta do
+/// veterinário não serve como evidência.
+model AcaoClinica {
+  id         String          @id @default(uuid())
+  petId      String          @map("pet_id")
+  tipo       AcaoClinicaTipo
+  entidade   EntidadeClinica
+  entidadeId String          @map("entidade_id")
+
+  autorTipo Role    @map("autor_tipo")
+  autorId   String  @map("autor_id")
+  autorNome String  @map("autor_nome")
+  autorCrmv String? @map("autor_crmv")
+
+  /// O que mudou, para EDICAO e EXCLUSAO. Snapshot, não diferencial.
+  detalhes Json?
+
+  createdAt DateTime @default(now()) @map("created_at")
+
+  pet Pet @relation(fields: [petId], references: [id], onDelete: Cascade)
+
+  @@index([petId, createdAt])
+  @@index([entidade, entidadeId])
+  @@map("acao_clinica")
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -31,6 +31,7 @@ import { TutorModule } from './modules/tutor/tutor.module';
 import { UploadModule } from './modules/upload/upload.module';
 import { VetNoteModule } from './modules/vet-note/vet-note.module';
 import { VeterinarioModule } from './modules/veterinario/veterinario.module';
+import { HistoricoModule } from './modules/historico/historico.module';
 import { PrismaModule } from './prisma/prisma.module';
 
 @Module({
@@ -70,6 +71,7 @@ import { PrismaModule } from './prisma/prisma.module';
     ReminderModule,
     VetNoteModule,
     VeterinarioModule,
+    HistoricoModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/modules/card/__tests__/card.service.spec.ts
+++ b/src/modules/card/__tests__/card.service.spec.ts
@@ -519,20 +519,18 @@ describe('CardService', () => {
         include: {
           tutor: true,
           carteiraDigital: true,
+          // Registro excluído não conta nos totais da carteira (api#117).
           vaccineRecords: {
-            select: {
-              nextDoseAt: true,
-            },
+            where: { deletedAt: null },
+            select: { nextDoseAt: true },
           },
           dewormingRecords: {
-            select: {
-              nextDoseAt: true,
-            },
+            where: { deletedAt: null },
+            select: { nextDoseAt: true },
           },
           medicationRecords: {
-            select: {
-              endDate: true,
-            },
+            where: { deletedAt: null },
+            select: { endDate: true },
           },
         },
       });

--- a/src/modules/card/card.service.ts
+++ b/src/modules/card/card.service.ts
@@ -81,8 +81,14 @@ export class CardService {
         pet: {
           include: {
             tutor: true,
-            vaccineRecords: { orderBy: { appliedAt: 'desc' } },
-            dewormingRecords: { orderBy: { appliedAt: 'desc' } },
+            vaccineRecords: {
+              where: { deletedAt: null },
+              orderBy: { appliedAt: 'desc' },
+            },
+            dewormingRecords: {
+              where: { deletedAt: null },
+              orderBy: { appliedAt: 'desc' },
+            },
           },
         },
       },
@@ -157,11 +163,11 @@ export class CardService {
         select: { crmv: true },
       }),
       this.prisma.medicationRecord.findMany({
-        where: { petId: publica.pet_id },
+        where: { petId: publica.pet_id, deletedAt: null },
         orderBy: { startDate: 'desc' },
       }),
       this.prisma.notaClinica.findMany({
-        where: { petId: publica.pet_id },
+        where: { petId: publica.pet_id, deletedAt: null },
         orderBy: { createdAt: 'desc' },
         include: { veterinario: { select: { nome: true, crmv: true } } },
       }),
@@ -209,19 +215,16 @@ export class CardService {
         tutor: true,
         carteiraDigital: true,
         vaccineRecords: {
-          select: {
-            nextDoseAt: true,
-          },
+          where: { deletedAt: null },
+          select: { nextDoseAt: true },
         },
         dewormingRecords: {
-          select: {
-            nextDoseAt: true,
-          },
+          where: { deletedAt: null },
+          select: { nextDoseAt: true },
         },
         medicationRecords: {
-          select: {
-            endDate: true,
-          },
+          where: { deletedAt: null },
+          select: { endDate: true },
         },
       },
     });

--- a/src/modules/health/deworming/__tests__/deworming.controller.spec.ts
+++ b/src/modules/health/deworming/__tests__/deworming.controller.spec.ts
@@ -1,6 +1,10 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import request from 'supertest';
 import {
+  acaoClinicaProvider,
+  comTransacao,
+} from '../../../../../test/utils/acao-clinica';
+import {
   createControllerTestApp,
   ControllerHarness,
   TUTOR,
@@ -20,7 +24,7 @@ describe('DewormingController (integração)', () => {
     dewormingRecord: {
       create: jest.Mock;
       findMany: jest.Mock;
-      findUnique: jest.Mock;
+      findFirst: jest.Mock;
       update: jest.Mock;
       delete: jest.Mock;
     };
@@ -45,15 +49,18 @@ describe('DewormingController (integração)', () => {
       dewormingRecord: {
         create: jest.fn(),
         findMany: jest.fn(),
-        findUnique: jest.fn(),
+        findFirst: jest.fn(),
         update: jest.fn(),
         delete: jest.fn(),
       },
     };
 
+    comTransacao(prisma);
+
     harness = await createControllerTestApp({
       controllers: [DewormingController],
       providers: [
+        acaoClinicaProvider().provider,
         DewormingService,
         PetService,
         TutorService,
@@ -127,7 +134,7 @@ describe('DewormingController (integração)', () => {
   });
 
   it('PATCH atualiza o registro (200)', async () => {
-    prisma.dewormingRecord.findUnique.mockResolvedValue(record);
+    prisma.dewormingRecord.findFirst.mockResolvedValue(record);
     prisma.dewormingRecord.update.mockResolvedValue({
       ...record,
       productName: 'Drontal Plus',
@@ -142,7 +149,7 @@ describe('DewormingController (integração)', () => {
   });
 
   it('DELETE remove o registro do dono (204)', async () => {
-    prisma.dewormingRecord.findUnique.mockResolvedValue(record);
+    prisma.dewormingRecord.findFirst.mockResolvedValue(record);
     prisma.dewormingRecord.delete.mockResolvedValue(record);
 
     await request(harness.app.getHttpServer())

--- a/src/modules/health/deworming/__tests__/deworming.service.spec.ts
+++ b/src/modules/health/deworming/__tests__/deworming.service.spec.ts
@@ -1,5 +1,9 @@
 import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
+import {
+  acaoClinicaProvider,
+  comTransacao,
+} from '../../../../../test/utils/acao-clinica';
 import { PrismaService } from '../../../../prisma/prisma.service';
 import { PetService } from '../../../pet/pet.service';
 import { DewormingService } from '../deworming.service';
@@ -10,7 +14,7 @@ describe('DewormingService', () => {
     dewormingRecord: {
       create: jest.Mock;
       findMany: jest.Mock;
-      findUnique: jest.Mock;
+      findFirst: jest.Mock;
       update: jest.Mock;
       delete: jest.Mock;
     };
@@ -37,7 +41,7 @@ describe('DewormingService', () => {
       dewormingRecord: {
         create: jest.fn(),
         findMany: jest.fn(),
-        findUnique: jest.fn(),
+        findFirst: jest.fn(),
         update: jest.fn(),
         delete: jest.fn(),
       },
@@ -47,8 +51,11 @@ describe('DewormingService', () => {
       assertOwnership: jest.fn().mockResolvedValue({ id: 'pet-1' }),
     };
 
+    comTransacao(prisma);
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
+        acaoClinicaProvider().provider,
         DewormingService,
         { provide: PrismaService, useValue: prisma },
         { provide: PetService, useValue: petService },
@@ -91,7 +98,7 @@ describe('DewormingService', () => {
   });
 
   it('should throw when updating missing record', async () => {
-    prisma.dewormingRecord.findUnique.mockResolvedValue(null);
+    prisma.dewormingRecord.findFirst.mockResolvedValue(null);
 
     await expect(
       service.update('missing', 'tutor-1', false, {}),
@@ -99,7 +106,7 @@ describe('DewormingService', () => {
   });
 
   it('should delete owned record', async () => {
-    prisma.dewormingRecord.findUnique.mockResolvedValue(record);
+    prisma.dewormingRecord.findFirst.mockResolvedValue(record);
     prisma.dewormingRecord.delete.mockResolvedValue(record);
 
     await service.remove('dew-1', 'tutor-1');

--- a/src/modules/health/deworming/deworming.module.ts
+++ b/src/modules/health/deworming/deworming.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common';
+import { HistoricoModule } from '../../historico/historico.module';
 import { AuthModule } from '../../auth/auth.module';
 import { PetModule } from '../../pet/pet.module';
 import { DewormingController } from './deworming.controller';
 import { DewormingService } from './deworming.service';
 
 @Module({
-  imports: [AuthModule, PetModule],
+  imports: [HistoricoModule, AuthModule, PetModule],
   controllers: [DewormingController],
   providers: [DewormingService],
 })

--- a/src/modules/health/deworming/deworming.service.ts
+++ b/src/modules/health/deworming/deworming.service.ts
@@ -1,5 +1,10 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { DewormingRecord } from '@prisma/client';
+import {
+  AcaoClinicaTipo,
+  DewormingRecord,
+  EntidadeClinica,
+  Role,
+} from '@prisma/client';
 import {
   CreateDewormingRecordDto,
   DewormingRecordResponseDto,
@@ -7,6 +12,7 @@ import {
 } from '@petcardorg/shared';
 import { PrismaService } from '../../../prisma/prisma.service';
 import { PetService } from '../../pet/pet.service';
+import { AcaoClinicaService } from '../../historico/acao-clinica.service';
 
 type DewormingInput = Omit<CreateDewormingRecordDto, 'pet_id'>;
 
@@ -26,11 +32,23 @@ function toResponseDto(record: DewormingRecord): DewormingRecordResponseDto {
   };
 }
 
+/** Só os campos clínicos; o snapshot é evidência, não cópia de linha. */
+function toSnapshot(record: DewormingRecord) {
+  return {
+    product_name: record.productName,
+    applied_at: record.appliedAt.toISOString(),
+    next_dose_at: record.nextDoseAt?.toISOString() ?? null,
+    veterinarian_name: record.veterinarianName,
+    notes: record.notes,
+  };
+}
+
 @Injectable()
 export class DewormingService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly petService: PetService,
+    private readonly acoes: AcaoClinicaService,
   ) {}
 
   async create(
@@ -40,15 +58,30 @@ export class DewormingService {
     dto: DewormingInput,
   ): Promise<DewormingRecordResponseDto> {
     await this.petService.assertAccess(petId, userId, isVet);
-    const record = await this.prisma.dewormingRecord.create({
-      data: {
-        petId,
-        productName: dto.product_name,
-        appliedAt: new Date(dto.applied_at),
-        nextDoseAt: dto.next_dose_at ? new Date(dto.next_dose_at) : null,
-        veterinarianName: dto.veterinarian_name,
-        notes: dto.notes,
-      },
+    const record = await this.prisma.$transaction(async (tx) => {
+      const criado = await tx.dewormingRecord.create({
+        data: {
+          petId,
+          productName: dto.product_name,
+          appliedAt: new Date(dto.applied_at),
+          nextDoseAt: dto.next_dose_at ? new Date(dto.next_dose_at) : null,
+          veterinarioId: isVet ? userId : null,
+          veterinarianName: dto.veterinarian_name,
+          notes: dto.notes,
+        },
+      });
+      await this.acoes.registrar(
+        {
+          petId,
+          tipo: AcaoClinicaTipo.CRIACAO,
+          entidade: EntidadeClinica.VERMIFUGO,
+          entidadeId: criado.id,
+          autorId: userId,
+          autorTipo: isVet ? Role.VET : Role.TUTOR,
+        },
+        tx,
+      );
+      return criado;
     });
     return toResponseDto(record);
   }
@@ -60,7 +93,7 @@ export class DewormingService {
   ): Promise<DewormingRecordResponseDto[]> {
     await this.petService.assertAccess(petId, userId, isVet);
     const records = await this.prisma.dewormingRecord.findMany({
-      where: { petId },
+      where: { petId, deletedAt: null },
       orderBy: { appliedAt: 'desc' },
     });
     return records.map(toResponseDto);
@@ -74,28 +107,63 @@ export class DewormingService {
   ): Promise<DewormingRecordResponseDto> {
     const record = await this.getRecord(id);
     await this.petService.assertAccess(record.petId, userId, isVet);
-    const updated = await this.prisma.dewormingRecord.update({
-      where: { id },
-      data: {
-        productName: dto.product_name,
-        appliedAt: dto.applied_at ? new Date(dto.applied_at) : undefined,
-        nextDoseAt: dto.next_dose_at ? new Date(dto.next_dose_at) : undefined,
-        veterinarianName: dto.veterinarian_name,
-        notes: dto.notes,
-      },
+    const updated = await this.prisma.$transaction(async (tx) => {
+      const alterado = await tx.dewormingRecord.update({
+        where: { id },
+        data: {
+          productName: dto.product_name,
+          appliedAt: dto.applied_at ? new Date(dto.applied_at) : undefined,
+          nextDoseAt: dto.next_dose_at ? new Date(dto.next_dose_at) : undefined,
+          veterinarianName: dto.veterinarian_name,
+          notes: dto.notes,
+        },
+      });
+      await this.acoes.registrar(
+        {
+          petId: record.petId,
+          tipo: AcaoClinicaTipo.EDICAO,
+          entidade: EntidadeClinica.VERMIFUGO,
+          entidadeId: id,
+          autorId: userId,
+          autorTipo: isVet ? Role.VET : Role.TUTOR,
+          detalhes: { antes: toSnapshot(record), depois: toSnapshot(alterado) },
+        },
+        tx,
+      );
+      return alterado;
     });
     return toResponseDto(updated);
   }
 
+  /**
+   * Exclusão lógica (api#117): sai da listagem, permanece no histórico.
+   */
   async remove(id: string, userId: string): Promise<void> {
     const record = await this.getRecord(id);
     await this.petService.assertOwnership(record.petId, userId);
-    await this.prisma.dewormingRecord.delete({ where: { id } });
+    await this.prisma.$transaction(async (tx) => {
+      await tx.dewormingRecord.update({
+        where: { id },
+        data: { deletedAt: new Date() },
+      });
+      await this.acoes.registrar(
+        {
+          petId: record.petId,
+          tipo: AcaoClinicaTipo.EXCLUSAO,
+          entidade: EntidadeClinica.VERMIFUGO,
+          entidadeId: id,
+          autorId: userId,
+          autorTipo: Role.TUTOR,
+          detalhes: { antes: toSnapshot(record) },
+        },
+        tx,
+      );
+    });
   }
 
   private async getRecord(id: string): Promise<DewormingRecord> {
-    const record = await this.prisma.dewormingRecord.findUnique({
-      where: { id },
+    const record = await this.prisma.dewormingRecord.findFirst({
+      where: { id, deletedAt: null },
     });
     if (!record) {
       throw new NotFoundException(`Deworming record with id ${id} not found`);

--- a/src/modules/health/medication/__tests__/medication.controller.spec.ts
+++ b/src/modules/health/medication/__tests__/medication.controller.spec.ts
@@ -1,6 +1,10 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import request from 'supertest';
 import {
+  acaoClinicaProvider,
+  comTransacao,
+} from '../../../../../test/utils/acao-clinica';
+import {
   createControllerTestApp,
   ControllerHarness,
   TUTOR,
@@ -21,7 +25,7 @@ describe('MedicationController (integração)', () => {
     medicationRecord: {
       create: jest.Mock;
       findMany: jest.Mock;
-      findUnique: jest.Mock;
+      findFirst: jest.Mock;
       update: jest.Mock;
       delete: jest.Mock;
     };
@@ -47,15 +51,18 @@ describe('MedicationController (integração)', () => {
       medicationRecord: {
         create: jest.fn(),
         findMany: jest.fn(),
-        findUnique: jest.fn(),
+        findFirst: jest.fn(),
         update: jest.fn(),
         delete: jest.fn(),
       },
     };
 
+    comTransacao(prisma);
+
     harness = await createControllerTestApp({
       controllers: [MedicationController],
       providers: [
+        acaoClinicaProvider().provider,
         MedicationService,
         PetService,
         TutorService,
@@ -136,7 +143,7 @@ describe('MedicationController (integração)', () => {
   });
 
   it('PATCH atualiza o registro (200)', async () => {
-    prisma.medicationRecord.findUnique.mockResolvedValue(record);
+    prisma.medicationRecord.findFirst.mockResolvedValue(record);
     prisma.medicationRecord.update.mockResolvedValue({
       ...record,
       dosage: '250mg',
@@ -151,7 +158,7 @@ describe('MedicationController (integração)', () => {
   });
 
   it('DELETE remove o registro do dono (204)', async () => {
-    prisma.medicationRecord.findUnique.mockResolvedValue(record);
+    prisma.medicationRecord.findFirst.mockResolvedValue(record);
     prisma.medicationRecord.delete.mockResolvedValue(record);
 
     await request(harness.app.getHttpServer())

--- a/src/modules/health/medication/__tests__/medication.service.spec.ts
+++ b/src/modules/health/medication/__tests__/medication.service.spec.ts
@@ -1,5 +1,9 @@
 import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
+import {
+  acaoClinicaProvider,
+  comTransacao,
+} from '../../../../../test/utils/acao-clinica';
 import { PrismaService } from '../../../../prisma/prisma.service';
 import { PetService } from '../../../pet/pet.service';
 import { MedicationService } from '../medication.service';
@@ -10,7 +14,7 @@ describe('MedicationService', () => {
     medicationRecord: {
       create: jest.Mock;
       findMany: jest.Mock;
-      findUnique: jest.Mock;
+      findFirst: jest.Mock;
       update: jest.Mock;
       delete: jest.Mock;
     };
@@ -38,7 +42,7 @@ describe('MedicationService', () => {
       medicationRecord: {
         create: jest.fn(),
         findMany: jest.fn(),
-        findUnique: jest.fn(),
+        findFirst: jest.fn(),
         update: jest.fn(),
         delete: jest.fn(),
       },
@@ -48,8 +52,11 @@ describe('MedicationService', () => {
       assertOwnership: jest.fn().mockResolvedValue({ id: 'pet-1' }),
     };
 
+    comTransacao(prisma);
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
+        acaoClinicaProvider().provider,
         MedicationService,
         { provide: PrismaService, useValue: prisma },
         { provide: PetService, useValue: petService },
@@ -83,7 +90,8 @@ describe('MedicationService', () => {
     const result = await service.findAllForPet('pet-1', 'tutor-1', false);
 
     expect(prisma.medicationRecord.findMany).toHaveBeenCalledWith({
-      where: { petId: 'pet-1' },
+      // Registro excluído não aparece na listagem (api#117).
+      where: { petId: 'pet-1', deletedAt: null },
       orderBy: { startDate: 'desc' },
     });
     expect(result).toEqual([
@@ -103,21 +111,26 @@ describe('MedicationService', () => {
   });
 
   it('should throw when updating a missing record', async () => {
-    prisma.medicationRecord.findUnique.mockResolvedValue(null);
+    prisma.medicationRecord.findFirst.mockResolvedValue(null);
 
     await expect(
       service.update('missing', 'tutor-1', false, {}),
     ).rejects.toThrow(NotFoundException);
   });
 
-  it('should delete an owned record', async () => {
-    prisma.medicationRecord.findUnique.mockResolvedValue(record);
-    prisma.medicationRecord.delete.mockResolvedValue(record);
+  it('marca como excluída em vez de apagar (api#117)', async () => {
+    prisma.medicationRecord.findFirst.mockResolvedValue(record);
+    prisma.medicationRecord.update.mockResolvedValue(record);
 
     await service.remove('med-1', 'tutor-1');
 
-    expect(prisma.medicationRecord.delete).toHaveBeenCalledWith({
-      where: { id: 'med-1' },
-    });
+    // O caso central da issue: o tutor decide não dar o remédio e apaga,
+    // mas a prescrição do veterinário continua demonstrável.
+    expect(prisma.medicationRecord.delete).not.toHaveBeenCalled();
+    const [[chamada]] = prisma.medicationRecord.update.mock.calls as Array<
+      [{ where: { id: string }; data: { deletedAt: Date } }]
+    >;
+    expect(chamada.where).toEqual({ id: 'med-1' });
+    expect(chamada.data.deletedAt).toBeInstanceOf(Date);
   });
 });

--- a/src/modules/health/medication/medication.module.ts
+++ b/src/modules/health/medication/medication.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { HistoricoModule } from '../../historico/historico.module';
 import { AuthModule } from '../../auth/auth.module';
 import { PetModule } from '../../pet/pet.module';
 import { VeterinarioModule } from '../../veterinario/veterinario.module';
@@ -6,7 +7,7 @@ import { MedicationController } from './medication.controller';
 import { MedicationService } from './medication.service';
 
 @Module({
-  imports: [AuthModule, PetModule, VeterinarioModule],
+  imports: [HistoricoModule, AuthModule, PetModule, VeterinarioModule],
   controllers: [MedicationController],
   providers: [MedicationService],
 })

--- a/src/modules/health/medication/medication.service.ts
+++ b/src/modules/health/medication/medication.service.ts
@@ -1,5 +1,10 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { MedicationRecord } from '@prisma/client';
+import {
+  AcaoClinicaTipo,
+  EntidadeClinica,
+  MedicationRecord,
+  Role,
+} from '@prisma/client';
 import {
   CreateMedicationRecordDto,
   MedicationRecordResponseDto,
@@ -7,6 +12,7 @@ import {
 } from '@petcardorg/shared';
 import { PrismaService } from '../../../prisma/prisma.service';
 import { PetService } from '../../pet/pet.service';
+import { AcaoClinicaService } from '../../historico/acao-clinica.service';
 
 type MedicationInput = Omit<CreateMedicationRecordDto, 'pet_id'>;
 
@@ -27,11 +33,24 @@ function toResponseDto(record: MedicationRecord): MedicationRecordResponseDto {
   };
 }
 
+/** Só os campos clínicos; o snapshot é evidência, não cópia de linha. */
+function toSnapshot(record: MedicationRecord) {
+  return {
+    medication_name: record.medicationName,
+    dosage: record.dosage,
+    frequency: record.frequency,
+    start_date: record.startDate.toISOString(),
+    end_date: record.endDate?.toISOString() ?? null,
+    notes: record.notes,
+  };
+}
+
 @Injectable()
 export class MedicationService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly petService: PetService,
+    private readonly acoes: AcaoClinicaService,
   ) {}
 
   async create(
@@ -41,16 +60,32 @@ export class MedicationService {
     dto: MedicationInput,
   ): Promise<MedicationRecordResponseDto> {
     await this.petService.assertAccess(petId, userId, isVet);
-    const record = await this.prisma.medicationRecord.create({
-      data: {
-        petId,
-        medicationName: dto.medication_name,
-        dosage: dto.dosage,
-        frequency: dto.frequency,
-        startDate: new Date(dto.start_date),
-        endDate: dto.end_date ? new Date(dto.end_date) : null,
-        notes: dto.notes,
-      },
+    const record = await this.prisma.$transaction(async (tx) => {
+      const criado = await tx.medicationRecord.create({
+        data: {
+          petId,
+          medicationName: dto.medication_name,
+          dosage: dto.dosage,
+          frequency: dto.frequency,
+          startDate: new Date(dto.start_date),
+          endDate: dto.end_date ? new Date(dto.end_date) : null,
+          // Quem prescreveu, quando é um vet do PetCard.
+          veterinarioId: isVet ? userId : null,
+          notes: dto.notes,
+        },
+      });
+      await this.acoes.registrar(
+        {
+          petId,
+          tipo: AcaoClinicaTipo.CRIACAO,
+          entidade: EntidadeClinica.MEDICACAO,
+          entidadeId: criado.id,
+          autorId: userId,
+          autorTipo: isVet ? Role.VET : Role.TUTOR,
+        },
+        tx,
+      );
+      return criado;
     });
     return toResponseDto(record);
   }
@@ -62,7 +97,7 @@ export class MedicationService {
   ): Promise<MedicationRecordResponseDto[]> {
     await this.petService.assertAccess(petId, userId, isVet);
     const records = await this.prisma.medicationRecord.findMany({
-      where: { petId },
+      where: { petId, deletedAt: null },
       orderBy: { startDate: 'desc' },
     });
     return records.map(toResponseDto);
@@ -76,29 +111,66 @@ export class MedicationService {
   ): Promise<MedicationRecordResponseDto> {
     const record = await this.getRecord(id);
     await this.petService.assertAccess(record.petId, userId, isVet);
-    const updated = await this.prisma.medicationRecord.update({
-      where: { id },
-      data: {
-        medicationName: dto.medication_name,
-        dosage: dto.dosage,
-        frequency: dto.frequency,
-        startDate: dto.start_date ? new Date(dto.start_date) : undefined,
-        endDate: dto.end_date ? new Date(dto.end_date) : undefined,
-        notes: dto.notes,
-      },
+    const updated = await this.prisma.$transaction(async (tx) => {
+      const alterado = await tx.medicationRecord.update({
+        where: { id },
+        data: {
+          medicationName: dto.medication_name,
+          dosage: dto.dosage,
+          frequency: dto.frequency,
+          startDate: dto.start_date ? new Date(dto.start_date) : undefined,
+          endDate: dto.end_date ? new Date(dto.end_date) : undefined,
+          notes: dto.notes,
+        },
+      });
+      await this.acoes.registrar(
+        {
+          petId: record.petId,
+          tipo: AcaoClinicaTipo.EDICAO,
+          entidade: EntidadeClinica.MEDICACAO,
+          entidadeId: id,
+          autorId: userId,
+          autorTipo: isVet ? Role.VET : Role.TUTOR,
+          detalhes: { antes: toSnapshot(record), depois: toSnapshot(alterado) },
+        },
+        tx,
+      );
+      return alterado;
     });
     return toResponseDto(updated);
   }
 
+  /**
+   * Exclusão lógica (api#117). É o caso central da issue: o tutor decide não
+   * dar o remédio e apaga o registro — a prescrição do veterinário continua
+   * no histórico.
+   */
   async remove(id: string, userId: string): Promise<void> {
     const record = await this.getRecord(id);
     await this.petService.assertOwnership(record.petId, userId);
-    await this.prisma.medicationRecord.delete({ where: { id } });
+    await this.prisma.$transaction(async (tx) => {
+      await tx.medicationRecord.update({
+        where: { id },
+        data: { deletedAt: new Date() },
+      });
+      await this.acoes.registrar(
+        {
+          petId: record.petId,
+          tipo: AcaoClinicaTipo.EXCLUSAO,
+          entidade: EntidadeClinica.MEDICACAO,
+          entidadeId: id,
+          autorId: userId,
+          autorTipo: Role.TUTOR,
+          detalhes: { antes: toSnapshot(record) },
+        },
+        tx,
+      );
+    });
   }
 
   private async getRecord(id: string): Promise<MedicationRecord> {
-    const record = await this.prisma.medicationRecord.findUnique({
-      where: { id },
+    const record = await this.prisma.medicationRecord.findFirst({
+      where: { id, deletedAt: null },
     });
     if (!record) {
       throw new NotFoundException(`Medication record with id ${id} not found`);

--- a/src/modules/health/vaccine/__tests__/vaccine.controller.spec.ts
+++ b/src/modules/health/vaccine/__tests__/vaccine.controller.spec.ts
@@ -1,6 +1,10 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import request from 'supertest';
 import {
+  acaoClinicaProvider,
+  comTransacao,
+} from '../../../../../test/utils/acao-clinica';
+import {
   createControllerTestApp,
   ControllerHarness,
   TUTOR,
@@ -20,7 +24,7 @@ describe('VaccineController (integração)', () => {
     vaccineRecord: {
       create: jest.Mock;
       findMany: jest.Mock;
-      findUnique: jest.Mock;
+      findFirst: jest.Mock;
       update: jest.Mock;
       delete: jest.Mock;
     };
@@ -45,15 +49,18 @@ describe('VaccineController (integração)', () => {
       vaccineRecord: {
         create: jest.fn(),
         findMany: jest.fn(),
-        findUnique: jest.fn(),
+        findFirst: jest.fn(),
         update: jest.fn(),
         delete: jest.fn(),
       },
     };
 
+    comTransacao(prisma);
+
     harness = await createControllerTestApp({
       controllers: [VaccineController],
       providers: [
+        acaoClinicaProvider().provider,
         VaccineService,
         PetService,
         TutorService,
@@ -127,7 +134,7 @@ describe('VaccineController (integração)', () => {
   });
 
   it('PATCH atualiza o registro (200)', async () => {
-    prisma.vaccineRecord.findUnique.mockResolvedValue(record);
+    prisma.vaccineRecord.findFirst.mockResolvedValue(record);
     prisma.vaccineRecord.update.mockResolvedValue({
       ...record,
       vaccineName: 'Raiva Plus',
@@ -142,7 +149,7 @@ describe('VaccineController (integração)', () => {
   });
 
   it('DELETE remove o registro do dono (204)', async () => {
-    prisma.vaccineRecord.findUnique.mockResolvedValue(record);
+    prisma.vaccineRecord.findFirst.mockResolvedValue(record);
     prisma.vaccineRecord.delete.mockResolvedValue(record);
 
     await request(harness.app.getHttpServer())

--- a/src/modules/health/vaccine/__tests__/vaccine.service.spec.ts
+++ b/src/modules/health/vaccine/__tests__/vaccine.service.spec.ts
@@ -1,16 +1,22 @@
 import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
+import {
+  acaoClinicaProvider,
+  comTransacao,
+} from '../../../../../test/utils/acao-clinica';
 import { PrismaService } from '../../../../prisma/prisma.service';
 import { PetService } from '../../../pet/pet.service';
 import { VaccineService } from '../vaccine.service';
 
 describe('VaccineService', () => {
   let service: VaccineService;
+  let acaoTrilha: ReturnType<typeof acaoClinicaProvider>;
+  let registrarAcao: jest.Mock;
   let prisma: {
     vaccineRecord: {
       create: jest.Mock;
       findMany: jest.Mock;
-      findUnique: jest.Mock;
+      findFirst: jest.Mock;
       update: jest.Mock;
       delete: jest.Mock;
     };
@@ -33,11 +39,13 @@ describe('VaccineService', () => {
   };
 
   beforeEach(async () => {
+    acaoTrilha = acaoClinicaProvider();
+    registrarAcao = acaoTrilha.registrar;
     prisma = {
       vaccineRecord: {
         create: jest.fn(),
         findMany: jest.fn(),
-        findUnique: jest.fn(),
+        findFirst: jest.fn(),
         update: jest.fn(),
         delete: jest.fn(),
       },
@@ -47,8 +55,11 @@ describe('VaccineService', () => {
       assertOwnership: jest.fn().mockResolvedValue({ id: 'pet-1' }),
     };
 
+    comTransacao(prisma);
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
+        acaoTrilha.provider,
         VaccineService,
         { provide: PrismaService, useValue: prisma },
         { provide: PetService, useValue: petService },
@@ -105,7 +116,7 @@ describe('VaccineService', () => {
 
   describe('update', () => {
     it('should throw NotFoundException when the record is missing', async () => {
-      prisma.vaccineRecord.findUnique.mockResolvedValue(null);
+      prisma.vaccineRecord.findFirst.mockResolvedValue(null);
 
       await expect(
         service.update('missing', 'tutor-1', false, {}),
@@ -113,7 +124,7 @@ describe('VaccineService', () => {
     });
 
     it('should update the record when access is granted', async () => {
-      prisma.vaccineRecord.findUnique.mockResolvedValue(record);
+      prisma.vaccineRecord.findFirst.mockResolvedValue(record);
       prisma.vaccineRecord.update.mockResolvedValue({
         ...record,
         vaccineName: 'Rabies Plus',
@@ -128,9 +139,9 @@ describe('VaccineService', () => {
   });
 
   describe('remove', () => {
-    it('should delete the record when owned', async () => {
-      prisma.vaccineRecord.findUnique.mockResolvedValue(record);
-      prisma.vaccineRecord.delete.mockResolvedValue(record);
+    it('marca como excluído em vez de apagar (api#117)', async () => {
+      prisma.vaccineRecord.findFirst.mockResolvedValue(record);
+      prisma.vaccineRecord.update.mockResolvedValue(record);
 
       await service.remove('vac-1', 'tutor-1');
 
@@ -138,9 +149,31 @@ describe('VaccineService', () => {
         'pet-1',
         'tutor-1',
       );
-      expect(prisma.vaccineRecord.delete).toHaveBeenCalledWith({
-        where: { id: 'vac-1' },
-      });
+      // O registro precisa sobreviver: é o que o histórico clínico mostra.
+      expect(prisma.vaccineRecord.delete).not.toHaveBeenCalled();
+      const [[chamada]] = prisma.vaccineRecord.update.mock.calls as Array<
+        [{ where: { id: string }; data: { deletedAt: Date } }]
+      >;
+      expect(chamada.where).toEqual({ id: 'vac-1' });
+      expect(chamada.data.deletedAt).toBeInstanceOf(Date);
+    });
+
+    it('registra a exclusão na trilha, com o autor', async () => {
+      prisma.vaccineRecord.findFirst.mockResolvedValue(record);
+      prisma.vaccineRecord.update.mockResolvedValue(record);
+
+      await service.remove('vac-1', 'tutor-1');
+
+      expect(registrarAcao).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tipo: 'EXCLUSAO',
+          entidade: 'VACINA',
+          entidadeId: 'vac-1',
+          autorId: 'tutor-1',
+          autorTipo: 'TUTOR',
+        }),
+        expect.anything(),
+      );
     });
   });
 });

--- a/src/modules/health/vaccine/vaccine.module.ts
+++ b/src/modules/health/vaccine/vaccine.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common';
+import { HistoricoModule } from '../../historico/historico.module';
 import { AuthModule } from '../../auth/auth.module';
 import { PetModule } from '../../pet/pet.module';
 import { VaccineController } from './vaccine.controller';
 import { VaccineService } from './vaccine.service';
 
 @Module({
-  imports: [AuthModule, PetModule],
+  imports: [HistoricoModule, AuthModule, PetModule],
   controllers: [VaccineController],
   providers: [VaccineService],
 })

--- a/src/modules/health/vaccine/vaccine.service.ts
+++ b/src/modules/health/vaccine/vaccine.service.ts
@@ -1,5 +1,10 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { VaccineRecord } from '@prisma/client';
+import {
+  AcaoClinicaTipo,
+  EntidadeClinica,
+  Role,
+  VaccineRecord,
+} from '@prisma/client';
 import {
   CreateVaccineRecordDto,
   UpdateVaccineRecordDto,
@@ -7,6 +12,7 @@ import {
 } from '@petcardorg/shared';
 import { PrismaService } from '../../../prisma/prisma.service';
 import { PetService } from '../../pet/pet.service';
+import { AcaoClinicaService } from '../../historico/acao-clinica.service';
 
 type VaccineInput = Omit<CreateVaccineRecordDto, 'pet_id'>;
 
@@ -26,11 +32,23 @@ function toResponseDto(record: VaccineRecord): VaccineRecordResponseDto {
   };
 }
 
+/** Só os campos clínicos; o snapshot é evidência, não cópia de linha. */
+function toSnapshot(record: VaccineRecord) {
+  return {
+    vaccine_name: record.vaccineName,
+    applied_at: record.appliedAt.toISOString(),
+    next_dose_at: record.nextDoseAt?.toISOString() ?? null,
+    veterinarian_name: record.veterinarianName,
+    notes: record.notes,
+  };
+}
+
 @Injectable()
 export class VaccineService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly petService: PetService,
+    private readonly acoes: AcaoClinicaService,
   ) {}
 
   async create(
@@ -40,15 +58,31 @@ export class VaccineService {
     dto: VaccineInput,
   ): Promise<VaccineRecordResponseDto> {
     await this.petService.assertAccess(petId, userId, isVet);
-    const record = await this.prisma.vaccineRecord.create({
-      data: {
-        petId,
-        vaccineName: dto.vaccine_name,
-        appliedAt: new Date(dto.applied_at),
-        nextDoseAt: dto.next_dose_at ? new Date(dto.next_dose_at) : null,
-        veterinarianName: dto.veterinarian_name,
-        notes: dto.notes,
-      },
+    const record = await this.prisma.$transaction(async (tx) => {
+      const criado = await tx.vaccineRecord.create({
+        data: {
+          petId,
+          vaccineName: dto.vaccine_name,
+          appliedAt: new Date(dto.applied_at),
+          nextDoseAt: dto.next_dose_at ? new Date(dto.next_dose_at) : null,
+          // Atribuição confiável quando quem registra é um vet do PetCard.
+          veterinarioId: isVet ? userId : null,
+          veterinarianName: dto.veterinarian_name,
+          notes: dto.notes,
+        },
+      });
+      await this.acoes.registrar(
+        {
+          petId,
+          tipo: AcaoClinicaTipo.CRIACAO,
+          entidade: EntidadeClinica.VACINA,
+          entidadeId: criado.id,
+          autorId: userId,
+          autorTipo: isVet ? Role.VET : Role.TUTOR,
+        },
+        tx,
+      );
+      return criado;
     });
     return toResponseDto(record);
   }
@@ -60,7 +94,7 @@ export class VaccineService {
   ): Promise<VaccineRecordResponseDto[]> {
     await this.petService.assertAccess(petId, userId, isVet);
     const records = await this.prisma.vaccineRecord.findMany({
-      where: { petId },
+      where: { petId, deletedAt: null },
       orderBy: { appliedAt: 'desc' },
     });
     return records.map(toResponseDto);
@@ -74,28 +108,65 @@ export class VaccineService {
   ): Promise<VaccineRecordResponseDto> {
     const record = await this.getRecord(id);
     await this.petService.assertAccess(record.petId, userId, isVet);
-    const updated = await this.prisma.vaccineRecord.update({
-      where: { id },
-      data: {
-        vaccineName: dto.vaccine_name,
-        appliedAt: dto.applied_at ? new Date(dto.applied_at) : undefined,
-        nextDoseAt: dto.next_dose_at ? new Date(dto.next_dose_at) : undefined,
-        veterinarianName: dto.veterinarian_name,
-        notes: dto.notes,
-      },
+    const updated = await this.prisma.$transaction(async (tx) => {
+      const alterado = await tx.vaccineRecord.update({
+        where: { id },
+        data: {
+          vaccineName: dto.vaccine_name,
+          appliedAt: dto.applied_at ? new Date(dto.applied_at) : undefined,
+          nextDoseAt: dto.next_dose_at ? new Date(dto.next_dose_at) : undefined,
+          veterinarianName: dto.veterinarian_name,
+          notes: dto.notes,
+        },
+      });
+      await this.acoes.registrar(
+        {
+          petId: record.petId,
+          tipo: AcaoClinicaTipo.EDICAO,
+          entidade: EntidadeClinica.VACINA,
+          entidadeId: id,
+          autorId: userId,
+          autorTipo: isVet ? Role.VET : Role.TUTOR,
+          detalhes: { antes: toSnapshot(record), depois: toSnapshot(alterado) },
+        },
+        tx,
+      );
+      return alterado;
     });
     return toResponseDto(updated);
   }
 
+  /**
+   * Exclusão lógica (api#117): sai da listagem, permanece no histórico.
+   * O tutor deixa de ver o registro, mas o que o veterinário aplicou continua
+   * demonstrável.
+   */
   async remove(id: string, userId: string): Promise<void> {
     const record = await this.getRecord(id);
     await this.petService.assertOwnership(record.petId, userId);
-    await this.prisma.vaccineRecord.delete({ where: { id } });
+    await this.prisma.$transaction(async (tx) => {
+      await tx.vaccineRecord.update({
+        where: { id },
+        data: { deletedAt: new Date() },
+      });
+      await this.acoes.registrar(
+        {
+          petId: record.petId,
+          tipo: AcaoClinicaTipo.EXCLUSAO,
+          entidade: EntidadeClinica.VACINA,
+          entidadeId: id,
+          autorId: userId,
+          autorTipo: Role.TUTOR,
+          detalhes: { antes: toSnapshot(record) },
+        },
+        tx,
+      );
+    });
   }
 
   private async getRecord(id: string): Promise<VaccineRecord> {
-    const record = await this.prisma.vaccineRecord.findUnique({
-      where: { id },
+    const record = await this.prisma.vaccineRecord.findFirst({
+      where: { id, deletedAt: null },
     });
     if (!record) {
       throw new NotFoundException(`Vaccine record with id ${id} not found`);

--- a/src/modules/historico/__tests__/acao-clinica.service.spec.ts
+++ b/src/modules/historico/__tests__/acao-clinica.service.spec.ts
@@ -1,0 +1,109 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AcaoClinicaTipo, EntidadeClinica, Role } from '@prisma/client';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { AcaoClinicaService } from '../acao-clinica.service';
+
+describe('AcaoClinicaService', () => {
+  let service: AcaoClinicaService;
+  let prisma: {
+    acaoClinica: { create: jest.Mock };
+    veterinario: { findUnique: jest.Mock };
+    tutor: { findUnique: jest.Mock };
+  };
+
+  const base = {
+    petId: 'pet-1',
+    tipo: AcaoClinicaTipo.EXCLUSAO,
+    entidade: EntidadeClinica.MEDICACAO,
+    entidadeId: 'med-1',
+  };
+
+  beforeEach(async () => {
+    prisma = {
+      acaoClinica: { create: jest.fn() },
+      veterinario: { findUnique: jest.fn() },
+      tutor: { findUnique: jest.fn() },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AcaoClinicaService,
+        { provide: PrismaService, useValue: prisma },
+      ],
+    }).compile();
+
+    service = module.get<AcaoClinicaService>(AcaoClinicaService);
+  });
+
+  function dadosGravados() {
+    const [[chamada]] = prisma.acaoClinica.create.mock.calls as Array<
+      [{ data: Record<string, unknown> }]
+    >;
+    return chamada.data;
+  }
+
+  it('grava nome e CRMV do veterinário na própria trilha', async () => {
+    prisma.veterinario.findUnique.mockResolvedValue({
+      nome: 'Dra. Camila',
+      crmv: 'CRMV-SP 12345',
+    });
+
+    await service.registrar({ ...base, autorId: 'vet-1', autorTipo: Role.VET });
+
+    // Copiado, não referenciado: a evidência precisa sobreviver à exclusão
+    // da conta do veterinário.
+    expect(dadosGravados()).toMatchObject({
+      autorNome: 'Dra. Camila',
+      autorCrmv: 'CRMV-SP 12345',
+      autorTipo: Role.VET,
+      entidadeId: 'med-1',
+    });
+  });
+
+  it('grava o nome do tutor, sem CRMV', async () => {
+    prisma.tutor.findUnique.mockResolvedValue({ name: 'Ana Silva' });
+
+    await service.registrar({
+      ...base,
+      autorId: 'tutor-1',
+      autorTipo: Role.TUTOR,
+    });
+
+    expect(dadosGravados()).toMatchObject({
+      autorNome: 'Ana Silva',
+      autorCrmv: null,
+      autorTipo: Role.TUTOR,
+    });
+  });
+
+  it('registra mesmo se o autor não for encontrado', async () => {
+    prisma.veterinario.findUnique.mockResolvedValue(null);
+
+    await service.registrar({
+      ...base,
+      autorId: 'vet-sumiu',
+      autorTipo: Role.VET,
+    });
+
+    // Perder o nome não pode impedir a ação; o id ainda identifica quem agiu.
+    expect(prisma.acaoClinica.create).toHaveBeenCalled();
+    expect(dadosGravados()).toMatchObject({ autorNome: 'vet-sumiu' });
+  });
+
+  it('usa a transação recebida em vez do cliente próprio', async () => {
+    const tx = {
+      acaoClinica: { create: jest.fn() },
+      veterinario: { findUnique: jest.fn().mockResolvedValue(null) },
+      tutor: { findUnique: jest.fn() },
+    };
+
+    await service.registrar(
+      { ...base, autorId: 'vet-1', autorTipo: Role.VET },
+      tx as never,
+    );
+
+    // A trilha precisa cair junto com a operação que a originou.
+    expect(tx.acaoClinica.create).toHaveBeenCalled();
+    expect(prisma.acaoClinica.create).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/historico/__tests__/historico-clinico.controller.spec.ts
+++ b/src/modules/historico/__tests__/historico-clinico.controller.spec.ts
@@ -1,0 +1,77 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import request from 'supertest';
+import {
+  createControllerTestApp,
+  ControllerHarness,
+  TUTOR,
+  VET,
+} from '../../../../test/utils/controller-harness';
+import { CrmvVerificationService } from '../../veterinario/crmv/crmv-verification.service';
+import { HistoricoClinicoController } from '../historico-clinico.controller';
+import { HistoricoClinicoService } from '../historico-clinico.service';
+
+describe('HistoricoClinicoController (integração)', () => {
+  let harness: ControllerHarness;
+  let historico: { doPet: jest.Mock };
+
+  beforeAll(async () => {
+    historico = {
+      doPet: jest.fn().mockResolvedValue({
+        pet_id: 'pet-1',
+        pet_nome: 'Rex',
+        itens: [],
+      }),
+    };
+
+    harness = await createControllerTestApp({
+      controllers: [HistoricoClinicoController],
+      providers: [
+        { provide: HistoricoClinicoService, useValue: historico },
+        {
+          provide: CrmvVerificationService,
+          useValue: {
+            getStatus: jest.fn().mockResolvedValue({ verified: true }),
+          },
+        },
+      ],
+    });
+  });
+
+  afterAll(async () => {
+    await harness.app.close();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    harness.setUser(TUTOR);
+  });
+
+  it('devolve o histórico para o tutor (200)', async () => {
+    const res = await request(harness.app.getHttpServer())
+      .get('/pets/pet-1/historico-clinico')
+      .expect(200);
+
+    expect(res.body.pet_nome).toBe('Rex');
+    expect(historico.doPet).toHaveBeenCalledWith('pet-1', 'tutor-1', false);
+  });
+
+  it('marca o solicitante como veterinário quando o papel é VET', async () => {
+    harness.setUser(VET);
+
+    await request(harness.app.getHttpServer())
+      .get('/pets/pet-1/historico-clinico')
+      .expect(200);
+
+    expect(historico.doPet).toHaveBeenCalledWith('pet-1', 'vet-1', true);
+  });
+
+  it('exige autenticação (401)', async () => {
+    harness.setUser(null);
+
+    await request(harness.app.getHttpServer())
+      .get('/pets/pet-1/historico-clinico')
+      .expect(401);
+
+    expect(historico.doPet).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/historico/__tests__/historico-clinico.service.spec.ts
+++ b/src/modules/historico/__tests__/historico-clinico.service.spec.ts
@@ -1,0 +1,253 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AcaoClinicaTipo, EntidadeClinica, Role } from '@petcardorg/shared';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { PetService } from '../../pet/pet.service';
+import { HistoricoClinicoService } from '../historico-clinico.service';
+
+describe('HistoricoClinicoService', () => {
+  let service: HistoricoClinicoService;
+  let prisma: {
+    notaClinica: { findMany: jest.Mock };
+    vaccineRecord: { findMany: jest.Mock };
+    dewormingRecord: { findMany: jest.Mock };
+    medicationRecord: { findMany: jest.Mock };
+    acaoClinica: { findMany: jest.Mock };
+  };
+  let petService: { assertAccess: jest.Mock };
+
+  const vet = {
+    id: 'vet-1',
+    nome: 'Dra. Camila',
+    crmv: 'CRMV-SP 12345',
+  };
+
+  const medicacaoExcluida = {
+    id: 'med-1',
+    petId: 'pet-1',
+    medicationName: 'Amoxicilina',
+    dosage: '250mg',
+    frequency: '12/12h',
+    startDate: new Date('2026-03-10'),
+    endDate: null,
+    createdAt: new Date('2026-03-10'),
+    deletedAt: new Date('2026-03-11'),
+    veterinario: vet,
+  };
+
+  beforeEach(async () => {
+    prisma = {
+      notaClinica: { findMany: jest.fn().mockResolvedValue([]) },
+      vaccineRecord: { findMany: jest.fn().mockResolvedValue([]) },
+      dewormingRecord: { findMany: jest.fn().mockResolvedValue([]) },
+      medicationRecord: { findMany: jest.fn().mockResolvedValue([]) },
+      acaoClinica: { findMany: jest.fn().mockResolvedValue([]) },
+    };
+    petService = {
+      assertAccess: jest.fn().mockResolvedValue({ id: 'pet-1', name: 'Rex' }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        HistoricoClinicoService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: PetService, useValue: petService },
+      ],
+    }).compile();
+
+    service = module.get<HistoricoClinicoService>(HistoricoClinicoService);
+  });
+
+  it('inclui registro excluído, marcado como tal', async () => {
+    prisma.medicationRecord.findMany.mockResolvedValue([medicacaoExcluida]);
+
+    const resultado = await service.doPet('pet-1', 'tutor-1', false);
+
+    // O ponto da issue: o tutor apagou, mas a prescrição segue demonstrável.
+    expect(resultado.itens).toHaveLength(1);
+    expect(resultado.itens[0]).toMatchObject({
+      entidade: EntidadeClinica.MEDICACAO,
+      titulo: 'Amoxicilina',
+      excluido: true,
+      excluido_em: medicacaoExcluida.deletedAt,
+      veterinario_crmv: 'CRMV-SP 12345',
+    });
+  });
+
+  it('não filtra excluídos na consulta — é o oposto das listagens', async () => {
+    await service.doPet('pet-1', 'tutor-1', false);
+
+    for (const modelo of [
+      prisma.notaClinica,
+      prisma.vaccineRecord,
+      prisma.dewormingRecord,
+      prisma.medicationRecord,
+    ]) {
+      const [[chamada]] = modelo.findMany.mock.calls as Array<
+        [{ where: Record<string, unknown> }]
+      >;
+      expect(chamada.where).not.toHaveProperty('deletedAt');
+    }
+  });
+
+  it('anexa a trilha de ações ao registro correspondente', async () => {
+    prisma.medicationRecord.findMany.mockResolvedValue([medicacaoExcluida]);
+    prisma.acaoClinica.findMany.mockResolvedValue([
+      {
+        id: 'acao-1',
+        entidade: EntidadeClinica.MEDICACAO,
+        entidadeId: 'med-1',
+        tipo: AcaoClinicaTipo.EXCLUSAO,
+        autorTipo: Role.TUTOR,
+        autorId: 'tutor-1',
+        autorNome: 'Ana Silva',
+        autorCrmv: null,
+        createdAt: new Date('2026-03-11'),
+      },
+      {
+        id: 'acao-2',
+        entidade: EntidadeClinica.VACINA,
+        entidadeId: 'outra',
+        tipo: AcaoClinicaTipo.CRIACAO,
+        autorTipo: Role.VET,
+        autorId: 'vet-1',
+        autorNome: 'Dra. Camila',
+        autorCrmv: 'CRMV-SP 12345',
+        createdAt: new Date('2026-03-01'),
+      },
+    ]);
+
+    const resultado = await service.doPet('pet-1', 'tutor-1', false);
+
+    // Só a ação daquela entidade, não a da vacina.
+    expect(resultado.itens[0].acoes).toHaveLength(1);
+    expect(resultado.itens[0].acoes[0]).toMatchObject({
+      tipo: AcaoClinicaTipo.EXCLUSAO,
+      autor_nome: 'Ana Silva',
+      autor_crmv: undefined,
+    });
+  });
+
+  it('ordena a linha do tempo do mais recente para o mais antigo', async () => {
+    prisma.vaccineRecord.findMany.mockResolvedValue([
+      {
+        id: 'vac-1',
+        petId: 'pet-1',
+        vaccineName: 'Antirrábica',
+        appliedAt: new Date('2026-01-05'),
+        notes: null,
+        createdAt: new Date('2026-01-05'),
+        deletedAt: null,
+        veterinarianName: 'Dr. Externo',
+        veterinario: null,
+      },
+    ]);
+    prisma.medicationRecord.findMany.mockResolvedValue([medicacaoExcluida]);
+
+    const resultado = await service.doPet('pet-1', 'tutor-1', false);
+
+    expect(resultado.itens.map((i) => i.entidade)).toEqual([
+      EntidadeClinica.MEDICACAO,
+      EntidadeClinica.VACINA,
+    ]);
+  });
+
+  it('usa o nome livre quando não há veterinário do PetCard', async () => {
+    prisma.vaccineRecord.findMany.mockResolvedValue([
+      {
+        id: 'vac-1',
+        petId: 'pet-1',
+        vaccineName: 'V8',
+        appliedAt: new Date('2026-01-05'),
+        notes: null,
+        createdAt: new Date('2026-01-05'),
+        deletedAt: null,
+        veterinarianName: 'Dr. Externo',
+        veterinario: null,
+      },
+    ]);
+
+    const resultado = await service.doPet('pet-1', 'tutor-1', false);
+
+    // Sem FK não há atribuição confiável nem CRMV — só o nome digitado.
+    expect(resultado.itens[0].veterinario_nome).toBe('Dr. Externo');
+    expect(resultado.itens[0].veterinario_id).toBeUndefined();
+    expect(resultado.itens[0].veterinario_crmv).toBeUndefined();
+  });
+
+  it('monta nota clínica e vermífugo na linha do tempo', async () => {
+    prisma.notaClinica.findMany.mockResolvedValue([
+      {
+        id: 'nota-1',
+        petId: 'pet-1',
+        diagnostico: 'Otite externa',
+        prescricao: 'Antibiótico 7 dias',
+        observacoes: null,
+        createdAt: new Date('2026-04-01'),
+        deletedAt: null,
+        veterinario: vet,
+      },
+    ]);
+    prisma.dewormingRecord.findMany.mockResolvedValue([
+      {
+        id: 'verm-1',
+        petId: 'pet-1',
+        productName: 'Drontal',
+        appliedAt: new Date('2026-02-01'),
+        notes: 'Dose única',
+        createdAt: new Date('2026-02-01'),
+        deletedAt: null,
+        veterinarianName: null,
+        veterinario: vet,
+      },
+    ]);
+
+    const resultado = await service.doPet('pet-1', 'tutor-1', false);
+
+    const nota = resultado.itens.find(
+      (i) => i.entidade === EntidadeClinica.NOTA_CLINICA,
+    );
+    // O diagnóstico é o título; a prescrição vira a descrição.
+    expect(nota).toMatchObject({
+      titulo: 'Otite externa',
+      descricao: 'Antibiótico 7 dias',
+      excluido: false,
+      veterinario_crmv: 'CRMV-SP 12345',
+    });
+
+    const verm = resultado.itens.find(
+      (i) => i.entidade === EntidadeClinica.VERMIFUGO,
+    );
+    expect(verm).toMatchObject({
+      titulo: 'Drontal',
+      descricao: 'Dose única',
+      excluido: false,
+    });
+  });
+
+  it('cai nas observações quando a nota não tem prescrição', async () => {
+    prisma.notaClinica.findMany.mockResolvedValue([
+      {
+        id: 'nota-2',
+        petId: 'pet-1',
+        diagnostico: 'Revisão',
+        prescricao: null,
+        observacoes: 'Retornar em 30 dias',
+        createdAt: new Date('2026-04-02'),
+        deletedAt: null,
+        veterinario: vet,
+      },
+    ]);
+
+    const resultado = await service.doPet('pet-1', 'tutor-1', false);
+
+    expect(resultado.itens[0].descricao).toBe('Retornar em 30 dias');
+  });
+
+  it('respeita a autorização de acesso ao pet', async () => {
+    petService.assertAccess.mockRejectedValue(new Error('sem acesso'));
+
+    await expect(service.doPet('pet-1', 'outro', false)).rejects.toThrow(
+      'sem acesso',
+    );
+  });
+});

--- a/src/modules/historico/acao-clinica.service.ts
+++ b/src/modules/historico/acao-clinica.service.ts
@@ -1,0 +1,89 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { AcaoClinicaTipo, EntidadeClinica, Prisma, Role } from '@prisma/client';
+import { PrismaService } from '../../prisma/prisma.service';
+
+/** Cliente do Prisma dentro ou fora de transação. */
+export type PrismaLike = Prisma.TransactionClient | PrismaService;
+
+export interface RegistrarAcaoInput {
+  petId: string;
+  tipo: AcaoClinicaTipo;
+  entidade: EntidadeClinica;
+  entidadeId: string;
+  autorId: string;
+  autorTipo: Role;
+  /** Snapshot do que mudou. Opcional para CRIACAO. */
+  detalhes?: Prisma.InputJsonValue;
+}
+
+/**
+ * Registra a trilha de auditoria das ações clínicas (api#117).
+ *
+ * A gravação acontece na mesma transação da ação que a originou: um registro
+ * clínico sem entrada na trilha seria exatamente o buraco que esta issue
+ * fecha, então não pode existir estado onde um foi gravado e o outro não.
+ */
+@Injectable()
+export class AcaoClinicaService {
+  private readonly logger = new Logger(AcaoClinicaService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  async registrar(
+    input: RegistrarAcaoInput,
+    tx: PrismaLike = this.prisma,
+  ): Promise<void> {
+    const { nome, crmv } = await this.identificarAutor(
+      input.autorId,
+      input.autorTipo,
+      tx,
+    );
+
+    await tx.acaoClinica.create({
+      data: {
+        petId: input.petId,
+        tipo: input.tipo,
+        entidade: input.entidade,
+        entidadeId: input.entidadeId,
+        autorTipo: input.autorTipo,
+        autorId: input.autorId,
+        autorNome: nome,
+        autorCrmv: crmv,
+        detalhes: input.detalhes,
+      },
+    });
+  }
+
+  /**
+   * Resolve nome e CRMV **no momento da ação**, para gravá-los na trilha.
+   *
+   * O valor é copiado de propósito em vez de referenciado: a trilha precisa
+   * continuar legível depois que a conta do autor for excluída.
+   */
+  private async identificarAutor(
+    autorId: string,
+    autorTipo: Role,
+    tx: PrismaLike,
+  ): Promise<{ nome: string; crmv: string | null }> {
+    if (autorTipo === Role.VET) {
+      const vet = await tx.veterinario.findUnique({
+        where: { id: autorId },
+        select: { nome: true, crmv: true },
+      });
+      if (vet) return { nome: vet.nome, crmv: vet.crmv };
+    } else {
+      const tutor = await tx.tutor.findUnique({
+        where: { id: autorId },
+        select: { name: true },
+      });
+      if (tutor) return { nome: tutor.name, crmv: null };
+    }
+
+    // Não impedir a ação por causa da trilha: sem o nome, o id ainda
+    // identifica quem agiu.
+    this.logger.warn(
+      `Autor ${autorTipo} ${autorId} não encontrado ao registrar ação clínica.`,
+    );
+    return { nome: autorId, crmv: null };
+  }
+}

--- a/src/modules/historico/historico-clinico.controller.ts
+++ b/src/modules/historico/historico-clinico.controller.ts
@@ -1,0 +1,31 @@
+import { Controller, Get, Param } from '@nestjs/common';
+import { ApiNotFoundResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { HistoricoClinicoResponseDto } from '@petcardorg/shared';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { Role } from '../auth/enums/role.enum';
+import type { JwtPayload } from '../auth/strategies/jwt.strategy';
+import { AuthCrmvVerificado } from '../veterinario/crmv/auth-crmv.decorator';
+import { HistoricoClinicoService } from './historico-clinico.service';
+
+@ApiTags('historico-clinico')
+@Controller()
+export class HistoricoClinicoController {
+  constructor(private readonly historico: HistoricoClinicoService) {}
+
+  @Get('pets/:petId/historico-clinico')
+  @AuthCrmvVerificado(Role.TUTOR, Role.VET)
+  @ApiOperation({
+    summary: 'Histórico clínico completo do pet',
+    description:
+      'Linha do tempo com notas, vacinas, vermífugos e medicações. Inclui ' +
+      'registros excluídos, marcados por `excluido`, e a trilha de ações de ' +
+      'cada um com o responsável e o CRMV.',
+  })
+  @ApiNotFoundResponse({ description: 'Pet não encontrado' })
+  async doPet(
+    @Param('petId') petId: string,
+    @CurrentUser() user: JwtPayload,
+  ): Promise<HistoricoClinicoResponseDto> {
+    return this.historico.doPet(petId, user.sub, user.role === Role.VET);
+  }
+}

--- a/src/modules/historico/historico-clinico.service.ts
+++ b/src/modules/historico/historico-clinico.service.ts
@@ -1,0 +1,193 @@
+import { Injectable } from '@nestjs/common';
+import {
+  AcaoClinica,
+  DewormingRecord,
+  MedicationRecord,
+  NotaClinica,
+  VaccineRecord,
+  Veterinario,
+} from '@prisma/client';
+import {
+  AcaoClinicaResponseDto,
+  AcaoClinicaTipo,
+  EntidadeClinica,
+  HistoricoClinicoItemResponseDto,
+  HistoricoClinicoResponseDto,
+  Role,
+} from '@petcardorg/shared';
+import { PrismaService } from '../../prisma/prisma.service';
+import { PetService } from '../pet/pet.service';
+
+type ComVet<T> = T & { veterinario: Veterinario | null };
+
+@Injectable()
+export class HistoricoClinicoService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly petService: PetService,
+  ) {}
+
+  /**
+   * Linha do tempo clínica do pet (api#117).
+   *
+   * Diferente das listagens normais, **inclui os registros excluídos**,
+   * marcados por `excluido`. É o ponto da issue: o que o veterinário orientou
+   * continua demonstrável mesmo quando o tutor apagou da própria visualização.
+   */
+  async doPet(
+    petId: string,
+    userId: string,
+    isVet: boolean,
+  ): Promise<HistoricoClinicoResponseDto> {
+    const pet = await this.petService.assertAccess(petId, userId, isVet);
+
+    const [notas, vacinas, vermifugos, medicacoes, acoes] = await Promise.all([
+      this.prisma.notaClinica.findMany({
+        where: { petId },
+        include: { veterinario: true },
+      }),
+      this.prisma.vaccineRecord.findMany({
+        where: { petId },
+        include: { veterinario: true },
+      }),
+      this.prisma.dewormingRecord.findMany({
+        where: { petId },
+        include: { veterinario: true },
+      }),
+      this.prisma.medicationRecord.findMany({
+        where: { petId },
+        include: { veterinario: true },
+      }),
+      this.prisma.acaoClinica.findMany({
+        where: { petId },
+        orderBy: { createdAt: 'asc' },
+      }),
+    ]);
+
+    const porEntidade = agruparAcoes(acoes);
+
+    const itens: HistoricoClinicoItemResponseDto[] = [
+      ...notas.map((n) => this.itemDaNota(n, porEntidade)),
+      ...vacinas.map((v) => this.itemDaVacina(v, porEntidade)),
+      ...vermifugos.map((d) => this.itemDoVermifugo(d, porEntidade)),
+      ...medicacoes.map((m) => this.itemDaMedicacao(m, porEntidade)),
+    ].sort((a, b) => b.ocorrido_em.getTime() - a.ocorrido_em.getTime());
+
+    return { pet_id: pet.id, pet_nome: pet.name, itens };
+  }
+
+  private itemDaNota(
+    nota: ComVet<NotaClinica>,
+    acoes: Map<string, AcaoClinicaResponseDto[]>,
+  ): HistoricoClinicoItemResponseDto {
+    return {
+      entidade: EntidadeClinica.NOTA_CLINICA,
+      entidade_id: nota.id,
+      titulo: nota.diagnostico,
+      descricao: nota.prescricao ?? nota.observacoes ?? undefined,
+      ocorrido_em: nota.createdAt,
+      registrado_em: nota.createdAt,
+      ...this.exclusao(nota.deletedAt),
+      ...this.vet(nota.veterinario),
+      acoes: acoes.get(chave(EntidadeClinica.NOTA_CLINICA, nota.id)) ?? [],
+    };
+  }
+
+  private itemDaVacina(
+    vacina: ComVet<VaccineRecord>,
+    acoes: Map<string, AcaoClinicaResponseDto[]>,
+  ): HistoricoClinicoItemResponseDto {
+    return {
+      entidade: EntidadeClinica.VACINA,
+      entidade_id: vacina.id,
+      titulo: vacina.vaccineName,
+      descricao: vacina.notes ?? undefined,
+      ocorrido_em: vacina.appliedAt,
+      registrado_em: vacina.createdAt,
+      ...this.exclusao(vacina.deletedAt),
+      ...this.vet(vacina.veterinario, vacina.veterinarianName),
+      acoes: acoes.get(chave(EntidadeClinica.VACINA, vacina.id)) ?? [],
+    };
+  }
+
+  private itemDoVermifugo(
+    verm: ComVet<DewormingRecord>,
+    acoes: Map<string, AcaoClinicaResponseDto[]>,
+  ): HistoricoClinicoItemResponseDto {
+    return {
+      entidade: EntidadeClinica.VERMIFUGO,
+      entidade_id: verm.id,
+      titulo: verm.productName,
+      descricao: verm.notes ?? undefined,
+      ocorrido_em: verm.appliedAt,
+      registrado_em: verm.createdAt,
+      ...this.exclusao(verm.deletedAt),
+      ...this.vet(verm.veterinario, verm.veterinarianName),
+      acoes: acoes.get(chave(EntidadeClinica.VERMIFUGO, verm.id)) ?? [],
+    };
+  }
+
+  private itemDaMedicacao(
+    med: ComVet<MedicationRecord>,
+    acoes: Map<string, AcaoClinicaResponseDto[]>,
+  ): HistoricoClinicoItemResponseDto {
+    return {
+      entidade: EntidadeClinica.MEDICACAO,
+      entidade_id: med.id,
+      titulo: med.medicationName,
+      descricao: `${med.dosage} · ${med.frequency}`,
+      ocorrido_em: med.startDate,
+      registrado_em: med.createdAt,
+      ...this.exclusao(med.deletedAt),
+      ...this.vet(med.veterinario),
+      acoes: acoes.get(chave(EntidadeClinica.MEDICACAO, med.id)) ?? [],
+    };
+  }
+
+  private exclusao(deletedAt: Date | null) {
+    return {
+      excluido: deletedAt !== null,
+      excluido_em: deletedAt ?? undefined,
+    };
+  }
+
+  /**
+   * O nome em texto livre cobre o profissional que não usa o PetCard; a FK,
+   * quando existe, é a atribuição confiável e traz o CRMV junto.
+   */
+  private vet(veterinario: Veterinario | null, nomeLivre?: string | null) {
+    if (veterinario) {
+      return {
+        veterinario_id: veterinario.id,
+        veterinario_nome: veterinario.nome,
+        veterinario_crmv: veterinario.crmv,
+      };
+    }
+    return { veterinario_nome: nomeLivre ?? undefined };
+  }
+}
+
+function chave(entidade: EntidadeClinica, id: string): string {
+  return `${entidade}:${id}`;
+}
+
+function agruparAcoes(
+  acoes: AcaoClinica[],
+): Map<string, AcaoClinicaResponseDto[]> {
+  const mapa = new Map<string, AcaoClinicaResponseDto[]>();
+  for (const acao of acoes) {
+    const k = chave(acao.entidade as EntidadeClinica, acao.entidadeId);
+    const lista = mapa.get(k) ?? [];
+    lista.push({
+      id: acao.id,
+      tipo: acao.tipo as AcaoClinicaTipo,
+      autor_tipo: acao.autorTipo as Role,
+      autor_id: acao.autorId,
+      autor_nome: acao.autorNome,
+      autor_crmv: acao.autorCrmv ?? undefined,
+      ocorrido_em: acao.createdAt,
+    });
+    mapa.set(k, lista);
+  }
+  return mapa;
+}

--- a/src/modules/historico/historico.module.ts
+++ b/src/modules/historico/historico.module.ts
@@ -1,0 +1,16 @@
+import { Module, forwardRef } from '@nestjs/common';
+import { AuthModule } from '../auth/auth.module';
+import { PetModule } from '../pet/pet.module';
+import { VeterinarioModule } from '../veterinario/veterinario.module';
+import { AcaoClinicaService } from './acao-clinica.service';
+import { HistoricoClinicoController } from './historico-clinico.controller';
+import { HistoricoClinicoService } from './historico-clinico.service';
+
+@Module({
+  imports: [forwardRef(() => AuthModule), PetModule, VeterinarioModule],
+  controllers: [HistoricoClinicoController],
+  providers: [AcaoClinicaService, HistoricoClinicoService],
+  // A trilha é escrita pelos módulos que alteram registro clínico.
+  exports: [AcaoClinicaService],
+})
+export class HistoricoModule {}

--- a/src/modules/reminder/dose-reminder.service.ts
+++ b/src/modules/reminder/dose-reminder.service.ts
@@ -71,7 +71,8 @@ export class DoseReminderService {
     windowDays: number,
   ): Promise<number> {
     const records = await this.prisma.vaccineRecord.findMany({
-      where: { nextDoseAt: { gte: now, lte: windowEnd } },
+      // Registro excluído não gera lembrete (api#117).
+      where: { nextDoseAt: { gte: now, lte: windowEnd }, deletedAt: null },
       include: { pet: { select: { name: true, tutorId: true } } },
     });
 
@@ -102,7 +103,7 @@ export class DoseReminderService {
     windowDays: number,
   ): Promise<number> {
     const records = await this.prisma.dewormingRecord.findMany({
-      where: { nextDoseAt: { gte: now, lte: windowEnd } },
+      where: { nextDoseAt: { gte: now, lte: windowEnd }, deletedAt: null },
       include: { pet: { select: { name: true, tutorId: true } } },
     });
 

--- a/src/modules/vet-note/__tests__/vet-note.controller.spec.ts
+++ b/src/modules/vet-note/__tests__/vet-note.controller.spec.ts
@@ -2,6 +2,10 @@
 import { Logger } from '@nestjs/common';
 import request from 'supertest';
 import {
+  acaoClinicaProvider,
+  comTransacao,
+} from '../../../../test/utils/acao-clinica';
+import {
   createControllerTestApp,
   ControllerHarness,
   TUTOR,
@@ -21,7 +25,8 @@ describe('VetNoteController (integração)', () => {
     notaClinica: {
       create: jest.Mock;
       findMany: jest.Mock;
-      findUnique: jest.Mock;
+      findFirst: jest.Mock;
+      update: jest.Mock;
       delete: jest.Mock;
     };
   };
@@ -49,15 +54,20 @@ describe('VetNoteController (integração)', () => {
       notaClinica: {
         create: jest.fn(),
         findMany: jest.fn(),
-        findUnique: jest.fn(),
+        findFirst: jest.fn(),
+        update: jest.fn(),
         delete: jest.fn(),
+        update: jest.fn(),
       },
     };
     notifications = { schedulePush: jest.fn().mockResolvedValue(undefined) };
 
+    comTransacao(prisma);
+
     harness = await createControllerTestApp({
       controllers: [VetNoteController],
       providers: [
+        acaoClinicaProvider().provider,
         VetNoteService,
         { provide: PrismaService, useValue: prisma },
         { provide: NotificationService, useValue: notifications },
@@ -151,7 +161,7 @@ describe('VetNoteController (integração)', () => {
   describe('GET /clinical-notes/:id', () => {
     it('retorna a nota para o dono do pet (200)', async () => {
       harness.setUser(TUTOR);
-      prisma.notaClinica.findUnique.mockResolvedValue({
+      prisma.notaClinica.findFirst.mockResolvedValue({
         ...nota,
         pet: { tutorId: 'tutor-1' },
       });
@@ -164,7 +174,7 @@ describe('VetNoteController (integração)', () => {
     });
 
     it('retorna 404 para nota inexistente', async () => {
-      prisma.notaClinica.findUnique.mockResolvedValue(null);
+      prisma.notaClinica.findFirst.mockResolvedValue(null);
 
       await request(harness.app.getHttpServer())
         .get('/clinical-notes/missing')
@@ -174,16 +184,18 @@ describe('VetNoteController (integração)', () => {
 
   describe('DELETE /clinical-notes/:id', () => {
     it('o autor (VET) remove a própria nota (204)', async () => {
-      prisma.notaClinica.findUnique.mockResolvedValue(nota);
-      prisma.notaClinica.delete.mockResolvedValue(nota);
+      prisma.notaClinica.findFirst.mockResolvedValue(nota);
+      prisma.notaClinica.update.mockResolvedValue(nota);
 
       await request(harness.app.getHttpServer())
         .delete('/clinical-notes/nota-1')
         .expect(204);
+
+      expect(prisma.notaClinica.delete).not.toHaveBeenCalled();
     });
 
     it('proíbe VET de apagar nota de outro vet (403)', async () => {
-      prisma.notaClinica.findUnique.mockResolvedValue({
+      prisma.notaClinica.findFirst.mockResolvedValue({
         ...nota,
         veterinarioId: 'outro-vet',
       });

--- a/src/modules/vet-note/__tests__/vet-note.service.spec.ts
+++ b/src/modules/vet-note/__tests__/vet-note.service.spec.ts
@@ -1,5 +1,9 @@
 import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
+import {
+  acaoClinicaProvider,
+  comTransacao,
+} from '../../../../test/utils/acao-clinica';
 import { NotificationKind } from '@prisma/client';
 import { PrismaService } from '../../../prisma/prisma.service';
 import { NotificationService } from '../../notification/notification.service';
@@ -11,7 +15,8 @@ describe('VetNoteService', () => {
     notaClinica: {
       create: jest.Mock;
       findMany: jest.Mock;
-      findUnique: jest.Mock;
+      findFirst: jest.Mock;
+      update: jest.Mock;
       delete: jest.Mock;
     };
     pet: { findUnique: jest.Mock };
@@ -49,8 +54,10 @@ describe('VetNoteService', () => {
       notaClinica: {
         create: jest.fn(),
         findMany: jest.fn(),
-        findUnique: jest.fn(),
+        findFirst: jest.fn(),
+        update: jest.fn(),
         delete: jest.fn(),
+        update: jest.fn(),
       },
       pet: { findUnique: jest.fn() },
       veterinario: { findUnique: jest.fn() },
@@ -59,8 +66,11 @@ describe('VetNoteService', () => {
       schedulePush: jest.fn().mockResolvedValue([]),
     };
 
+    comTransacao(prisma);
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
+        acaoClinicaProvider().provider,
         VetNoteService,
         { provide: PrismaService, useValue: prisma },
         { provide: NotificationService, useValue: notificationService },
@@ -245,7 +255,7 @@ describe('VetNoteService', () => {
     };
 
     it('should return a clinical note when tutor owns the pet', async () => {
-      prisma.notaClinica.findUnique.mockResolvedValue(notaWithPet);
+      prisma.notaClinica.findFirst.mockResolvedValue(notaWithPet);
 
       const result = await service.findOne('nota-1', 'tutor-1', false);
 
@@ -253,7 +263,7 @@ describe('VetNoteService', () => {
     });
 
     it('should return a clinical note when user is vet', async () => {
-      prisma.notaClinica.findUnique.mockResolvedValue(notaWithPet);
+      prisma.notaClinica.findFirst.mockResolvedValue(notaWithPet);
 
       const result = await service.findOne('nota-1', 'vet-1', true);
 
@@ -261,7 +271,7 @@ describe('VetNoteService', () => {
     });
 
     it('should throw ForbiddenException when tutor does not own the pet', async () => {
-      prisma.notaClinica.findUnique.mockResolvedValue(notaWithPet);
+      prisma.notaClinica.findFirst.mockResolvedValue(notaWithPet);
 
       await expect(
         service.findOne('nota-1', 'tutor-other', false),
@@ -269,7 +279,7 @@ describe('VetNoteService', () => {
     });
 
     it('should throw NotFoundException when note does not exist', async () => {
-      prisma.notaClinica.findUnique.mockResolvedValue(null);
+      prisma.notaClinica.findFirst.mockResolvedValue(null);
 
       await expect(
         service.findOne('missing', 'tutor-1', false),
@@ -278,22 +288,25 @@ describe('VetNoteService', () => {
   });
 
   describe('remove', () => {
-    it('should delete a note when the author is the veterinario', async () => {
-      prisma.notaClinica.findUnique.mockResolvedValue({
+    it('marca como excluída em vez de apagar (api#117)', async () => {
+      prisma.notaClinica.findFirst.mockResolvedValue({
         ...notaFixture,
         veterinarioId: 'vet-1',
       });
-      prisma.notaClinica.delete.mockResolvedValue(notaFixture);
+      prisma.notaClinica.update.mockResolvedValue(notaFixture);
 
       await service.remove('nota-1', 'vet-1');
 
-      expect(prisma.notaClinica.delete).toHaveBeenCalledWith({
-        where: { id: 'nota-1' },
-      });
+      expect(prisma.notaClinica.delete).not.toHaveBeenCalled();
+      const [[chamada]] = prisma.notaClinica.update.mock.calls as Array<
+        [{ where: { id: string }; data: { deletedAt: Date } }]
+      >;
+      expect(chamada.where).toEqual({ id: 'nota-1' });
+      expect(chamada.data.deletedAt).toBeInstanceOf(Date);
     });
 
     it('should throw ForbiddenException when another vet tries to delete', async () => {
-      prisma.notaClinica.findUnique.mockResolvedValue({
+      prisma.notaClinica.findFirst.mockResolvedValue({
         ...notaFixture,
         veterinarioId: 'vet-1',
       });
@@ -304,7 +317,7 @@ describe('VetNoteService', () => {
     });
 
     it('should throw NotFoundException when note does not exist', async () => {
-      prisma.notaClinica.findUnique.mockResolvedValue(null);
+      prisma.notaClinica.findFirst.mockResolvedValue(null);
 
       await expect(service.remove('missing', 'vet-1')).rejects.toThrow(
         NotFoundException,

--- a/src/modules/vet-note/vet-note.module.ts
+++ b/src/modules/vet-note/vet-note.module.ts
@@ -1,4 +1,5 @@
 import { Module, forwardRef } from '@nestjs/common';
+import { HistoricoModule } from '../historico/historico.module';
 import { AuthModule } from '../auth/auth.module';
 import { NotificationModule } from '../notification/notification.module';
 import { VeterinarioModule } from '../veterinario/veterinario.module';
@@ -7,6 +8,7 @@ import { VetNoteService } from './vet-note.service';
 
 @Module({
   imports: [
+    HistoricoModule,
     forwardRef(() => AuthModule),
     NotificationModule,
     VeterinarioModule,

--- a/src/modules/vet-note/vet-note.service.ts
+++ b/src/modules/vet-note/vet-note.service.ts
@@ -4,9 +4,16 @@ import {
   Logger,
   NotFoundException,
 } from '@nestjs/common';
-import { NotaClinica, NotificationKind } from '@prisma/client';
+import {
+  AcaoClinicaTipo,
+  EntidadeClinica,
+  NotaClinica,
+  NotificationKind,
+  Role,
+} from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
 import { NotificationService } from '../notification/notification.service';
+import { AcaoClinicaService } from '../historico/acao-clinica.service';
 import {
   CreateNotaClinicaDto,
   NotaClinicaResponseDto,
@@ -39,6 +46,7 @@ export class VetNoteService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly notificationService: NotificationService,
+    private readonly acoes: AcaoClinicaService,
   ) {}
 
   async create(
@@ -49,16 +57,30 @@ export class VetNoteService {
     const pet = await this.findPetOrFail(petId);
     await this.assertVeterinarioExists(veterinarioId);
 
-    const nota = await this.prisma.notaClinica.create({
-      data: {
-        petId,
-        veterinarioId,
-        diagnostico: dto.diagnostico,
-        prescricao: dto.prescricao,
-        observacoes: dto.observacoes,
-        googlePlaceId: dto.google_place_id,
-      },
-      include: { veterinario: { select: { nome: true, crmv: true } } },
+    const nota = await this.prisma.$transaction(async (tx) => {
+      const criada = await tx.notaClinica.create({
+        data: {
+          petId,
+          veterinarioId,
+          diagnostico: dto.diagnostico,
+          prescricao: dto.prescricao,
+          observacoes: dto.observacoes,
+          googlePlaceId: dto.google_place_id,
+        },
+        include: { veterinario: { select: { nome: true, crmv: true } } },
+      });
+      await this.acoes.registrar(
+        {
+          petId,
+          tipo: AcaoClinicaTipo.CRIACAO,
+          entidade: EntidadeClinica.NOTA_CLINICA,
+          entidadeId: criada.id,
+          autorId: veterinarioId,
+          autorTipo: Role.VET,
+        },
+        tx,
+      );
+      return criada;
     });
 
     const response = toResponseDto(nota);
@@ -99,7 +121,7 @@ export class VetNoteService {
     }
 
     const notas = await this.prisma.notaClinica.findMany({
-      where: { petId },
+      where: { petId, deletedAt: null },
       orderBy: { createdAt: 'desc' },
       include: { veterinario: { select: { nome: true, crmv: true } } },
     });
@@ -112,8 +134,8 @@ export class VetNoteService {
     userId: string,
     isVet: boolean,
   ): Promise<NotaClinicaResponseDto> {
-    const nota = await this.prisma.notaClinica.findUnique({
-      where: { id },
+    const nota = await this.prisma.notaClinica.findFirst({
+      where: { id, deletedAt: null },
       include: {
         veterinario: { select: { nome: true, crmv: true } },
         pet: { select: { tutorId: true } },
@@ -131,8 +153,14 @@ export class VetNoteService {
     return toResponseDto(nota);
   }
 
+  /**
+   * Exclusão lógica (api#117): a nota some da listagem, mas o histórico
+   * clínico preserva o que foi diagnosticado e quem diagnosticou.
+   */
   async remove(id: string, veterinarioId: string): Promise<void> {
-    const nota = await this.prisma.notaClinica.findUnique({ where: { id } });
+    const nota = await this.prisma.notaClinica.findFirst({
+      where: { id, deletedAt: null },
+    });
 
     if (!nota) {
       throw new NotFoundException(`Clinical note with id ${id} not found`);
@@ -144,7 +172,30 @@ export class VetNoteService {
       );
     }
 
-    await this.prisma.notaClinica.delete({ where: { id } });
+    await this.prisma.$transaction(async (tx) => {
+      await tx.notaClinica.update({
+        where: { id },
+        data: { deletedAt: new Date() },
+      });
+      await this.acoes.registrar(
+        {
+          petId: nota.petId,
+          tipo: AcaoClinicaTipo.EXCLUSAO,
+          entidade: EntidadeClinica.NOTA_CLINICA,
+          entidadeId: id,
+          autorId: veterinarioId,
+          autorTipo: Role.VET,
+          detalhes: {
+            antes: {
+              diagnostico: nota.diagnostico,
+              prescricao: nota.prescricao,
+              observacoes: nota.observacoes,
+            },
+          },
+        },
+        tx,
+      );
+    });
   }
 
   private async findPetOrFail(

--- a/src/modules/veterinario/__tests__/dashboard.service.spec.ts
+++ b/src/modules/veterinario/__tests__/dashboard.service.spec.ts
@@ -83,7 +83,8 @@ describe('VeterinarioService - findAttendedPets', () => {
     expect(result.total).toBe(1);
     expect(prisma.notaClinica.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: { veterinarioId: 'vet-1' },
+        // Nota excluída não traz o pet de volta ao dashboard (api#117).
+        where: { veterinarioId: 'vet-1', deletedAt: null },
       }),
     );
   });

--- a/src/modules/veterinario/veterinario.service.ts
+++ b/src/modules/veterinario/veterinario.service.ts
@@ -99,7 +99,11 @@ export class VeterinarioService {
     const pageSize = query.pageSize ?? 10;
     const search = query.search?.trim();
 
-    const where: Prisma.NotaClinicaWhereInput = { veterinarioId };
+    // Nota excluída não traz o pet de volta ao dashboard (api#117).
+    const where: Prisma.NotaClinicaWhereInput = {
+      veterinarioId,
+      deletedAt: null,
+    };
 
     if (search) {
       where.OR = [

--- a/test/e2e/historico-clinico.e2e-spec.ts
+++ b/test/e2e/historico-clinico.e2e-spec.ts
@@ -1,0 +1,208 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import type { INestApplication } from '@nestjs/common';
+import type { App } from 'supertest/types';
+import request from 'supertest';
+import { createE2EApp, E2EApp } from '../utils/e2e-app';
+import { createAndLoginVet, registerTutor, resetDb } from '../utils/e2e-db';
+import { PrismaService } from '../../src/prisma/prisma.service';
+import type {
+  HistoricoClinicoItemResponseDto,
+  HistoricoClinicoResponseDto,
+} from '@petcardorg/shared';
+
+function acharItem(
+  body: HistoricoClinicoResponseDto,
+  entidadeId: string,
+): HistoricoClinicoItemResponseDto | undefined {
+  return body.itens.find((i) => i.entidade_id === entidadeId);
+}
+
+describe('Histórico clínico (e2e)', () => {
+  let ctx: E2EApp;
+  let app: INestApplication<App>;
+  let prisma: PrismaService;
+  let tutorToken: string;
+  let tutorId: string;
+  let vetToken: string;
+  let petId: string;
+
+  beforeAll(async () => {
+    ctx = await createE2EApp();
+    ({ app, prisma } = ctx);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(async () => {
+    await resetDb(prisma);
+    const tutor = await registerTutor(app);
+    tutorToken = tutor.token;
+    tutorId = tutor.user.id;
+    ({ token: vetToken } = await createAndLoginVet(app, prisma));
+
+    const pet = await request(app.getHttpServer())
+      .post('/pets')
+      .set('Authorization', `Bearer ${tutorToken}`)
+      .send({ name: 'Rex', species: 'DOG', sex: 'MALE' })
+      .expect(201);
+    petId = pet.body.id as string;
+  });
+
+  async function prescreverMedicacao(): Promise<string> {
+    const res = await request(app.getHttpServer())
+      .post(`/pets/${petId}/medications`)
+      .set('Authorization', `Bearer ${vetToken}`)
+      .send({
+        pet_id: petId,
+        medication_name: 'Amoxicilina',
+        dosage: '250mg',
+        frequency: '12/12h',
+        start_date: '2026-03-10',
+      })
+      .expect(201);
+    return res.body.id as string;
+  }
+
+  it('o tutor apaga a prescrição, mas ela permanece no histórico', async () => {
+    const medId = await prescreverMedicacao();
+
+    await request(app.getHttpServer())
+      .delete(`/medications/${medId}`)
+      .set('Authorization', `Bearer ${tutorToken}`)
+      .expect(204);
+
+    // Sumiu da listagem do tutor...
+    const lista = await request(app.getHttpServer())
+      .get(`/pets/${petId}/medications`)
+      .set('Authorization', `Bearer ${tutorToken}`)
+      .expect(200);
+    expect(lista.body).toHaveLength(0);
+
+    // ...mas continua no histórico, marcada como excluída.
+    const historico = await request(app.getHttpServer())
+      .get(`/pets/${petId}/historico-clinico`)
+      .set('Authorization', `Bearer ${vetToken}`)
+      .expect(200);
+
+    const item = acharItem(
+      historico.body as HistoricoClinicoResponseDto,
+      medId,
+    );
+    expect(item).toBeDefined();
+    expect(item!.excluido).toBe(true);
+    expect(item!.titulo).toBe('Amoxicilina');
+
+    // E a linha continua no banco.
+    const noBanco = await prisma.medicationRecord.findUnique({
+      where: { id: medId },
+    });
+    expect(noBanco).not.toBeNull();
+    expect(noBanco?.deletedAt).not.toBeNull();
+  });
+
+  it('registra quem prescreveu, com CRMV, e quem apagou', async () => {
+    const medId = await prescreverMedicacao();
+    await request(app.getHttpServer())
+      .delete(`/medications/${medId}`)
+      .set('Authorization', `Bearer ${tutorToken}`)
+      .expect(204);
+
+    const historico = await request(app.getHttpServer())
+      .get(`/pets/${petId}/historico-clinico`)
+      .set('Authorization', `Bearer ${vetToken}`)
+      .expect(200);
+
+    const item = acharItem(
+      historico.body as HistoricoClinicoResponseDto,
+      medId,
+    )!;
+    expect(item.veterinario_crmv).toBe('CRMV-CE-1234');
+
+    const tipos = item.acoes.map((a) => a.tipo);
+    expect(tipos).toEqual(['CRIACAO', 'EXCLUSAO']);
+
+    const criacao = item.acoes[0];
+    expect(criacao.autor_tipo).toBe('VET');
+    expect(criacao.autor_crmv).toBe('CRMV-CE-1234');
+
+    const exclusao = item.acoes[1];
+    expect(exclusao.autor_tipo).toBe('TUTOR');
+    expect(exclusao.autor_id).toBe(tutorId);
+  });
+
+  it('a trilha sobrevive à exclusão da conta do veterinário', async () => {
+    const medId = await prescreverMedicacao();
+    const vet = await prisma.veterinario.findFirstOrThrow();
+
+    await prisma.veterinario.delete({ where: { id: vet.id } });
+
+    const acoes = await prisma.acaoClinica.findMany({
+      where: { entidadeId: medId },
+    });
+    // Nome e CRMV estão gravados na trilha, não referenciados.
+    expect(acoes[0].autorNome).toBe('Dra. Camila');
+    expect(acoes[0].autorCrmv).toBe('CRMV-CE-1234');
+  });
+
+  it('a edição entra na trilha com o antes e o depois', async () => {
+    const medId = await prescreverMedicacao();
+
+    await request(app.getHttpServer())
+      .patch(`/medications/${medId}`)
+      .set('Authorization', `Bearer ${tutorToken}`)
+      .send({ dosage: '500mg' })
+      .expect(200);
+
+    const acoes = await prisma.acaoClinica.findMany({
+      where: { entidadeId: medId, tipo: 'EDICAO' },
+    });
+    expect(acoes).toHaveLength(1);
+    const detalhes = acoes[0].detalhes as {
+      antes: { dosage: string };
+      depois: { dosage: string };
+    };
+    expect(detalhes.antes.dosage).toBe('250mg');
+    expect(detalhes.depois.dosage).toBe('500mg');
+  });
+
+  it('proíbe tutor que não é dono de ver o histórico (403)', async () => {
+    const { token: outro } = await registerTutor(app, {
+      email: 'outro@petcard.com',
+    });
+
+    await request(app.getHttpServer())
+      .get(`/pets/${petId}/historico-clinico`)
+      .set('Authorization', `Bearer ${outro}`)
+      .expect(403);
+  });
+
+  it('vacina excluída some da carteira pública', async () => {
+    const vacina = await request(app.getHttpServer())
+      .post(`/pets/${petId}/vaccines`)
+      .set('Authorization', `Bearer ${tutorToken}`)
+      .send({
+        pet_id: petId,
+        vaccine_name: 'Antirrábica',
+        applied_at: '2026-02-01',
+      })
+      .expect(201);
+
+    const card = await request(app.getHttpServer())
+      .get(`/cards/pets/${petId}`)
+      .set('Authorization', `Bearer ${tutorToken}`)
+      .expect(200);
+    const token = (card.body.public_url as string).split('/').pop()!;
+
+    await request(app.getHttpServer())
+      .delete(`/vaccines/${vacina.body.id}`)
+      .set('Authorization', `Bearer ${tutorToken}`)
+      .expect(204);
+
+    const publica = await request(app.getHttpServer())
+      .get(`/cards/${token}`)
+      .expect(200);
+    expect(publica.body.vaccines).toHaveLength(0);
+  });
+});

--- a/test/utils/acao-clinica.ts
+++ b/test/utils/acao-clinica.ts
@@ -1,0 +1,27 @@
+import { AcaoClinicaService } from '../../src/modules/historico/acao-clinica.service';
+
+/**
+ * Provider da trilha de auditoria para specs (api#117).
+ *
+ * A gravação em si tem spec própria; aqui interessa só que os serviços
+ * clínicos a chamem, então o dublê registra as chamadas.
+ */
+export function acaoClinicaProvider(registrar = jest.fn()) {
+  return {
+    registrar,
+    provider: { provide: AcaoClinicaService, useValue: { registrar } },
+  };
+}
+
+/**
+ * Faz o mock do Prisma executar callbacks de `$transaction` contra ele mesmo.
+ * Sem isto, os serviços que agrupam escrita + trilha numa transação quebram
+ * nos specs que mockam o Prisma.
+ */
+export function comTransacao<T extends object>(prismaMock: T): T {
+  return Object.assign(prismaMock, {
+    $transaction: jest.fn(
+      (cb: (tx: T) => Promise<unknown>): Promise<unknown> => cb(prismaMock),
+    ),
+  });
+}


### PR DESCRIPTION
Fecha #117. Depende de `@petcardorg/shared@0.12.0`, já publicada (PetCardOrg/petcard-shared#55).

## O problema

O veterinário prescrevia uma medicação, o tutor decidia não dar o remédio e apagava o registro — que **saía do banco permanentemente**. Na consulta seguinte não havia vestígio nem do que foi orientado, nem de que foi ignorado.

Não era brecha: `DELETE /vaccines/:id`, `/dewormings/:id` e `/medications/:id` são `@Auth(Role.TUTOR)`, e os quatro modelos clínicos usavam `delete()` físico. Era o caminho normal.

## O que muda

**Exclusão lógica** nos quatro modelos. Toda leitura passou a filtrar `deletedAt: null` — incluindo os pontos que não são óbvios: a carteira pública, a carteira clínica do QR, o dashboard do vet (uma nota excluída não traz o pet de volta) e o cron de lembrete de dose (registro excluído não gera push).

**Veterinário responsável de verdade** em vacina, vermífugo e medicação: FK para `Veterinario`, preenchida a partir do JWT quando quem registra é um vet. O `veterinarianName` em texto livre **permanece** — cobre registros históricos e o profissional que não usa o PetCard. Medicação não tinha nenhuma atribuição antes.

**Trilha de auditoria** (`acao_clinica`): criação, edição e exclusão, com autor, CRMV e snapshot do antes/depois. Duas decisões que valem explicação:

- **Nome e CRMV são gravados na trilha, não referenciados.** Uma evidência que some junto com a conta do veterinário não serve como evidência. Há teste e2e que apaga a conta do vet e verifica que a trilha continua legível.
- **Escrita e trilha na mesma transação.** Um registro clínico sem a ação correspondente seria exatamente o buraco que a issue fecha, então não pode existir estado onde um foi gravado e o outro não.

**`GET /pets/:petId/historico-clinico`** — linha do tempo com as quatro entidades, ordenada por data clínica, **incluindo os excluídos** marcados por `excluido`. É o oposto das listagens normais, e tem teste garantindo que a consulta não filtra. Autorização igual à das notas: tutor no próprio pet, ou VET com CRMV verificado.

## Verificação

- **437 testes unitários + 36 e2e** verdes; suíte completa rodada 3× seguidas.
- Cobertura **86.04 / 80.55 / 94.06 / 87.4** (catraca 84/80/93/85).
- Os dois testes centrais foram verificados por reintrodução do bug: voltar o `delete()` físico derruba 2 e2e; fazer a trilha referenciar em vez de copiar o autor derruba 2 e2e + 1 unitário.
- Migration aditiva — todas as colunas novas são nulas, os registros existentes sobrevivem com `deletedAt` nulo.

## Fora de escopo

**Modelagem de aderência** (prescrição com estado seguida/interrompida/ignorada) fica como trabalho futuro, conforme decidido na issue. Esta PR entrega imutabilidade: o que o vet orientou continua demonstrável.

## Efeito nas issues dependentes

- **mobile#59** (tutor vê o histórico) tem o endpoint para consumir.
- **mobile#58** (aviso ao editar/apagar observação do vet) continua valendo como UX, mas o buraco embaixo está fechado — a API não apaga mais de verdade.
- **api#112** (excluir notificações em cascata) vai precisar decidir se a notificação some ou acompanha o `deletedAt`.
