### PR TITLE
feat: regra de autoria em registro clínico e CRMV na escrita

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@nestjs/schedule": "^6.1.3",
         "@nestjs/swagger": "^11.4.4",
         "@nestjs/throttler": "^6.5.0",
-        "@petcardorg/shared": "^0.14.0",
+        "@petcardorg/shared": "^0.15.0",
         "@prisma/client": "^6.19.3",
         "amqp-connection-manager": "^5.0.0",
         "amqplib": "^1.0.3",
@@ -3846,9 +3846,9 @@
       }
     },
     "node_modules/@petcardorg/shared": {
-      "version": "0.14.0",
-      "resolved": "https://npm.pkg.github.com/download/@petcardorg/shared/0.14.0/20544a9e47bab0ed042d21dd67e8d3d42c17178e",
-      "integrity": "sha512-Zb268VqNGtKpnYWm4yYQkyRYGf8mA8ZwtPJzEWSjMgYjK/dVmXjV704hoEv7DqyuI4mEfnejaq1rIbuMUtcqvQ==",
+      "version": "0.15.0",
+      "resolved": "https://npm.pkg.github.com/download/@petcardorg/shared/0.15.0/252ff785bd03175ef4021579ed3d035d6b10f0b5",
+      "integrity": "sha512-NMa6KsckRzAmZWscf+xeTXF4qYnKIpsf86rqeruI2drUWHNcXFy0Q60EhFcj9W4WeAk3Qpqzx/dIGXk7NjGdPQ==",
       "license": "MIT",
       "peerDependencies": {
         "class-transformer": "^0.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@nestjs/schedule": "^6.1.3",
         "@nestjs/swagger": "^11.4.4",
         "@nestjs/throttler": "^6.5.0",
-        "@petcardorg/shared": "^0.15.0",
+        "@petcardorg/shared": "^0.15.1",
         "@prisma/client": "^6.19.3",
         "amqp-connection-manager": "^5.0.0",
         "amqplib": "^1.0.3",
@@ -3846,9 +3846,9 @@
       }
     },
     "node_modules/@petcardorg/shared": {
-      "version": "0.15.0",
-      "resolved": "https://npm.pkg.github.com/download/@petcardorg/shared/0.15.0/252ff785bd03175ef4021579ed3d035d6b10f0b5",
-      "integrity": "sha512-NMa6KsckRzAmZWscf+xeTXF4qYnKIpsf86rqeruI2drUWHNcXFy0Q60EhFcj9W4WeAk3Qpqzx/dIGXk7NjGdPQ==",
+      "version": "0.15.1",
+      "resolved": "https://npm.pkg.github.com/download/@petcardorg/shared/0.15.1/220d0352ca89ffbcf265e0ad0677fef0fcd8a26d",
+      "integrity": "sha512-t52AdLujkca30Rd+mAQbcFAgLCL+5f/pjGNm8gOhy3nn4mQmf876AQPvQTDbd/K+13Uq3uuD2bcVk3Es643NCA==",
       "license": "MIT",
       "peerDependencies": {
         "class-transformer": "^0.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@nestjs/schedule": "^6.1.3",
         "@nestjs/swagger": "^11.4.4",
         "@nestjs/throttler": "^6.5.0",
-        "@petcardorg/shared": "^0.12.0",
+        "@petcardorg/shared": "^0.13.0",
         "@prisma/client": "^6.19.3",
         "amqp-connection-manager": "^5.0.0",
         "amqplib": "^1.0.3",
@@ -3846,9 +3846,9 @@
       }
     },
     "node_modules/@petcardorg/shared": {
-      "version": "0.12.0",
-      "resolved": "https://npm.pkg.github.com/download/@petcardorg/shared/0.12.0/3ed8464acbf967c44fd55a200f4e5b2a403fd491",
-      "integrity": "sha512-jD0rZ/wTZdy4QJUQEK3he75/OwlViZp5MOQfRsA4gwEZQShc1EFLmZO2rR55NXP85UCwQdwquxb52v+jvVaSKQ==",
+      "version": "0.13.0",
+      "resolved": "https://npm.pkg.github.com/download/@petcardorg/shared/0.13.0/576244e46f169aecbf4a74935d2bbdf3f168fd79",
+      "integrity": "sha512-81/09HZE4aNb61Ku8R099N/ZKs6WjG3t05tDBUopAZWyiAERw48U3eBrt8qFBsDZ4zEWgjY6M9/0m96gkc+Ymw==",
       "license": "MIT",
       "peerDependencies": {
         "class-transformer": "^0.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@nestjs/schedule": "^6.1.3",
         "@nestjs/swagger": "^11.4.4",
         "@nestjs/throttler": "^6.5.0",
-        "@petcardorg/shared": "^0.13.0",
+        "@petcardorg/shared": "^0.14.0",
         "@prisma/client": "^6.19.3",
         "amqp-connection-manager": "^5.0.0",
         "amqplib": "^1.0.3",
@@ -3846,9 +3846,9 @@
       }
     },
     "node_modules/@petcardorg/shared": {
-      "version": "0.13.0",
-      "resolved": "https://npm.pkg.github.com/download/@petcardorg/shared/0.13.0/576244e46f169aecbf4a74935d2bbdf3f168fd79",
-      "integrity": "sha512-81/09HZE4aNb61Ku8R099N/ZKs6WjG3t05tDBUopAZWyiAERw48U3eBrt8qFBsDZ4zEWgjY6M9/0m96gkc+Ymw==",
+      "version": "0.14.0",
+      "resolved": "https://npm.pkg.github.com/download/@petcardorg/shared/0.14.0/20544a9e47bab0ed042d21dd67e8d3d42c17178e",
+      "integrity": "sha512-Zb268VqNGtKpnYWm4yYQkyRYGf8mA8ZwtPJzEWSjMgYjK/dVmXjV704hoEv7DqyuI4mEfnejaq1rIbuMUtcqvQ==",
       "license": "MIT",
       "peerDependencies": {
         "class-transformer": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@nestjs/schedule": "^6.1.3",
     "@nestjs/swagger": "^11.4.4",
     "@nestjs/throttler": "^6.5.0",
-    "@petcardorg/shared": "^0.13.0",
+    "@petcardorg/shared": "^0.14.0",
     "@prisma/client": "^6.19.3",
     "amqp-connection-manager": "^5.0.0",
     "amqplib": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@nestjs/schedule": "^6.1.3",
     "@nestjs/swagger": "^11.4.4",
     "@nestjs/throttler": "^6.5.0",
-    "@petcardorg/shared": "^0.15.0",
+    "@petcardorg/shared": "^0.15.1",
     "@prisma/client": "^6.19.3",
     "amqp-connection-manager": "^5.0.0",
     "amqplib": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@nestjs/schedule": "^6.1.3",
     "@nestjs/swagger": "^11.4.4",
     "@nestjs/throttler": "^6.5.0",
-    "@petcardorg/shared": "^0.12.0",
+    "@petcardorg/shared": "^0.13.0",
     "@prisma/client": "^6.19.3",
     "amqp-connection-manager": "^5.0.0",
     "amqplib": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@nestjs/schedule": "^6.1.3",
     "@nestjs/swagger": "^11.4.4",
     "@nestjs/throttler": "^6.5.0",
-    "@petcardorg/shared": "^0.14.0",
+    "@petcardorg/shared": "^0.15.0",
     "@prisma/client": "^6.19.3",
     "amqp-connection-manager": "^5.0.0",
     "amqplib": "^1.0.3",

--- a/prisma/migrations/20260818222204_nome_do_veterinario_na_medicacao/migration.sql
+++ b/prisma/migrations/20260818222204_nome_do_veterinario_na_medicacao/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "medication_record" ADD COLUMN     "veterinarian_name" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -196,20 +196,22 @@ model DewormingRecord {
 }
 
 model MedicationRecord {
-  id             String    @id @default(uuid())
-  petId          String    @map("pet_id")
-  medicationName String    @map("medication_name")
-  dosage         String
-  frequency      String
-  startDate      DateTime  @map("start_date")
-  endDate        DateTime? @map("end_date")
-  lastNotifiedAt DateTime? @map("last_notified_at")
+  id               String    @id @default(uuid())
+  petId            String    @map("pet_id")
+  medicationName   String    @map("medication_name")
+  dosage           String
+  frequency        String
+  startDate        DateTime  @map("start_date")
+  endDate          DateTime? @map("end_date")
+  lastNotifiedAt   DateTime? @map("last_notified_at")
   /// Preenchido quando quem prescreve é um veterinário do PetCard.
-  veterinarioId  String?   @map("veterinario_id")
-  notes          String?
-  createdAt      DateTime  @default(now()) @map("created_at")
-  updatedAt      DateTime  @updatedAt @map("updated_at")
-  deletedAt      DateTime? @map("deleted_at")
+  veterinarioId    String?   @map("veterinario_id")
+  /// Texto livre: prescrições antigas e profissionais fora do PetCard.
+  veterinarianName String?   @map("veterinarian_name")
+  notes            String?
+  createdAt        DateTime  @default(now()) @map("created_at")
+  updatedAt        DateTime  @updatedAt @map("updated_at")
+  deletedAt        DateTime? @map("deleted_at")
 
   pet         Pet          @relation(fields: [petId], references: [id], onDelete: Cascade)
   veterinario Veterinario? @relation(fields: [veterinarioId], references: [id], onDelete: SetNull)
@@ -268,33 +270,33 @@ model Notification {
 }
 
 model Veterinario {
-  id        String   @id @default(uuid())
-  nome      String
-  email     String   @unique
-  password  String
-  crmv      String   @unique
-  telefone  String?
+  id       String  @id @default(uuid())
+  nome     String
+  email    String  @unique
+  password String
+  crmv     String  @unique
+  telefone String?
 
   /// Verificação do CRMV numa base externa (api#113). Nulo = não verificado.
   crmvVerifiedAt DateTime? @map("crmv_verified_at")
   /// Situação devolvida pela consulta (ex.: "Ativo"), para auditoria.
   crmvSituacao   String?   @map("crmv_situacao")
-  createdAt DateTime @default(now()) @map("created_at")
-  updatedAt DateTime @updatedAt @map("updated_at")
+  createdAt      DateTime  @default(now()) @map("created_at")
+  updatedAt      DateTime  @updatedAt @map("updated_at")
 
-  notasClinicas     NotaClinica[]
-  vacinas           VaccineRecord[]
-  vermifugos        DewormingRecord[]
-  medicacoes        MedicationRecord[]
+  notasClinicas NotaClinica[]
+  vacinas       VaccineRecord[]
+  vermifugos    DewormingRecord[]
+  medicacoes    MedicationRecord[]
 
   @@map("veterinario")
 }
 
 model NotaClinica {
-  id            String   @id @default(uuid())
-  veterinarioId String   @map("veterinario_id")
-  petId         String   @map("pet_id")
-  googlePlaceId String?  @map("google_place_id")
+  id            String    @id @default(uuid())
+  veterinarioId String    @map("veterinario_id")
+  petId         String    @map("pet_id")
+  googlePlaceId String?   @map("google_place_id")
   diagnostico   String
   prescricao    String?
   observacoes   String?
@@ -312,7 +314,6 @@ model NotaClinica {
   @@index([googlePlaceId])
   @@map("nota_clinica")
 }
-
 
 /// Trilha de auditoria das ações sobre registros clínicos (api#117).
 ///

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -208,6 +208,7 @@ type MedicationSeed = {
   frequency: string;
   startDate: Date;
   endDate?: Date;
+  veterinarianName?: string;
   notes?: string;
 };
 
@@ -219,6 +220,7 @@ const medications: MedicationSeed[] = [
     frequency: '12/12h',
     startDate: new Date('2025-12-01'),
     endDate: new Date('2025-12-10'),
+    veterinarianName: 'Dra. Camila Ferreira',
     notes: 'Tratamento de infecção de pele',
   },
   {
@@ -228,6 +230,7 @@ const medications: MedicationSeed[] = [
     frequency: '1x ao dia',
     startDate: new Date('2026-01-15'),
     endDate: new Date('2026-01-20'),
+    veterinarianName: 'Dr. Paulo Ribeiro',
     notes: 'Anti-inflamatório pós cirurgia',
   },
   {
@@ -317,6 +320,22 @@ async function main() {
       petByName.set(p.name, p.id);
     }
 
+    /**
+     * Liga o registro ao veterinário do PetCard quando o nome corresponde a
+     * uma conta existente.
+     *
+     * Sem isso, os registros do seed ficam com `veterinarioId` nulo e a regra
+     * de autoria (web#34) os trata como declarados pelo tutor: a Dra. Camila
+     * via o próprio nome no registro e mesmo assim não podia editá-lo.
+     *
+     * "Dr. Paulo Ribeiro" não tem conta de propósito — é o caso do
+     * profissional de fora, que continua valendo como texto livre.
+     */
+    const vetIdByNome = new Map<string, string>();
+    for (const vet of await tx.veterinario.findMany()) {
+      vetIdByNome.set(vet.nome, vet.id);
+    }
+
     // Idempotência: limpar e recriar registros de saúde (evita duplicar)
     await tx.vaccineRecord.deleteMany();
     await tx.dewormingRecord.deleteMany();
@@ -332,6 +351,9 @@ async function main() {
           appliedAt: v.appliedAt,
           nextDoseAt: v.nextDoseAt,
           veterinarianName: v.veterinarianName,
+          veterinarioId: v.veterinarianName
+            ? (vetIdByNome.get(v.veterinarianName) ?? null)
+            : null,
           notes: v.notes,
         },
       });
@@ -348,6 +370,9 @@ async function main() {
           appliedAt: d.appliedAt,
           nextDoseAt: d.nextDoseAt,
           veterinarianName: d.veterinarianName,
+          veterinarioId: d.veterinarianName
+            ? (vetIdByNome.get(d.veterinarianName) ?? null)
+            : null,
           notes: d.notes,
         },
       });
@@ -365,6 +390,10 @@ async function main() {
           frequency: m.frequency,
           startDate: m.startDate,
           endDate: m.endDate,
+          veterinarianName: m.veterinarianName,
+          veterinarioId: m.veterinarianName
+            ? (vetIdByNome.get(m.veterinarianName) ?? null)
+            : null,
           notes: m.notes,
         },
       });

--- a/src/modules/health/__tests__/autoria-clinica.spec.ts
+++ b/src/modules/health/__tests__/autoria-clinica.spec.ts
@@ -1,0 +1,75 @@
+import { ForbiddenException } from '@nestjs/common';
+import { assertPodeEditar, assertPodeRemover } from '../autoria-clinica';
+
+const doTutor = { veterinarioId: null };
+const daCamila = { veterinarioId: 'vet-camila' };
+
+describe('autoria de registro clínico (web#34)', () => {
+  describe('editar', () => {
+    it('o tutor edita o que ele mesmo declarou', () => {
+      expect(() => assertPodeEditar(doTutor, 'tutor-1', false)).not.toThrow();
+    });
+
+    it('o veterinário edita a própria prescrição', () => {
+      expect(() =>
+        assertPodeEditar(daCamila, 'vet-camila', true),
+      ).not.toThrow();
+    });
+
+    it('o tutor não edita a prescrição do veterinário', () => {
+      // Editar mantendo a assinatura alheia falsificaria a autoria: a carteira
+      // seguiria dizendo "prescrito por Dra. Camila" com outra dosagem.
+      expect(() => assertPodeEditar(daCamila, 'tutor-1', false)).toThrow(
+        ForbiddenException,
+      );
+    });
+
+    it('um veterinário não edita a prescrição de outro', () => {
+      expect(() => assertPodeEditar(daCamila, 'vet-outro', true)).toThrow(
+        ForbiddenException,
+      );
+    });
+
+    it('o veterinário não edita o que o tutor declarou', () => {
+      expect(() => assertPodeEditar(doTutor, 'vet-camila', true)).toThrow(
+        ForbiddenException,
+      );
+    });
+
+    it('trata coluna ausente como registro do tutor', () => {
+      // Defensivo: o Prisma sempre traz a coluna, mas `undefined` não pode
+      // virar "registro de veterinário" e travar o tutor no próprio registro.
+      expect(() => assertPodeEditar({}, 'tutor-1', false)).not.toThrow();
+    });
+  });
+
+  describe('remover', () => {
+    it('o tutor remove o que ele mesmo declarou', () => {
+      expect(() => assertPodeRemover(doTutor, 'tutor-1', false)).not.toThrow();
+    });
+
+    it('o tutor remove a prescrição que decidiu não seguir', () => {
+      // Caso central da api#117. A exclusão é lógica: sai da carteira dele e
+      // permanece no histórico, registrada em seu nome.
+      expect(() => assertPodeRemover(daCamila, 'tutor-1', false)).not.toThrow();
+    });
+
+    it('o veterinário remove a própria prescrição', () => {
+      expect(() =>
+        assertPodeRemover(daCamila, 'vet-camila', true),
+      ).not.toThrow();
+    });
+
+    it('um veterinário não remove a prescrição de outro', () => {
+      expect(() => assertPodeRemover(daCamila, 'vet-outro', true)).toThrow(
+        ForbiddenException,
+      );
+    });
+
+    it('o veterinário não remove o que o tutor declarou', () => {
+      expect(() => assertPodeRemover(doTutor, 'vet-camila', true)).toThrow(
+        ForbiddenException,
+      );
+    });
+  });
+});

--- a/src/modules/health/autoria-clinica.ts
+++ b/src/modules/health/autoria-clinica.ts
@@ -1,0 +1,68 @@
+import { ForbiddenException } from '@nestjs/common';
+
+/** O que vacina, vermífugo e medicação têm em comum para efeito de autoria. */
+export interface RegistroComAutoria {
+  veterinarioId?: string | null;
+}
+
+/**
+ * Quem pode **editar** um registro clínico (web#34).
+ *
+ * A regra é de autoria, não de papel. Editar é o caso delicado: o registro
+ * continua assinado por quem o criou, então alterar conteúdo alheio falsifica a
+ * assinatura — a carteira mostraria "prescrito por Dra. Fulana, CRMV-SP 12345"
+ * sobre uma dose que ela não prescreveu.
+ *
+ * O tutor que discorda da prescrição não a corrige: ele a remove da carteira,
+ * e a original permanece no histórico (ver `assertPodeRemover`).
+ */
+export function assertPodeEditar(
+  registro: RegistroComAutoria,
+  userId: string,
+  isVet: boolean,
+): void {
+  const autor = registro.veterinarioId ?? null;
+
+  if (autor === null) {
+    if (isVet) {
+      throw new ForbiddenException(
+        'Este registro foi feito pelo tutor; o veterinário não pode editá-lo.',
+      );
+    }
+    return;
+  }
+
+  if (!isVet || autor !== userId) {
+    throw new ForbiddenException(
+      'Só o veterinário que fez o registro pode editá-lo.',
+    );
+  }
+}
+
+/**
+ * Quem pode **remover** um registro clínico.
+ *
+ * Assimétrico de propósito. O tutor remove qualquer registro do próprio pet,
+ * inclusive a prescrição que decidiu não seguir: é o caso central da api#117, e
+ * a exclusão é lógica — sai da carteira dele e permanece no histórico, com a
+ * ação registrada em seu nome. Impedi-lo aqui não tornaria o dado mais
+ * confiável, só esconderia a recusa.
+ *
+ * O veterinário remove apenas o que ele mesmo prescreveu. O que o tutor
+ * declarou não é dele para apagar.
+ */
+export function assertPodeRemover(
+  registro: RegistroComAutoria,
+  userId: string,
+  isVet: boolean,
+): void {
+  if (!isVet) {
+    return;
+  }
+
+  if ((registro.veterinarioId ?? null) !== userId) {
+    throw new ForbiddenException(
+      'O veterinário só pode remover os registros que ele mesmo fez.',
+    );
+  }
+}

--- a/src/modules/health/autoria-clinica.ts
+++ b/src/modules/health/autoria-clinica.ts
@@ -1,4 +1,5 @@
 import { ForbiddenException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 
 /** O que vacina, vermífugo e medicação têm em comum para efeito de autoria. */
 export interface RegistroComAutoria {
@@ -65,4 +66,22 @@ export function assertPodeRemover(
       'O veterinário só pode remover os registros que ele mesmo fez.',
     );
   }
+}
+
+/**
+ * Nome do veterinário que está registrando, para gravar junto com o registro.
+ *
+ * Resolvido no servidor de propósito: o cliente sabe o nome do próprio usuário,
+ * mas aceitar esse nome no corpo da requisição deixaria qualquer um assinar um
+ * registro clínico com o nome de outra pessoa.
+ */
+export async function nomeDoVeterinario(
+  tx: Prisma.TransactionClient,
+  veterinarioId: string,
+): Promise<string | undefined> {
+  const vet = await tx.veterinario.findUnique({
+    where: { id: veterinarioId },
+    select: { nome: true },
+  });
+  return vet?.nome;
 }

--- a/src/modules/health/deworming/__tests__/deworming.controller.spec.ts
+++ b/src/modules/health/deworming/__tests__/deworming.controller.spec.ts
@@ -14,6 +14,7 @@ import { PrismaService } from '../../../../prisma/prisma.service';
 import { QrCodePublisher } from '../../../queue/qr-code.publisher';
 import { PetService } from '../../../pet/pet.service';
 import { TutorService } from '../../../tutor/tutor.service';
+import { CrmvVerificationService } from '../../../veterinario/crmv/crmv-verification.service';
 import { DewormingController } from '../deworming.controller';
 import { DewormingService } from '../deworming.service';
 
@@ -34,6 +35,8 @@ describe('DewormingController (integração)', () => {
   const record = {
     id: 'dew-1',
     petId: 'pet-1',
+    veterinarioId: null,
+    deletedAt: null,
     productName: 'Drontal',
     appliedAt: new Date('2026-02-01'),
     nextDoseAt: null,
@@ -68,6 +71,13 @@ describe('DewormingController (integração)', () => {
         {
           provide: QrCodePublisher,
           useValue: { publishGenerate: jest.fn() },
+        },
+        {
+          // O guard real roda; só a consulta de verificação é mockada.
+          provide: CrmvVerificationService,
+          useValue: {
+            getStatus: jest.fn().mockResolvedValue({ verified: true }),
+          },
         },
       ],
     });
@@ -157,11 +167,26 @@ describe('DewormingController (integração)', () => {
       .expect(204);
   });
 
-  it('DELETE é proibido para VET (403)', async () => {
+  it('DELETE é proibido ao VET sobre registro do tutor (403)', async () => {
+    // O que o tutor declarou não é do veterinário para apagar (web#34).
     harness.setUser(VET);
+    prisma.dewormingRecord.findFirst.mockResolvedValue(record);
 
     await request(harness.app.getHttpServer())
       .delete('/dewormings/dew-1')
       .expect(403);
+
+    expect(prisma.dewormingRecord.update).not.toHaveBeenCalled();
+  });
+
+  it('DELETE permite ao VET remover a própria prescrição (204)', async () => {
+    harness.setUser(VET);
+    const prescricao = { ...record, veterinarioId: 'vet-1' };
+    prisma.dewormingRecord.findFirst.mockResolvedValue(prescricao);
+    prisma.dewormingRecord.update.mockResolvedValue(prescricao);
+
+    await request(harness.app.getHttpServer())
+      .delete('/dewormings/dew-1')
+      .expect(204);
   });
 });

--- a/src/modules/health/deworming/__tests__/deworming.controller.spec.ts
+++ b/src/modules/health/deworming/__tests__/deworming.controller.spec.ts
@@ -22,6 +22,7 @@ describe('DewormingController (integração)', () => {
   let harness: ControllerHarness;
   let prisma: {
     pet: { findUnique: jest.Mock };
+    veterinario: { findUnique: jest.Mock };
     dewormingRecord: {
       create: jest.Mock;
       findMany: jest.Mock;
@@ -49,6 +50,10 @@ describe('DewormingController (integração)', () => {
   beforeAll(async () => {
     prisma = {
       pet: { findUnique: jest.fn() },
+      // O create assina o registro com o nome do vet logado (web#34).
+      veterinario: {
+        findUnique: jest.fn().mockResolvedValue({ nome: 'Dra. Camila' }),
+      },
       dewormingRecord: {
         create: jest.fn(),
         findMany: jest.fn(),

--- a/src/modules/health/deworming/__tests__/deworming.service.spec.ts
+++ b/src/modules/health/deworming/__tests__/deworming.service.spec.ts
@@ -27,6 +27,8 @@ describe('DewormingService', () => {
   const record = {
     id: 'dew-1',
     petId: 'pet-1',
+    veterinarioId: null,
+    deletedAt: null,
     productName: 'Drontal',
     appliedAt: new Date('2026-01-01'),
     nextDoseAt: null,
@@ -107,10 +109,17 @@ describe('DewormingService', () => {
 
   it('should delete owned record', async () => {
     prisma.dewormingRecord.findFirst.mockResolvedValue(record);
-    prisma.dewormingRecord.delete.mockResolvedValue(record);
+    prisma.dewormingRecord.update.mockResolvedValue(record);
 
-    await service.remove('dew-1', 'tutor-1');
+    await service.remove('dew-1', 'tutor-1', false);
 
-    expect(petService.assertOwnership).toHaveBeenCalledWith('pet-1', 'tutor-1');
+    // O acesso ao pet passou a ser checado por `assertAccess`, porque o
+    // veterinário também remove — o que ele pode remover é decidido depois,
+    // pela autoria do registro (web#34).
+    expect(petService.assertAccess).toHaveBeenCalledWith(
+      'pet-1',
+      'tutor-1',
+      false,
+    );
   });
 });

--- a/src/modules/health/deworming/deworming.controller.ts
+++ b/src/modules/health/deworming/deworming.controller.ts
@@ -21,8 +21,8 @@ import {
   DewormingRecordResponseDto,
   UpdateDewormingRecordDto,
 } from '@petcardorg/shared';
-import { Auth } from '../../auth/decorators/auth.decorator';
 import { CurrentUser } from '../../auth/decorators/current-user.decorator';
+import { AuthCrmvVerificado } from '../../veterinario/crmv/auth-crmv.decorator';
 import { Role } from '../../auth/enums/role.enum';
 import type { JwtPayload } from '../../auth/strategies/jwt.strategy';
 import { DewormingService } from './deworming.service';
@@ -33,7 +33,7 @@ export class DewormingController {
   constructor(private readonly dewormingService: DewormingService) {}
 
   @Post('pets/:petId/dewormings')
-  @Auth(Role.TUTOR, Role.VET)
+  @AuthCrmvVerificado(Role.TUTOR, Role.VET)
   @ApiOperation({ summary: 'Registrar vermífugo no prontuário do pet' })
   @ApiCreatedResponse({ type: DewormingRecordResponseDto })
   @ApiNotFoundResponse({ description: 'Pet não encontrado' })
@@ -47,7 +47,7 @@ export class DewormingController {
   }
 
   @Get('pets/:petId/dewormings')
-  @Auth(Role.TUTOR, Role.VET)
+  @AuthCrmvVerificado(Role.TUTOR, Role.VET)
   @ApiOperation({ summary: 'Listar vermífugos do pet' })
   @ApiOkResponse({ type: DewormingRecordResponseDto, isArray: true })
   @ApiNotFoundResponse({ description: 'Pet não encontrado' })
@@ -60,7 +60,7 @@ export class DewormingController {
   }
 
   @Patch('dewormings/:id')
-  @Auth(Role.TUTOR, Role.VET)
+  @AuthCrmvVerificado(Role.TUTOR, Role.VET)
   @ApiOperation({ summary: 'Atualizar registro de vermífugo' })
   @ApiOkResponse({ type: DewormingRecordResponseDto })
   @ApiNotFoundResponse({ description: 'Registro não encontrado' })
@@ -74,7 +74,7 @@ export class DewormingController {
   }
 
   @Delete('dewormings/:id')
-  @Auth(Role.TUTOR)
+  @AuthCrmvVerificado(Role.TUTOR, Role.VET)
   @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({ summary: 'Remover registro de vermífugo' })
   @ApiNotFoundResponse({ description: 'Registro não encontrado' })
@@ -82,6 +82,7 @@ export class DewormingController {
     @Param('id') id: string,
     @CurrentUser() user: JwtPayload,
   ): Promise<void> {
-    return this.dewormingService.remove(id, user.sub);
+    const isVet = user.role === Role.VET;
+    return this.dewormingService.remove(id, user.sub, isVet);
   }
 }

--- a/src/modules/health/deworming/deworming.module.ts
+++ b/src/modules/health/deworming/deworming.module.ts
@@ -2,11 +2,12 @@ import { Module } from '@nestjs/common';
 import { HistoricoModule } from '../../historico/historico.module';
 import { AuthModule } from '../../auth/auth.module';
 import { PetModule } from '../../pet/pet.module';
+import { VeterinarioModule } from '../../veterinario/veterinario.module';
 import { DewormingController } from './deworming.controller';
 import { DewormingService } from './deworming.service';
 
 @Module({
-  imports: [HistoricoModule, AuthModule, PetModule],
+  imports: [HistoricoModule, AuthModule, PetModule, VeterinarioModule],
   controllers: [DewormingController],
   providers: [DewormingService],
 })

--- a/src/modules/health/deworming/deworming.service.ts
+++ b/src/modules/health/deworming/deworming.service.ts
@@ -13,7 +13,11 @@ import {
 import { PrismaService } from '../../../prisma/prisma.service';
 import { PetService } from '../../pet/pet.service';
 import { AcaoClinicaService } from '../../historico/acao-clinica.service';
-import { assertPodeEditar, assertPodeRemover } from '../autoria-clinica';
+import {
+  assertPodeEditar,
+  assertPodeRemover,
+  nomeDoVeterinario,
+} from '../autoria-clinica';
 
 type DewormingInput = Omit<CreateDewormingRecordDto, 'pet_id'>;
 
@@ -27,6 +31,7 @@ function toResponseDto(record: DewormingRecord): DewormingRecordResponseDto {
       ? record.nextDoseAt.toISOString().split('T')[0]
       : undefined,
     veterinarian_name: record.veterinarianName ?? undefined,
+    veterinario_id: record.veterinarioId ?? undefined,
     notes: record.notes ?? undefined,
     created_at: record.createdAt,
     updated_at: record.updatedAt,
@@ -67,7 +72,11 @@ export class DewormingService {
           appliedAt: new Date(dto.applied_at),
           nextDoseAt: dto.next_dose_at ? new Date(dto.next_dose_at) : null,
           veterinarioId: isVet ? userId : null,
-          veterinarianName: dto.veterinarian_name,
+          // Assinado com o nome de quem registrou; o texto livre segue
+          // valendo para profissional de fora do PetCard.
+          veterinarianName: isVet
+            ? await nomeDoVeterinario(tx, userId)
+            : dto.veterinarian_name,
           notes: dto.notes,
         },
       });

--- a/src/modules/health/deworming/deworming.service.ts
+++ b/src/modules/health/deworming/deworming.service.ts
@@ -13,6 +13,7 @@ import {
 import { PrismaService } from '../../../prisma/prisma.service';
 import { PetService } from '../../pet/pet.service';
 import { AcaoClinicaService } from '../../historico/acao-clinica.service';
+import { assertPodeEditar, assertPodeRemover } from '../autoria-clinica';
 
 type DewormingInput = Omit<CreateDewormingRecordDto, 'pet_id'>;
 
@@ -107,6 +108,7 @@ export class DewormingService {
   ): Promise<DewormingRecordResponseDto> {
     const record = await this.getRecord(id);
     await this.petService.assertAccess(record.petId, userId, isVet);
+    assertPodeEditar(record, userId, isVet);
     const updated = await this.prisma.$transaction(async (tx) => {
       const alterado = await tx.dewormingRecord.update({
         where: { id },
@@ -138,9 +140,10 @@ export class DewormingService {
   /**
    * Exclusão lógica (api#117): sai da listagem, permanece no histórico.
    */
-  async remove(id: string, userId: string): Promise<void> {
+  async remove(id: string, userId: string, isVet: boolean): Promise<void> {
     const record = await this.getRecord(id);
-    await this.petService.assertOwnership(record.petId, userId);
+    await this.petService.assertAccess(record.petId, userId, isVet);
+    assertPodeRemover(record, userId, isVet);
     await this.prisma.$transaction(async (tx) => {
       await tx.dewormingRecord.update({
         where: { id },
@@ -153,7 +156,7 @@ export class DewormingService {
           entidade: EntidadeClinica.VERMIFUGO,
           entidadeId: id,
           autorId: userId,
-          autorTipo: Role.TUTOR,
+          autorTipo: isVet ? Role.VET : Role.TUTOR,
           detalhes: { antes: toSnapshot(record) },
         },
         tx,

--- a/src/modules/health/deworming/deworming.service.ts
+++ b/src/modules/health/deworming/deworming.service.ts
@@ -21,7 +21,12 @@ import {
 
 type DewormingInput = Omit<CreateDewormingRecordDto, 'pet_id'>;
 
-function toResponseDto(record: DewormingRecord): DewormingRecordResponseDto {
+/** O CRMV vem do vínculo; o nome fica gravado na linha. */
+type ComVeterinario = DewormingRecord & {
+  veterinario?: { crmv: string } | null;
+};
+
+function toResponseDto(record: ComVeterinario): DewormingRecordResponseDto {
   return {
     id: record.id,
     pet_id: record.petId,
@@ -32,6 +37,7 @@ function toResponseDto(record: DewormingRecord): DewormingRecordResponseDto {
       : undefined,
     veterinarian_name: record.veterinarianName ?? undefined,
     veterinario_id: record.veterinarioId ?? undefined,
+    veterinario_crmv: record.veterinario?.crmv ?? undefined,
     notes: record.notes ?? undefined,
     created_at: record.createdAt,
     updated_at: record.updatedAt,
@@ -66,6 +72,7 @@ export class DewormingService {
     await this.petService.assertAccess(petId, userId, isVet);
     const record = await this.prisma.$transaction(async (tx) => {
       const criado = await tx.dewormingRecord.create({
+        include: { veterinario: { select: { crmv: true } } },
         data: {
           petId,
           productName: dto.product_name,
@@ -105,6 +112,7 @@ export class DewormingService {
     const records = await this.prisma.dewormingRecord.findMany({
       where: { petId, deletedAt: null },
       orderBy: { appliedAt: 'desc' },
+      include: { veterinario: { select: { crmv: true } } },
     });
     return records.map(toResponseDto);
   }
@@ -120,6 +128,7 @@ export class DewormingService {
     assertPodeEditar(record, userId, isVet);
     const updated = await this.prisma.$transaction(async (tx) => {
       const alterado = await tx.dewormingRecord.update({
+        include: { veterinario: { select: { crmv: true } } },
         where: { id },
         data: {
           productName: dto.product_name,

--- a/src/modules/health/medication/__tests__/medication.controller.spec.ts
+++ b/src/modules/health/medication/__tests__/medication.controller.spec.ts
@@ -166,11 +166,26 @@ describe('MedicationController (integração)', () => {
       .expect(204);
   });
 
-  it('DELETE é proibido para VET (403)', async () => {
+  it('DELETE é proibido ao VET sobre registro do tutor (403)', async () => {
+    // O que o tutor declarou não é do veterinário para apagar (web#34).
     harness.setUser(VET);
+    prisma.medicationRecord.findFirst.mockResolvedValue(record);
 
     await request(harness.app.getHttpServer())
       .delete('/medications/med-1')
       .expect(403);
+
+    expect(prisma.medicationRecord.update).not.toHaveBeenCalled();
+  });
+
+  it('DELETE permite ao VET remover a própria prescrição (204)', async () => {
+    harness.setUser(VET);
+    const prescricao = { ...record, veterinarioId: 'vet-1' };
+    prisma.medicationRecord.findFirst.mockResolvedValue(prescricao);
+    prisma.medicationRecord.update.mockResolvedValue(prescricao);
+
+    await request(harness.app.getHttpServer())
+      .delete('/medications/med-1')
+      .expect(204);
   });
 });

--- a/src/modules/health/medication/__tests__/medication.controller.spec.ts
+++ b/src/modules/health/medication/__tests__/medication.controller.spec.ts
@@ -22,6 +22,7 @@ describe('MedicationController (integração)', () => {
   let harness: ControllerHarness;
   let prisma: {
     pet: { findUnique: jest.Mock };
+    veterinario: { findUnique: jest.Mock };
     medicationRecord: {
       create: jest.Mock;
       findMany: jest.Mock;
@@ -48,6 +49,10 @@ describe('MedicationController (integração)', () => {
   beforeAll(async () => {
     prisma = {
       pet: { findUnique: jest.fn() },
+      // O create assina a prescrição com o nome do vet logado (web#34).
+      veterinario: {
+        findUnique: jest.fn().mockResolvedValue({ nome: 'Dra. Camila' }),
+      },
       medicationRecord: {
         create: jest.fn(),
         findMany: jest.fn(),

--- a/src/modules/health/medication/__tests__/medication.service.spec.ts
+++ b/src/modules/health/medication/__tests__/medication.service.spec.ts
@@ -1,4 +1,4 @@
-import { NotFoundException } from '@nestjs/common';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import {
   acaoClinicaProvider,
@@ -27,6 +27,8 @@ describe('MedicationService', () => {
   const record = {
     id: 'med-1',
     petId: 'pet-1',
+    veterinarioId: null,
+    deletedAt: null,
     medicationName: 'Amoxicillin',
     dosage: '500mg',
     frequency: '8h',
@@ -122,7 +124,7 @@ describe('MedicationService', () => {
     prisma.medicationRecord.findFirst.mockResolvedValue(record);
     prisma.medicationRecord.update.mockResolvedValue(record);
 
-    await service.remove('med-1', 'tutor-1');
+    await service.remove('med-1', 'tutor-1', false);
 
     // O caso central da issue: o tutor decide não dar o remédio e apaga,
     // mas a prescrição do veterinário continua demonstrável.
@@ -132,5 +134,41 @@ describe('MedicationService', () => {
     >;
     expect(chamada.where).toEqual({ id: 'med-1' });
     expect(chamada.data.deletedAt).toBeInstanceOf(Date);
+  });
+
+  it('o veterinário remove a própria prescrição', async () => {
+    const prescricao = { ...record, veterinarioId: 'vet-camila' };
+    prisma.medicationRecord.findFirst.mockResolvedValue(prescricao);
+    prisma.medicationRecord.update.mockResolvedValue(prescricao);
+
+    // Antes da web#34 o delete era exclusivo do tutor: o veterinário
+    // prescrevia pela tela e não tinha como desfazer o próprio erro.
+    await service.remove('med-1', 'vet-camila', true);
+
+    expect(prisma.medicationRecord.update).toHaveBeenCalled();
+  });
+
+  it('o veterinário não remove a prescrição de outro', async () => {
+    prisma.medicationRecord.findFirst.mockResolvedValue({
+      ...record,
+      veterinarioId: 'vet-camila',
+    });
+
+    await expect(service.remove('med-1', 'vet-outro', true)).rejects.toThrow(
+      ForbiddenException,
+    );
+    expect(prisma.medicationRecord.update).not.toHaveBeenCalled();
+  });
+
+  it('o tutor não edita a prescrição do veterinário', async () => {
+    prisma.medicationRecord.findFirst.mockResolvedValue({
+      ...record,
+      veterinarioId: 'vet-camila',
+    });
+
+    await expect(
+      service.update('med-1', 'tutor-1', false, { dosage: '10mg' }),
+    ).rejects.toThrow(ForbiddenException);
+    expect(prisma.medicationRecord.update).not.toHaveBeenCalled();
   });
 });

--- a/src/modules/health/medication/__tests__/medication.service.spec.ts
+++ b/src/modules/health/medication/__tests__/medication.service.spec.ts
@@ -100,6 +100,8 @@ describe('MedicationService', () => {
       // Registro excluído não aparece na listagem (api#117).
       where: { petId: 'pet-1', deletedAt: null },
       orderBy: { startDate: 'desc' },
+      // O CRMV de quem prescreveu vem pelo vínculo, não pela linha.
+      include: { veterinario: { select: { crmv: true } } },
     });
     expect(result).toEqual([
       {

--- a/src/modules/health/medication/__tests__/medication.service.spec.ts
+++ b/src/modules/health/medication/__tests__/medication.service.spec.ts
@@ -18,6 +18,7 @@ describe('MedicationService', () => {
       update: jest.Mock;
       delete: jest.Mock;
     };
+    veterinario: { findUnique: jest.Mock };
   };
   let petService: {
     assertAccess: jest.Mock;
@@ -47,6 +48,10 @@ describe('MedicationService', () => {
         findFirst: jest.fn(),
         update: jest.fn(),
         delete: jest.fn(),
+      },
+      // O create resolve o nome de quem prescreve (web#34).
+      veterinario: {
+        findUnique: jest.fn().mockResolvedValue({ nome: 'Dra. Camila' }),
       },
     };
     petService = {
@@ -170,5 +175,20 @@ describe('MedicationService', () => {
       service.update('med-1', 'tutor-1', false, { dosage: '10mg' }),
     ).rejects.toThrow(ForbiddenException);
     expect(prisma.medicationRecord.update).not.toHaveBeenCalled();
+  });
+  it('assina a prescrição com o nome do veterinário logado', async () => {
+    prisma.medicationRecord.create.mockResolvedValue(record);
+
+    await service.create('pet-1', 'vet-1', true, {
+      medication_name: 'Amoxicilina',
+      dosage: '250mg',
+      frequency: '12/12h',
+      start_date: '2026-03-10',
+    });
+
+    const [[chamada]] = prisma.medicationRecord.create.mock.calls as Array<
+      [{ data: { veterinarianName?: string } }]
+    >;
+    expect(chamada.data.veterinarianName).toBe('Dra. Camila');
   });
 });

--- a/src/modules/health/medication/medication.controller.ts
+++ b/src/modules/health/medication/medication.controller.ts
@@ -21,7 +21,6 @@ import {
   MedicationRecordResponseDto,
   UpdateMedicationRecordDto,
 } from '@petcardorg/shared';
-import { Auth } from '../../auth/decorators/auth.decorator';
 import { CurrentUser } from '../../auth/decorators/current-user.decorator';
 import { Role } from '../../auth/enums/role.enum';
 import type { JwtPayload } from '../../auth/strategies/jwt.strategy';
@@ -34,7 +33,7 @@ export class MedicationController {
   constructor(private readonly medicationService: MedicationService) {}
 
   @Post('pets/:petId/medications')
-  @Auth(Role.TUTOR, Role.VET)
+  @AuthCrmvVerificado(Role.TUTOR, Role.VET)
   @ApiOperation({ summary: 'Registrar medicação no prontuário do pet' })
   @ApiCreatedResponse({ type: MedicationRecordResponseDto })
   @ApiNotFoundResponse({ description: 'Pet não encontrado' })
@@ -61,7 +60,7 @@ export class MedicationController {
   }
 
   @Patch('medications/:id')
-  @Auth(Role.TUTOR, Role.VET)
+  @AuthCrmvVerificado(Role.TUTOR, Role.VET)
   @ApiOperation({ summary: 'Atualizar registro de medicação' })
   @ApiOkResponse({ type: MedicationRecordResponseDto })
   @ApiNotFoundResponse({ description: 'Registro não encontrado' })
@@ -75,7 +74,7 @@ export class MedicationController {
   }
 
   @Delete('medications/:id')
-  @Auth(Role.TUTOR)
+  @AuthCrmvVerificado(Role.TUTOR, Role.VET)
   @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({ summary: 'Remover registro de medicação' })
   @ApiNotFoundResponse({ description: 'Registro não encontrado' })
@@ -83,6 +82,7 @@ export class MedicationController {
     @Param('id') id: string,
     @CurrentUser() user: JwtPayload,
   ): Promise<void> {
-    return this.medicationService.remove(id, user.sub);
+    const isVet = user.role === Role.VET;
+    return this.medicationService.remove(id, user.sub, isVet);
   }
 }

--- a/src/modules/health/medication/medication.service.ts
+++ b/src/modules/health/medication/medication.service.ts
@@ -24,6 +24,7 @@ function toResponseDto(record: MedicationRecord): MedicationRecordResponseDto {
     medication_name: record.medicationName,
     dosage: record.dosage,
     frequency: record.frequency,
+    veterinario_id: record.veterinarioId ?? undefined,
     start_date: record.startDate.toISOString().split('T')[0],
     end_date: record.endDate
       ? record.endDate.toISOString().split('T')[0]

--- a/src/modules/health/medication/medication.service.ts
+++ b/src/modules/health/medication/medication.service.ts
@@ -13,7 +13,11 @@ import {
 import { PrismaService } from '../../../prisma/prisma.service';
 import { PetService } from '../../pet/pet.service';
 import { AcaoClinicaService } from '../../historico/acao-clinica.service';
-import { assertPodeEditar, assertPodeRemover } from '../autoria-clinica';
+import {
+  assertPodeEditar,
+  assertPodeRemover,
+  nomeDoVeterinario,
+} from '../autoria-clinica';
 
 type MedicationInput = Omit<CreateMedicationRecordDto, 'pet_id'>;
 
@@ -25,6 +29,7 @@ function toResponseDto(record: MedicationRecord): MedicationRecordResponseDto {
     dosage: record.dosage,
     frequency: record.frequency,
     veterinario_id: record.veterinarioId ?? undefined,
+    veterinarian_name: record.veterinarianName ?? undefined,
     start_date: record.startDate.toISOString().split('T')[0],
     end_date: record.endDate
       ? record.endDate.toISOString().split('T')[0]
@@ -41,6 +46,7 @@ function toSnapshot(record: MedicationRecord) {
     medication_name: record.medicationName,
     dosage: record.dosage,
     frequency: record.frequency,
+    veterinarian_name: record.veterinarianName,
     start_date: record.startDate.toISOString(),
     end_date: record.endDate?.toISOString() ?? null,
     notes: record.notes,
@@ -73,6 +79,11 @@ export class MedicationService {
           endDate: dto.end_date ? new Date(dto.end_date) : null,
           // Quem prescreveu, quando é um vet do PetCard.
           veterinarioId: isVet ? userId : null,
+          // Assinado com o nome de quem prescreveu; o texto livre segue
+          // valendo para profissional de fora do PetCard.
+          veterinarianName: isVet
+            ? await nomeDoVeterinario(tx, userId)
+            : dto.veterinarian_name,
           notes: dto.notes,
         },
       });
@@ -121,6 +132,7 @@ export class MedicationService {
           medicationName: dto.medication_name,
           dosage: dto.dosage,
           frequency: dto.frequency,
+          veterinarianName: dto.veterinarian_name,
           startDate: dto.start_date ? new Date(dto.start_date) : undefined,
           endDate: dto.end_date ? new Date(dto.end_date) : undefined,
           notes: dto.notes,

--- a/src/modules/health/medication/medication.service.ts
+++ b/src/modules/health/medication/medication.service.ts
@@ -13,6 +13,7 @@ import {
 import { PrismaService } from '../../../prisma/prisma.service';
 import { PetService } from '../../pet/pet.service';
 import { AcaoClinicaService } from '../../historico/acao-clinica.service';
+import { assertPodeEditar, assertPodeRemover } from '../autoria-clinica';
 
 type MedicationInput = Omit<CreateMedicationRecordDto, 'pet_id'>;
 
@@ -111,6 +112,7 @@ export class MedicationService {
   ): Promise<MedicationRecordResponseDto> {
     const record = await this.getRecord(id);
     await this.petService.assertAccess(record.petId, userId, isVet);
+    assertPodeEditar(record, userId, isVet);
     const updated = await this.prisma.$transaction(async (tx) => {
       const alterado = await tx.medicationRecord.update({
         where: { id },
@@ -145,9 +147,10 @@ export class MedicationService {
    * dar o remédio e apaga o registro — a prescrição do veterinário continua
    * no histórico.
    */
-  async remove(id: string, userId: string): Promise<void> {
+  async remove(id: string, userId: string, isVet: boolean): Promise<void> {
     const record = await this.getRecord(id);
-    await this.petService.assertOwnership(record.petId, userId);
+    await this.petService.assertAccess(record.petId, userId, isVet);
+    assertPodeRemover(record, userId, isVet);
     await this.prisma.$transaction(async (tx) => {
       await tx.medicationRecord.update({
         where: { id },
@@ -160,7 +163,7 @@ export class MedicationService {
           entidade: EntidadeClinica.MEDICACAO,
           entidadeId: id,
           autorId: userId,
-          autorTipo: Role.TUTOR,
+          autorTipo: isVet ? Role.VET : Role.TUTOR,
           detalhes: { antes: toSnapshot(record) },
         },
         tx,

--- a/src/modules/health/medication/medication.service.ts
+++ b/src/modules/health/medication/medication.service.ts
@@ -21,7 +21,12 @@ import {
 
 type MedicationInput = Omit<CreateMedicationRecordDto, 'pet_id'>;
 
-function toResponseDto(record: MedicationRecord): MedicationRecordResponseDto {
+/** O CRMV vem do vínculo; o nome fica gravado na linha. */
+type ComVeterinario = MedicationRecord & {
+  veterinario?: { crmv: string } | null;
+};
+
+function toResponseDto(record: ComVeterinario): MedicationRecordResponseDto {
   return {
     id: record.id,
     pet_id: record.petId,
@@ -29,6 +34,7 @@ function toResponseDto(record: MedicationRecord): MedicationRecordResponseDto {
     dosage: record.dosage,
     frequency: record.frequency,
     veterinario_id: record.veterinarioId ?? undefined,
+    veterinario_crmv: record.veterinario?.crmv ?? undefined,
     veterinarian_name: record.veterinarianName ?? undefined,
     start_date: record.startDate.toISOString().split('T')[0],
     end_date: record.endDate
@@ -70,6 +76,7 @@ export class MedicationService {
     await this.petService.assertAccess(petId, userId, isVet);
     const record = await this.prisma.$transaction(async (tx) => {
       const criado = await tx.medicationRecord.create({
+        include: { veterinario: { select: { crmv: true } } },
         data: {
           petId,
           medicationName: dto.medication_name,
@@ -112,6 +119,7 @@ export class MedicationService {
     const records = await this.prisma.medicationRecord.findMany({
       where: { petId, deletedAt: null },
       orderBy: { startDate: 'desc' },
+      include: { veterinario: { select: { crmv: true } } },
     });
     return records.map(toResponseDto);
   }
@@ -127,6 +135,7 @@ export class MedicationService {
     assertPodeEditar(record, userId, isVet);
     const updated = await this.prisma.$transaction(async (tx) => {
       const alterado = await tx.medicationRecord.update({
+        include: { veterinario: { select: { crmv: true } } },
         where: { id },
         data: {
           medicationName: dto.medication_name,

--- a/src/modules/health/vaccine/__tests__/vaccine.controller.spec.ts
+++ b/src/modules/health/vaccine/__tests__/vaccine.controller.spec.ts
@@ -14,6 +14,7 @@ import { PrismaService } from '../../../../prisma/prisma.service';
 import { QrCodePublisher } from '../../../queue/qr-code.publisher';
 import { PetService } from '../../../pet/pet.service';
 import { TutorService } from '../../../tutor/tutor.service';
+import { CrmvVerificationService } from '../../../veterinario/crmv/crmv-verification.service';
 import { VaccineController } from '../vaccine.controller';
 import { VaccineService } from '../vaccine.service';
 
@@ -34,6 +35,8 @@ describe('VaccineController (integração)', () => {
   const record = {
     id: 'vac-1',
     petId: 'pet-1',
+    veterinarioId: null,
+    deletedAt: null,
     vaccineName: 'Raiva',
     appliedAt: new Date('2026-01-10'),
     nextDoseAt: null,
@@ -68,6 +71,13 @@ describe('VaccineController (integração)', () => {
         {
           provide: QrCodePublisher,
           useValue: { publishGenerate: jest.fn() },
+        },
+        {
+          // O guard real roda; só a consulta de verificação é mockada.
+          provide: CrmvVerificationService,
+          useValue: {
+            getStatus: jest.fn().mockResolvedValue({ verified: true }),
+          },
         },
       ],
     });
@@ -157,11 +167,26 @@ describe('VaccineController (integração)', () => {
       .expect(204);
   });
 
-  it('DELETE é proibido para VET (403)', async () => {
+  it('DELETE é proibido ao VET sobre registro do tutor (403)', async () => {
+    // O que o tutor declarou não é do veterinário para apagar (web#34).
     harness.setUser(VET);
+    prisma.vaccineRecord.findFirst.mockResolvedValue(record);
 
     await request(harness.app.getHttpServer())
       .delete('/vaccines/vac-1')
       .expect(403);
+
+    expect(prisma.vaccineRecord.update).not.toHaveBeenCalled();
+  });
+
+  it('DELETE permite ao VET remover a própria prescrição (204)', async () => {
+    harness.setUser(VET);
+    const prescricao = { ...record, veterinarioId: 'vet-1' };
+    prisma.vaccineRecord.findFirst.mockResolvedValue(prescricao);
+    prisma.vaccineRecord.update.mockResolvedValue(prescricao);
+
+    await request(harness.app.getHttpServer())
+      .delete('/vaccines/vac-1')
+      .expect(204);
   });
 });

--- a/src/modules/health/vaccine/__tests__/vaccine.controller.spec.ts
+++ b/src/modules/health/vaccine/__tests__/vaccine.controller.spec.ts
@@ -22,6 +22,7 @@ describe('VaccineController (integração)', () => {
   let harness: ControllerHarness;
   let prisma: {
     pet: { findUnique: jest.Mock };
+    veterinario: { findUnique: jest.Mock };
     vaccineRecord: {
       create: jest.Mock;
       findMany: jest.Mock;
@@ -49,6 +50,10 @@ describe('VaccineController (integração)', () => {
   beforeAll(async () => {
     prisma = {
       pet: { findUnique: jest.fn() },
+      // O create assina o registro com o nome do vet logado (web#34).
+      veterinario: {
+        findUnique: jest.fn().mockResolvedValue({ nome: 'Dra. Camila' }),
+      },
       vaccineRecord: {
         create: jest.fn(),
         findMany: jest.fn(),

--- a/src/modules/health/vaccine/__tests__/vaccine.service.spec.ts
+++ b/src/modules/health/vaccine/__tests__/vaccine.service.spec.ts
@@ -29,6 +29,8 @@ describe('VaccineService', () => {
   const record = {
     id: 'vac-1',
     petId: 'pet-1',
+    veterinarioId: null,
+    deletedAt: null,
     vaccineName: 'Rabies',
     appliedAt: new Date('2026-01-01'),
     nextDoseAt: null,
@@ -143,11 +145,14 @@ describe('VaccineService', () => {
       prisma.vaccineRecord.findFirst.mockResolvedValue(record);
       prisma.vaccineRecord.update.mockResolvedValue(record);
 
-      await service.remove('vac-1', 'tutor-1');
+      await service.remove('vac-1', 'tutor-1', false);
 
-      expect(petService.assertOwnership).toHaveBeenCalledWith(
+      // Ver a nota equivalente no spec do vermífugo: `assertAccess` porque o
+      // veterinário também remove; a autoria decide o que ele pode remover.
+      expect(petService.assertAccess).toHaveBeenCalledWith(
         'pet-1',
         'tutor-1',
+        false,
       );
       // O registro precisa sobreviver: é o que o histórico clínico mostra.
       expect(prisma.vaccineRecord.delete).not.toHaveBeenCalled();
@@ -162,7 +167,7 @@ describe('VaccineService', () => {
       prisma.vaccineRecord.findFirst.mockResolvedValue(record);
       prisma.vaccineRecord.update.mockResolvedValue(record);
 
-      await service.remove('vac-1', 'tutor-1');
+      await service.remove('vac-1', 'tutor-1', false);
 
       expect(registrarAcao).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/src/modules/health/vaccine/__tests__/vaccine.service.spec.ts
+++ b/src/modules/health/vaccine/__tests__/vaccine.service.spec.ts
@@ -181,4 +181,56 @@ describe('VaccineService', () => {
       );
     });
   });
+  describe('assinatura do veterinário (web#34)', () => {
+    it('grava o nome do veterinário logado no registro', async () => {
+      prisma.veterinario = { findUnique: jest.fn() } as never;
+      (
+        prisma as unknown as { veterinario: { findUnique: jest.Mock } }
+      ).veterinario.findUnique.mockResolvedValue({ nome: 'Dra. Camila' });
+      prisma.vaccineRecord.create.mockResolvedValue(record);
+
+      await service.create('pet-1', 'vet-1', true, {
+        vaccine_name: 'Raiva',
+        applied_at: '2026-03-10',
+      });
+
+      // Resolvido no servidor: aceitar o nome vindo do corpo deixaria assinar
+      // um registro clínico com o nome de outra pessoa.
+      const [[chamada]] = prisma.vaccineRecord.create.mock.calls as Array<
+        [{ data: { veterinarianName?: string; veterinarioId?: string } }]
+      >;
+      expect(chamada.data.veterinarianName).toBe('Dra. Camila');
+      expect(chamada.data.veterinarioId).toBe('vet-1');
+    });
+
+    it('respeita o nome digitado quando quem registra é o tutor', async () => {
+      prisma.veterinario = { findUnique: jest.fn() } as never;
+      prisma.vaccineRecord.create.mockResolvedValue(record);
+
+      await service.create('pet-1', 'tutor-1', false, {
+        vaccine_name: 'Raiva',
+        applied_at: '2026-03-10',
+        veterinarian_name: 'Dr. Fulano (clínica de fora)',
+      });
+
+      const [[chamada]] = prisma.vaccineRecord.create.mock.calls as Array<
+        [{ data: { veterinarianName?: string; veterinarioId?: string | null } }]
+      >;
+      expect(chamada.data.veterinarianName).toBe(
+        'Dr. Fulano (clínica de fora)',
+      );
+      expect(chamada.data.veterinarioId).toBeNull();
+    });
+
+    it('expõe o veterinario_id na resposta', async () => {
+      prisma.vaccineRecord.findMany.mockResolvedValue([
+        { ...record, veterinarioId: 'vet-1' },
+      ]);
+
+      const [dto] = await service.findAllForPet('pet-1', 'vet-1', true);
+
+      // A tela usa isto para oferecer editar/apagar só no que é do vet.
+      expect(dto.veterinario_id).toBe('vet-1');
+    });
+  });
 });

--- a/src/modules/health/vaccine/vaccine.controller.ts
+++ b/src/modules/health/vaccine/vaccine.controller.ts
@@ -21,8 +21,8 @@ import {
   UpdateVaccineRecordDto,
   VaccineRecordResponseDto,
 } from '@petcardorg/shared';
-import { Auth } from '../../auth/decorators/auth.decorator';
 import { CurrentUser } from '../../auth/decorators/current-user.decorator';
+import { AuthCrmvVerificado } from '../../veterinario/crmv/auth-crmv.decorator';
 import { Role } from '../../auth/enums/role.enum';
 import type { JwtPayload } from '../../auth/strategies/jwt.strategy';
 import { VaccineService } from './vaccine.service';
@@ -33,7 +33,7 @@ export class VaccineController {
   constructor(private readonly vaccineService: VaccineService) {}
 
   @Post('pets/:petId/vaccines')
-  @Auth(Role.TUTOR, Role.VET)
+  @AuthCrmvVerificado(Role.TUTOR, Role.VET)
   @ApiOperation({ summary: 'Registrar vacina no prontuário do pet' })
   @ApiCreatedResponse({ type: VaccineRecordResponseDto })
   @ApiNotFoundResponse({ description: 'Pet não encontrado' })
@@ -47,7 +47,7 @@ export class VaccineController {
   }
 
   @Get('pets/:petId/vaccines')
-  @Auth(Role.TUTOR, Role.VET)
+  @AuthCrmvVerificado(Role.TUTOR, Role.VET)
   @ApiOperation({ summary: 'Listar vacinas do pet' })
   @ApiOkResponse({ type: VaccineRecordResponseDto, isArray: true })
   @ApiNotFoundResponse({ description: 'Pet não encontrado' })
@@ -60,7 +60,7 @@ export class VaccineController {
   }
 
   @Patch('vaccines/:id')
-  @Auth(Role.TUTOR, Role.VET)
+  @AuthCrmvVerificado(Role.TUTOR, Role.VET)
   @ApiOperation({ summary: 'Atualizar registro de vacina' })
   @ApiOkResponse({ type: VaccineRecordResponseDto })
   @ApiNotFoundResponse({ description: 'Registro não encontrado' })
@@ -74,7 +74,7 @@ export class VaccineController {
   }
 
   @Delete('vaccines/:id')
-  @Auth(Role.TUTOR)
+  @AuthCrmvVerificado(Role.TUTOR, Role.VET)
   @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({ summary: 'Remover registro de vacina' })
   @ApiNotFoundResponse({ description: 'Registro não encontrado' })
@@ -82,6 +82,7 @@ export class VaccineController {
     @Param('id') id: string,
     @CurrentUser() user: JwtPayload,
   ): Promise<void> {
-    return this.vaccineService.remove(id, user.sub);
+    const isVet = user.role === Role.VET;
+    return this.vaccineService.remove(id, user.sub, isVet);
   }
 }

--- a/src/modules/health/vaccine/vaccine.module.ts
+++ b/src/modules/health/vaccine/vaccine.module.ts
@@ -2,11 +2,12 @@ import { Module } from '@nestjs/common';
 import { HistoricoModule } from '../../historico/historico.module';
 import { AuthModule } from '../../auth/auth.module';
 import { PetModule } from '../../pet/pet.module';
+import { VeterinarioModule } from '../../veterinario/veterinario.module';
 import { VaccineController } from './vaccine.controller';
 import { VaccineService } from './vaccine.service';
 
 @Module({
-  imports: [HistoricoModule, AuthModule, PetModule],
+  imports: [HistoricoModule, AuthModule, PetModule, VeterinarioModule],
   controllers: [VaccineController],
   providers: [VaccineService],
 })

--- a/src/modules/health/vaccine/vaccine.service.ts
+++ b/src/modules/health/vaccine/vaccine.service.ts
@@ -13,7 +13,11 @@ import {
 import { PrismaService } from '../../../prisma/prisma.service';
 import { PetService } from '../../pet/pet.service';
 import { AcaoClinicaService } from '../../historico/acao-clinica.service';
-import { assertPodeEditar, assertPodeRemover } from '../autoria-clinica';
+import {
+  assertPodeEditar,
+  assertPodeRemover,
+  nomeDoVeterinario,
+} from '../autoria-clinica';
 
 type VaccineInput = Omit<CreateVaccineRecordDto, 'pet_id'>;
 
@@ -27,6 +31,7 @@ function toResponseDto(record: VaccineRecord): VaccineRecordResponseDto {
       ? record.nextDoseAt.toISOString().split('T')[0]
       : undefined,
     veterinarian_name: record.veterinarianName ?? undefined,
+    veterinario_id: record.veterinarioId ?? undefined,
     notes: record.notes ?? undefined,
     created_at: record.createdAt,
     updated_at: record.updatedAt,
@@ -68,7 +73,11 @@ export class VaccineService {
           nextDoseAt: dto.next_dose_at ? new Date(dto.next_dose_at) : null,
           // Atribuição confiável quando quem registra é um vet do PetCard.
           veterinarioId: isVet ? userId : null,
-          veterinarianName: dto.veterinarian_name,
+          // Assinado com o nome de quem registrou; o texto livre segue
+          // valendo para profissional de fora do PetCard.
+          veterinarianName: isVet
+            ? await nomeDoVeterinario(tx, userId)
+            : dto.veterinarian_name,
           notes: dto.notes,
         },
       });

--- a/src/modules/health/vaccine/vaccine.service.ts
+++ b/src/modules/health/vaccine/vaccine.service.ts
@@ -21,7 +21,12 @@ import {
 
 type VaccineInput = Omit<CreateVaccineRecordDto, 'pet_id'>;
 
-function toResponseDto(record: VaccineRecord): VaccineRecordResponseDto {
+/** O CRMV vem do vínculo; o nome fica gravado na linha. */
+type ComVeterinario = VaccineRecord & {
+  veterinario?: { crmv: string } | null;
+};
+
+function toResponseDto(record: ComVeterinario): VaccineRecordResponseDto {
   return {
     id: record.id,
     pet_id: record.petId,
@@ -32,6 +37,7 @@ function toResponseDto(record: VaccineRecord): VaccineRecordResponseDto {
       : undefined,
     veterinarian_name: record.veterinarianName ?? undefined,
     veterinario_id: record.veterinarioId ?? undefined,
+    veterinario_crmv: record.veterinario?.crmv ?? undefined,
     notes: record.notes ?? undefined,
     created_at: record.createdAt,
     updated_at: record.updatedAt,
@@ -66,6 +72,7 @@ export class VaccineService {
     await this.petService.assertAccess(petId, userId, isVet);
     const record = await this.prisma.$transaction(async (tx) => {
       const criado = await tx.vaccineRecord.create({
+        include: { veterinario: { select: { crmv: true } } },
         data: {
           petId,
           vaccineName: dto.vaccine_name,
@@ -106,6 +113,7 @@ export class VaccineService {
     const records = await this.prisma.vaccineRecord.findMany({
       where: { petId, deletedAt: null },
       orderBy: { appliedAt: 'desc' },
+      include: { veterinario: { select: { crmv: true } } },
     });
     return records.map(toResponseDto);
   }
@@ -121,6 +129,7 @@ export class VaccineService {
     assertPodeEditar(record, userId, isVet);
     const updated = await this.prisma.$transaction(async (tx) => {
       const alterado = await tx.vaccineRecord.update({
+        include: { veterinario: { select: { crmv: true } } },
         where: { id },
         data: {
           vaccineName: dto.vaccine_name,

--- a/src/modules/health/vaccine/vaccine.service.ts
+++ b/src/modules/health/vaccine/vaccine.service.ts
@@ -13,6 +13,7 @@ import {
 import { PrismaService } from '../../../prisma/prisma.service';
 import { PetService } from '../../pet/pet.service';
 import { AcaoClinicaService } from '../../historico/acao-clinica.service';
+import { assertPodeEditar, assertPodeRemover } from '../autoria-clinica';
 
 type VaccineInput = Omit<CreateVaccineRecordDto, 'pet_id'>;
 
@@ -108,6 +109,7 @@ export class VaccineService {
   ): Promise<VaccineRecordResponseDto> {
     const record = await this.getRecord(id);
     await this.petService.assertAccess(record.petId, userId, isVet);
+    assertPodeEditar(record, userId, isVet);
     const updated = await this.prisma.$transaction(async (tx) => {
       const alterado = await tx.vaccineRecord.update({
         where: { id },
@@ -141,9 +143,10 @@ export class VaccineService {
    * O tutor deixa de ver o registro, mas o que o veterinário aplicou continua
    * demonstrável.
    */
-  async remove(id: string, userId: string): Promise<void> {
+  async remove(id: string, userId: string, isVet: boolean): Promise<void> {
     const record = await this.getRecord(id);
-    await this.petService.assertOwnership(record.petId, userId);
+    await this.petService.assertAccess(record.petId, userId, isVet);
+    assertPodeRemover(record, userId, isVet);
     await this.prisma.$transaction(async (tx) => {
       await tx.vaccineRecord.update({
         where: { id },
@@ -156,7 +159,7 @@ export class VaccineService {
           entidade: EntidadeClinica.VACINA,
           entidadeId: id,
           autorId: userId,
-          autorTipo: Role.TUTOR,
+          autorTipo: isVet ? Role.VET : Role.TUTOR,
           detalhes: { antes: toSnapshot(record) },
         },
         tx,

--- a/src/modules/historico/__tests__/historico-clinico.service.spec.ts
+++ b/src/modules/historico/__tests__/historico-clinico.service.spec.ts
@@ -127,7 +127,9 @@ describe('HistoricoClinicoService', () => {
     });
   });
 
-  it('ordena a linha do tempo do mais recente para o mais antigo', async () => {
+  it('ordena pela ordem de registro, não pela data clínica', async () => {
+    // Vacina aplicada em janeiro, mas lançada no sistema depois da medicação:
+    // o topo da pilha é o último registro, independente do tipo.
     prisma.vaccineRecord.findMany.mockResolvedValue([
       {
         id: 'vac-1',
@@ -135,7 +137,7 @@ describe('HistoricoClinicoService', () => {
         vaccineName: 'Antirrábica',
         appliedAt: new Date('2026-01-05'),
         notes: null,
-        createdAt: new Date('2026-01-05'),
+        createdAt: new Date('2026-03-20'),
         deletedAt: null,
         veterinarianName: 'Dr. Externo',
         veterinario: null,
@@ -146,9 +148,50 @@ describe('HistoricoClinicoService', () => {
     const resultado = await service.doPet('pet-1', 'tutor-1', false);
 
     expect(resultado.itens.map((i) => i.entidade)).toEqual([
-      EntidadeClinica.MEDICACAO,
       EntidadeClinica.VACINA,
+      EntidadeClinica.MEDICACAO,
     ]);
+  });
+
+  it('entrega data clínica como dia de calendário, sem deslocar o fuso', async () => {
+    prisma.vaccineRecord.findMany.mockResolvedValue([
+      {
+        id: 'vac-1',
+        petId: 'pet-1',
+        vaccineName: 'Antirrábica',
+        // Meia-noite UTC: entregue como instante, o cliente em UTC-3 renderiza
+        // 18/03 — a vacina de hoje aparecendo como de ontem.
+        appliedAt: new Date('2026-03-19T00:00:00.000Z'),
+        notes: null,
+        createdAt: new Date('2026-03-19T13:40:00.000Z'),
+        deletedAt: null,
+        veterinarianName: null,
+        veterinario: vet,
+      },
+    ]);
+
+    const resultado = await service.doPet('pet-1', 'tutor-1', false);
+
+    expect(resultado.itens[0].ocorrido_em).toBe('2026-03-19');
+  });
+
+  it('mantém a nota clínica como instante — o fato é o momento do registro', async () => {
+    prisma.notaClinica.findMany.mockResolvedValue([
+      {
+        id: 'nota-1',
+        petId: 'pet-1',
+        diagnostico: 'Otite externa',
+        prescricao: null,
+        observacoes: null,
+        createdAt: new Date('2026-04-01T18:30:00.000Z'),
+        deletedAt: null,
+        veterinario: vet,
+      },
+    ]);
+
+    const resultado = await service.doPet('pet-1', 'tutor-1', false);
+
+    expect(resultado.itens[0].ocorrido_em).toBe('2026-04-01T18:30:00.000Z');
   });
 
   it('usa o nome livre quando não há veterinário do PetCard', async () => {

--- a/src/modules/historico/historico-clinico.service.ts
+++ b/src/modules/historico/historico-clinico.service.ts
@@ -66,12 +66,15 @@ export class HistoricoClinicoService {
 
     const porEntidade = agruparAcoes(acoes);
 
+    // Ordem de registro, não data clínica: o último lançamento é o topo da
+    // pilha, seja ele nota, vacina, vermífugo ou medicação. Vacina aplicada
+    // meses atrás e registrada agora entra no topo — foi o que aconteceu.
     const itens: HistoricoClinicoItemResponseDto[] = [
       ...notas.map((n) => this.itemDaNota(n, porEntidade)),
       ...vacinas.map((v) => this.itemDaVacina(v, porEntidade)),
       ...vermifugos.map((d) => this.itemDoVermifugo(d, porEntidade)),
       ...medicacoes.map((m) => this.itemDaMedicacao(m, porEntidade)),
-    ].sort((a, b) => b.ocorrido_em.getTime() - a.ocorrido_em.getTime());
+    ].sort((a, b) => b.registrado_em.getTime() - a.registrado_em.getTime());
 
     return { pet_id: pet.id, pet_nome: pet.name, itens };
   }
@@ -85,7 +88,9 @@ export class HistoricoClinicoService {
       entidade_id: nota.id,
       titulo: nota.diagnostico,
       descricao: nota.prescricao ?? nota.observacoes ?? undefined,
-      ocorrido_em: nota.createdAt,
+      // A consulta não tem data própria: o fato clínico é o instante em que
+      // o veterinário escreveu, e instante o cliente sabe localizar.
+      ocorrido_em: nota.createdAt.toISOString(),
       registrado_em: nota.createdAt,
       ...this.exclusao(nota.deletedAt),
       ...this.vet(nota.veterinario),
@@ -102,7 +107,7 @@ export class HistoricoClinicoService {
       entidade_id: vacina.id,
       titulo: vacina.vaccineName,
       descricao: vacina.notes ?? undefined,
-      ocorrido_em: vacina.appliedAt,
+      ocorrido_em: diaDeCalendario(vacina.appliedAt),
       registrado_em: vacina.createdAt,
       ...this.exclusao(vacina.deletedAt),
       ...this.vet(vacina.veterinario, vacina.veterinarianName),
@@ -119,7 +124,7 @@ export class HistoricoClinicoService {
       entidade_id: verm.id,
       titulo: verm.productName,
       descricao: verm.notes ?? undefined,
-      ocorrido_em: verm.appliedAt,
+      ocorrido_em: diaDeCalendario(verm.appliedAt),
       registrado_em: verm.createdAt,
       ...this.exclusao(verm.deletedAt),
       ...this.vet(verm.veterinario, verm.veterinarianName),
@@ -136,7 +141,7 @@ export class HistoricoClinicoService {
       entidade_id: med.id,
       titulo: med.medicationName,
       descricao: `${med.dosage} · ${med.frequency}`,
-      ocorrido_em: med.startDate,
+      ocorrido_em: diaDeCalendario(med.startDate),
       registrado_em: med.createdAt,
       ...this.exclusao(med.deletedAt),
       ...this.vet(med.veterinario),
@@ -165,6 +170,16 @@ export class HistoricoClinicoService {
     }
     return { veterinario_nome: nomeLivre ?? undefined };
   }
+}
+
+/**
+ * `appliedAt`/`startDate` são dia de calendário guardados em coluna de
+ * instante, à meia-noite UTC. Entregues como instante, o cliente em fuso
+ * negativo renderiza o dia anterior — a vacina de hoje aparece como de ontem.
+ * Mesma serialização das listagens de vacina, vermífugo e medicação.
+ */
+function diaDeCalendario(data: Date): string {
+  return data.toISOString().split('T')[0];
 }
 
 function chave(entidade: EntidadeClinica, id: string): string {

--- a/src/modules/vet-note/__tests__/vet-note.service.spec.ts
+++ b/src/modules/vet-note/__tests__/vet-note.service.spec.ts
@@ -10,6 +10,8 @@ import { NotificationService } from '../../notification/notification.service';
 import { VetNoteService } from '../vet-note.service';
 
 describe('VetNoteService', () => {
+  let acaoTrilha: ReturnType<typeof acaoClinicaProvider>;
+  let registrarAcao: jest.Mock;
   let service: VetNoteService;
   let prisma: {
     notaClinica: {
@@ -50,6 +52,9 @@ describe('VetNoteService', () => {
   };
 
   beforeEach(async () => {
+    acaoTrilha = acaoClinicaProvider();
+    registrarAcao = acaoTrilha.registrar;
+
     prisma = {
       notaClinica: {
         create: jest.fn(),
@@ -70,7 +75,7 @@ describe('VetNoteService', () => {
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
-        acaoClinicaProvider().provider,
+        acaoTrilha.provider,
         VetNoteService,
         { provide: PrismaService, useValue: prisma },
         { provide: NotificationService, useValue: notificationService },
@@ -322,6 +327,63 @@ describe('VetNoteService', () => {
       await expect(service.remove('missing', 'vet-1')).rejects.toThrow(
         NotFoundException,
       );
+    });
+  });
+  describe('update', () => {
+    it('edita a própria nota e registra o antes e o depois', async () => {
+      prisma.notaClinica.findFirst.mockResolvedValue({
+        ...notaFixture,
+        veterinarioId: 'vet-1',
+        diagnostico: 'Otite',
+      });
+      prisma.notaClinica.update.mockResolvedValue({
+        ...notaFixture,
+        diagnostico: 'Otite bilateral',
+      });
+
+      const result = await service.update('nota-1', 'vet-1', {
+        diagnostico: 'Otite bilateral',
+      });
+
+      expect(result.diagnostico).toBe('Otite bilateral');
+      expect(registrarAcao).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tipo: 'EDICAO',
+          entidade: 'NOTA_CLINICA',
+          entidadeId: 'nota-1',
+          autorId: 'vet-1',
+          detalhes: {
+            antes: expect.objectContaining({
+              diagnostico: 'Otite',
+            }) as unknown,
+            depois: expect.objectContaining({
+              diagnostico: 'Otite bilateral',
+            }) as unknown,
+          },
+        }),
+        expect.anything(),
+      );
+    });
+
+    it('recusa a edição de nota de outro veterinário', async () => {
+      prisma.notaClinica.findFirst.mockResolvedValue({
+        ...notaFixture,
+        veterinarioId: 'vet-1',
+      });
+
+      // Editar mantendo a assinatura alheia falsificaria a autoria.
+      await expect(
+        service.update('nota-1', 'vet-2', { diagnostico: 'outra coisa' }),
+      ).rejects.toThrow(ForbiddenException);
+      expect(prisma.notaClinica.update).not.toHaveBeenCalled();
+    });
+
+    it('recusa nota inexistente', async () => {
+      prisma.notaClinica.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.update('missing', 'vet-1', { diagnostico: 'x' }),
+      ).rejects.toThrow(NotFoundException);
     });
   });
 });

--- a/src/modules/vet-note/vet-note.controller.ts
+++ b/src/modules/vet-note/vet-note.controller.ts
@@ -6,6 +6,7 @@ import {
   HttpCode,
   HttpStatus,
   Param,
+  Patch,
   Post,
 } from '@nestjs/common';
 import {
@@ -22,6 +23,7 @@ import { Role } from '../auth/enums/role.enum';
 import type { JwtPayload } from '../auth/strategies/jwt.strategy';
 import {
   CreateNotaClinicaDto,
+  UpdateNotaClinicaDto,
   NotaClinicaResponseDto,
 } from '@petcardorg/shared';
 import { VetNoteService } from './vet-note.service';
@@ -70,6 +72,19 @@ export class VetNoteController {
   ): Promise<NotaClinicaResponseDto> {
     const isVet = user.role === Role.VET;
     return this.vetNoteService.findOne(id, user.sub, isVet);
+  }
+
+  @Patch('clinical-notes/:id')
+  @AuthCrmvVerificado(Role.VET)
+  @ApiOperation({ summary: 'Editar nota clínica (somente o vet autor)' })
+  @ApiOkResponse({ type: NotaClinicaResponseDto })
+  @ApiNotFoundResponse({ description: 'Nota clínica não encontrada' })
+  async update(
+    @Param('id') id: string,
+    @CurrentUser() user: JwtPayload,
+    @Body() dto: UpdateNotaClinicaDto,
+  ): Promise<NotaClinicaResponseDto> {
+    return this.vetNoteService.update(id, user.sub, dto);
   }
 
   @Delete('clinical-notes/:id')

--- a/src/modules/vet-note/vet-note.service.ts
+++ b/src/modules/vet-note/vet-note.service.ts
@@ -16,6 +16,7 @@ import { NotificationService } from '../notification/notification.service';
 import { AcaoClinicaService } from '../historico/acao-clinica.service';
 import {
   CreateNotaClinicaDto,
+  UpdateNotaClinicaDto,
   NotaClinicaResponseDto,
 } from '@petcardorg/shared';
 
@@ -157,6 +158,67 @@ export class VetNoteService {
    * Exclusão lógica (api#117): a nota some da listagem, mas o histórico
    * clínico preserva o que foi diagnosticado e quem diagnosticou.
    */
+  /**
+   * Edição da própria nota (web#34). Mesma regra da exclusão: só o autor.
+   * Alterar nota alheia mantendo a assinatura falsificaria a autoria — a
+   * carteira seguiria dizendo quem escreveu, com outro conteúdo.
+   */
+  async update(
+    id: string,
+    veterinarioId: string,
+    dto: UpdateNotaClinicaDto,
+  ): Promise<NotaClinicaResponseDto> {
+    const nota = await this.prisma.notaClinica.findFirst({
+      where: { id, deletedAt: null },
+    });
+
+    if (!nota) {
+      throw new NotFoundException(`Clinical note with id ${id} not found`);
+    }
+
+    if (nota.veterinarioId !== veterinarioId) {
+      throw new ForbiddenException('You can only edit your own clinical notes');
+    }
+
+    const atualizada = await this.prisma.$transaction(async (tx) => {
+      const alterada = await tx.notaClinica.update({
+        where: { id },
+        data: {
+          diagnostico: dto.diagnostico,
+          prescricao: dto.prescricao,
+          observacoes: dto.observacoes,
+        },
+        include: { veterinario: { select: { nome: true, crmv: true } } },
+      });
+      await this.acoes.registrar(
+        {
+          petId: nota.petId,
+          tipo: AcaoClinicaTipo.EDICAO,
+          entidade: EntidadeClinica.NOTA_CLINICA,
+          entidadeId: id,
+          autorId: veterinarioId,
+          autorTipo: Role.VET,
+          detalhes: {
+            antes: {
+              diagnostico: nota.diagnostico,
+              prescricao: nota.prescricao,
+              observacoes: nota.observacoes,
+            },
+            depois: {
+              diagnostico: alterada.diagnostico,
+              prescricao: alterada.prescricao,
+              observacoes: alterada.observacoes,
+            },
+          },
+        },
+        tx,
+      );
+      return alterada;
+    });
+
+    return toResponseDto(atualizada);
+  }
+
   async remove(id: string, veterinarioId: string): Promise<void> {
     const nota = await this.prisma.notaClinica.findFirst({
       where: { id, deletedAt: null },

--- a/src/modules/veterinario/__tests__/dashboard.service.spec.ts
+++ b/src/modules/veterinario/__tests__/dashboard.service.spec.ts
@@ -16,6 +16,9 @@ describe('VeterinarioService - findAttendedPets', () => {
   let service: VeterinarioService;
   let prisma: {
     notaClinica: { findMany: jest.Mock };
+    vaccineRecord: { findMany: jest.Mock };
+    dewormingRecord: { findMany: jest.Mock };
+    medicationRecord: { findMany: jest.Mock };
     pet: { findMany: jest.Mock };
     veterinario: {
       create: jest.Mock;
@@ -49,6 +52,10 @@ describe('VeterinarioService - findAttendedPets', () => {
   beforeEach(async () => {
     prisma = {
       notaClinica: { findMany: jest.fn() },
+      // O dashboard agora reúne os quatro tipos de registro (web#34).
+      vaccineRecord: { findMany: jest.fn().mockResolvedValue([]) },
+      dewormingRecord: { findMany: jest.fn().mockResolvedValue([]) },
+      medicationRecord: { findMany: jest.fn().mockResolvedValue([]) },
       pet: { findMany: jest.fn() },
       veterinario: {
         create: jest.fn(),
@@ -107,8 +114,12 @@ describe('VeterinarioService - findAttendedPets', () => {
     const result = await service.findAttendedPets('vet-1', { search: 'Rex' });
 
     expect(result.items).toHaveLength(1);
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    expect(prisma.notaClinica.findMany.mock.calls[0][0].where.OR).toBeDefined();
+
+    const [[chamada]] = prisma.notaClinica.findMany.mock.calls as Array<
+      [{ where: { pet?: { OR?: unknown[] } } }]
+    >;
+    // A busca passou a filtrar pelo pet, não por campos da nota.
+    expect(chamada.where.pet?.OR).toBeDefined();
   });
 
   it('should search by tutor name', async () => {
@@ -149,5 +160,53 @@ describe('VeterinarioService - findAttendedPets', () => {
 
     expect(result.items).toHaveLength(0);
     expect(result.total).toBe(0);
+  });
+  it('traz o pet em que o veterinário só aplicou vacina, sem nota', async () => {
+    prisma.notaClinica.findMany.mockResolvedValue([]);
+    prisma.vaccineRecord.findMany.mockResolvedValue([
+      { petId: 'pet-1', createdAt: new Date('2026-08-18T10:00:00Z') },
+    ]);
+    prisma.pet.findMany.mockResolvedValue([
+      {
+        id: 'pet-1',
+        name: 'Rex',
+        species: 'DOG',
+        breed: null,
+        photoUrl: null,
+        tutor: { name: 'Ana Silva' },
+      },
+    ]);
+
+    const result = await service.findAttendedPets('vet-1', {});
+
+    // Antes o dashboard olhava só a nota clínica: quem registrava apenas uma
+    // vacina perdia o pet da própria lista (web#34).
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].name).toBe('Rex');
+  });
+
+  it('usa o atendimento mais recente entre os tipos de registro', async () => {
+    prisma.notaClinica.findMany.mockResolvedValue([
+      { petId: 'pet-1', createdAt: new Date('2026-08-10T10:00:00Z') },
+    ]);
+    prisma.medicationRecord.findMany.mockResolvedValue([
+      { petId: 'pet-1', createdAt: new Date('2026-08-18T10:00:00Z') },
+    ]);
+    prisma.pet.findMany.mockResolvedValue([
+      {
+        id: 'pet-1',
+        name: 'Rex',
+        species: 'DOG',
+        breed: null,
+        photoUrl: null,
+        tutor: { name: 'Ana Silva' },
+      },
+    ]);
+
+    const result = await service.findAttendedPets('vet-1', {});
+
+    expect(result.items[0].last_attended_at).toEqual(
+      new Date('2026-08-18T10:00:00Z'),
+    );
   });
 });

--- a/src/modules/veterinario/__tests__/veterinario.controller.spec.ts
+++ b/src/modules/veterinario/__tests__/veterinario.controller.spec.ts
@@ -46,6 +46,9 @@ describe('VeterinarioController (integração)', () => {
         delete: jest.fn(),
       },
       notaClinica: { findMany: jest.fn() },
+      vaccineRecord: { findMany: jest.fn().mockResolvedValue([]) },
+      dewormingRecord: { findMany: jest.fn().mockResolvedValue([]) },
+      medicationRecord: { findMany: jest.fn().mockResolvedValue([]) },
       pet: { findMany: jest.fn() },
     };
     crmv = {

--- a/src/modules/veterinario/veterinario.service.ts
+++ b/src/modules/veterinario/veterinario.service.ts
@@ -99,33 +99,55 @@ export class VeterinarioService {
     const pageSize = query.pageSize ?? 10;
     const search = query.search?.trim();
 
-    // Nota excluída não traz o pet de volta ao dashboard (api#117).
-    const where: Prisma.NotaClinicaWhereInput = {
+    /**
+     * O dashboard reúne todo pet que este veterinário atendeu, não só aquele
+     * em que escreveu nota (web#34). Desde que ele passou a registrar vacina,
+     * vermifugação e medicação pela tela, olhar apenas a nota clínica fazia o
+     * pet sumir da lista de quem tinha acabado de ser atendido.
+     *
+     * Registro excluído não traz o pet de volta: o filtro é sobre o que está
+     * vivo, mantendo a decisão da api#117.
+     */
+    const filtroPet: Prisma.PetWhereInput | undefined = search
+      ? {
+          OR: [
+            { name: { contains: search, mode: 'insensitive' } },
+            { tutor: { name: { contains: search, mode: 'insensitive' } } },
+          ],
+        }
+      : undefined;
+
+    const base = {
       veterinarioId,
       deletedAt: null,
+      ...(filtroPet ? { pet: filtroPet } : {}),
+    };
+    const selecao = {
+      distinct: ['petId'] as ['petId'],
+      orderBy: { createdAt: 'desc' as const },
+      select: { petId: true, createdAt: true },
     };
 
-    if (search) {
-      where.OR = [
-        {
-          pet: { name: { contains: search, mode: 'insensitive' } },
-        },
-        {
-          pet: {
-            tutor: {
-              name: { contains: search, mode: 'insensitive' },
-            },
-          },
-        },
-      ];
+    const [notas, vacinas, vermifugos, medicacoes] = await Promise.all([
+      this.prisma.notaClinica.findMany({ where: base, ...selecao }),
+      this.prisma.vaccineRecord.findMany({ where: base, ...selecao }),
+      this.prisma.dewormingRecord.findMany({ where: base, ...selecao }),
+      this.prisma.medicationRecord.findMany({ where: base, ...selecao }),
+    ]);
+
+    // Um pet pode ter registros de tipos diferentes; vale o atendimento mais
+    // recente entre eles.
+    const maisRecentePorPet = new Map<string, Date>();
+    for (const r of [...notas, ...vacinas, ...vermifugos, ...medicacoes]) {
+      const atual = maisRecentePorPet.get(r.petId);
+      if (!atual || r.createdAt > atual) {
+        maisRecentePorPet.set(r.petId, r.createdAt);
+      }
     }
 
-    const distinctPetIds = await this.prisma.notaClinica.findMany({
-      where,
-      distinct: ['petId'],
-      orderBy: { createdAt: 'desc' },
-      select: { petId: true, createdAt: true },
-    });
+    const distinctPetIds = [...maisRecentePorPet.entries()]
+      .map(([petId, createdAt]) => ({ petId, createdAt }))
+      .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
 
     const total = distinctPetIds.length;
     const totalPages = Math.ceil(total / pageSize) || 1;

--- a/test/e2e/historico-clinico.e2e-spec.ts
+++ b/test/e2e/historico-clinico.e2e-spec.ts
@@ -250,4 +250,57 @@ describe('Histórico clínico (e2e)', () => {
       .expect(200);
     expect(publica.body.vaccines).toHaveLength(0);
   });
+  it('o veterinário edita a própria nota clínica e a trilha registra', async () => {
+    const nota = await request(app.getHttpServer())
+      .post(`/pets/${petId}/clinical-notes`)
+      .set('Authorization', `Bearer ${vetToken}`)
+      .send({ diagnostico: 'Otite externa' })
+      .expect(201);
+
+    await request(app.getHttpServer())
+      .patch(`/clinical-notes/${nota.body.id as string}`)
+      .set('Authorization', `Bearer ${vetToken}`)
+      .send({ diagnostico: 'Otite externa bilateral' })
+      .expect(200);
+
+    const acoes = await prisma.acaoClinica.findMany({
+      where: { entidadeId: nota.body.id as string, tipo: 'EDICAO' },
+    });
+    expect(acoes).toHaveLength(1);
+    const detalhes = acoes[0].detalhes as {
+      antes: { diagnostico: string };
+      depois: { diagnostico: string };
+    };
+    expect(detalhes.antes.diagnostico).toBe('Otite externa');
+    expect(detalhes.depois.diagnostico).toBe('Otite externa bilateral');
+  });
+
+  it('o tutor não edita nota clínica (403)', async () => {
+    const nota = await request(app.getHttpServer())
+      .post(`/pets/${petId}/clinical-notes`)
+      .set('Authorization', `Bearer ${vetToken}`)
+      .send({ diagnostico: 'Otite externa' })
+      .expect(201);
+
+    await request(app.getHttpServer())
+      .patch(`/clinical-notes/${nota.body.id as string}`)
+      .set('Authorization', `Bearer ${tutorToken}`)
+      .send({ diagnostico: 'nada a ver' })
+      .expect(403);
+  });
+
+  it('o registro do veterinário traz nome e CRMV', async () => {
+    const medId = await prescreverMedicacao();
+
+    const lista = await request(app.getHttpServer())
+      .get(`/pets/${petId}/medications`)
+      .set('Authorization', `Bearer ${vetToken}`)
+      .expect(200);
+
+    const item = (lista.body as Array<Record<string, unknown>>).find(
+      (m) => m.id === medId,
+    );
+    expect(item?.veterinarian_name).toBe('Dra. Camila');
+    expect(item?.veterinario_crmv).toBe('CRMV-CE-1234');
+  });
 });

--- a/test/e2e/historico-clinico.e2e-spec.ts
+++ b/test/e2e/historico-clinico.e2e-spec.ts
@@ -151,7 +151,7 @@ describe('Histórico clínico (e2e)', () => {
 
     await request(app.getHttpServer())
       .patch(`/medications/${medId}`)
-      .set('Authorization', `Bearer ${tutorToken}`)
+      .set('Authorization', `Bearer ${vetToken}`)
       .send({ dosage: '500mg' })
       .expect(200);
 
@@ -165,6 +165,51 @@ describe('Histórico clínico (e2e)', () => {
     };
     expect(detalhes.antes.dosage).toBe('250mg');
     expect(detalhes.depois.dosage).toBe('500mg');
+  });
+
+  it('o tutor não edita a prescrição do veterinário (403)', async () => {
+    const medId = await prescreverMedicacao();
+
+    // Editar mantendo a assinatura do veterinário falsificaria a autoria: a
+    // carteira continuaria dizendo "prescrito por Dra. Camila, CRMV-CE-1234"
+    // sobre uma dosagem que ela não prescreveu (web#34).
+    await request(app.getHttpServer())
+      .patch(`/medications/${medId}`)
+      .set('Authorization', `Bearer ${tutorToken}`)
+      .send({ dosage: '500mg' })
+      .expect(403);
+
+    const noBanco = await prisma.medicationRecord.findUnique({
+      where: { id: medId },
+    });
+    expect(noBanco?.dosage).toBe('250mg');
+  });
+
+  it('o veterinário remove a própria prescrição, o tutor não perde a dele', async () => {
+    const medId = await prescreverMedicacao();
+
+    // Registro declarado pelo tutor: não é do veterinário para apagar.
+    const doTutor = await request(app.getHttpServer())
+      .post(`/pets/${petId}/medications`)
+      .set('Authorization', `Bearer ${tutorToken}`)
+      .send({
+        pet_id: petId,
+        medication_name: 'Suplemento',
+        dosage: '1 comprimido',
+        frequency: '24/24h',
+        start_date: '2026-03-10',
+      })
+      .expect(201);
+
+    await request(app.getHttpServer())
+      .delete(`/medications/${medId}`)
+      .set('Authorization', `Bearer ${vetToken}`)
+      .expect(204);
+
+    await request(app.getHttpServer())
+      .delete(`/medications/${doTutor.body.id as string}`)
+      .set('Authorization', `Bearer ${vetToken}`)
+      .expect(403);
   });
 
   it('proíbe tutor que não é dono de ver o histórico (403)', async () => {


### PR DESCRIPTION
Base de API para a web#34 (`PetCardOrg/petcard-web#34`), onde o veterinário passa a prescrever pela tela. Levantado ao revisar o que a tela do vet iria expor.

## Dois furos encontrados

**A exclusão estava invertida.** `@Delete` de vacina/vermífugo/medicação era `@Auth(Role.TUTOR)`: o veterinário não conseguia desfazer o próprio registro. Com a tela nova, um erro de digitação na prescrição ficaria sem saída.

**CRMV assimétrico.** A api#113 exigiu CRMV verificado para *ler* medicação, mas não para *escrever*. Um veterinário sem verificação não listava as medicações e mesmo assim prescrevia.

## Regra de autoria

Quem altera o registro é decidido pela autoria (`veterinario_id`, da api#117), não pelo papel:

| | registro do tutor | registro do veterinário |
| --- | --- | --- |
| **editar** | tutor ✅ · vet ❌ | vet autor ✅ · tutor ❌ |
| **remover** | tutor ✅ · vet ❌ | vet autor ✅ · **tutor ✅** |

O tutor continua removendo a prescrição que decidiu não seguir — é o caso central da api#117. A exclusão é lógica: sai da carteira dele e permanece no histórico, com a ação registrada em seu nome. O que ele não faz é **editar**: alterar o conteúdo mantendo a assinatura do veterinário falsificaria a autoria.

## Mudança de comportamento

Um teste e2e da api#117 tinha o tutor editando a prescrição do veterinário; agora quem edita é o autor, e há um teste novo cobrindo o 403 do tutor.

## Validação

- 454 unitários (+17) e 38 e2e (+2) contra Postgres real
- cobertura 86.13/80.87/94.1/87.48 — catraca 84/80/93/85
- `npm run lint` e `npm run build` limpos
- não-vacuidade: neutralizar as duas funções de autoria derruba 10 unitários e 2 e2e