### PR TITLE
feat: vínculo explícito entre veterinário e pet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@nestjs/schedule": "^6.1.3",
         "@nestjs/swagger": "^11.4.4",
         "@nestjs/throttler": "^6.5.0",
-        "@petcardorg/shared": "^0.15.1",
+        "@petcardorg/shared": "^0.16.0",
         "@prisma/client": "^6.19.3",
         "amqp-connection-manager": "^5.0.0",
         "amqplib": "^1.0.3",
@@ -3846,9 +3846,9 @@
       }
     },
     "node_modules/@petcardorg/shared": {
-      "version": "0.15.1",
-      "resolved": "https://npm.pkg.github.com/download/@petcardorg/shared/0.15.1/220d0352ca89ffbcf265e0ad0677fef0fcd8a26d",
-      "integrity": "sha512-t52AdLujkca30Rd+mAQbcFAgLCL+5f/pjGNm8gOhy3nn4mQmf876AQPvQTDbd/K+13Uq3uuD2bcVk3Es643NCA==",
+      "version": "0.16.0",
+      "resolved": "https://npm.pkg.github.com/download/@petcardorg/shared/0.16.0/e5cc6c8ee2af3e7f25c410ac321c3189b3392242",
+      "integrity": "sha512-kdHgFXue1EiJtwvYFGcxgemthxlZ9MLVrOyK10cgDdpmTH7FSBr8RFLQHvJgHYyY3bpE5Jbz4b1ZRK0QycFTqA==",
       "license": "MIT",
       "peerDependencies": {
         "class-transformer": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@nestjs/schedule": "^6.1.3",
     "@nestjs/swagger": "^11.4.4",
     "@nestjs/throttler": "^6.5.0",
-    "@petcardorg/shared": "^0.15.1",
+    "@petcardorg/shared": "^0.16.0",
     "@prisma/client": "^6.19.3",
     "amqp-connection-manager": "^5.0.0",
     "amqplib": "^1.0.3",

--- a/prisma/migrations/20260819225757_vinculo_veterinario_pet/migration.sql
+++ b/prisma/migrations/20260819225757_vinculo_veterinario_pet/migration.sql
@@ -1,0 +1,39 @@
+-- CreateTable
+CREATE TABLE "pet_atendido" (
+    "id" TEXT NOT NULL,
+    "veterinario_id" TEXT NOT NULL,
+    "pet_id" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "ultimo_acesso_em" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "pet_atendido_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "pet_atendido_veterinario_id_ultimo_acesso_em_idx" ON "pet_atendido"("veterinario_id", "ultimo_acesso_em");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "pet_atendido_veterinario_id_pet_id_key" ON "pet_atendido"("veterinario_id", "pet_id");
+
+-- AddForeignKey
+ALTER TABLE "pet_atendido" ADD CONSTRAINT "pet_atendido_veterinario_id_fkey" FOREIGN KEY ("veterinario_id") REFERENCES "veterinario"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "pet_atendido" ADD CONSTRAINT "pet_atendido_pet_id_fkey" FOREIGN KEY ("pet_id") REFERENCES "pet"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Backfill: até aqui o dashboard era derivado dos registros clínicos. Sem
+-- semear o vínculo, todo veterinário perderia a lista no deploy. Inclui
+-- registro excluído de propósito: o atendimento aconteceu, e a regra nova é
+-- que apagar o registro não tira o pet da lista.
+INSERT INTO "pet_atendido" ("id", "veterinario_id", "pet_id", "created_at", "ultimo_acesso_em")
+SELECT gen_random_uuid(), "veterinario_id", "pet_id", MIN("created_at"), MAX("created_at")
+FROM (
+    SELECT "veterinario_id", "pet_id", "created_at" FROM "nota_clinica" WHERE "veterinario_id" IS NOT NULL
+    UNION ALL
+    SELECT "veterinario_id", "pet_id", "created_at" FROM "vaccine_record" WHERE "veterinario_id" IS NOT NULL
+    UNION ALL
+    SELECT "veterinario_id", "pet_id", "created_at" FROM "deworming_record" WHERE "veterinario_id" IS NOT NULL
+    UNION ALL
+    SELECT "veterinario_id", "pet_id", "created_at" FROM "medication_record" WHERE "veterinario_id" IS NOT NULL
+) AS "atendimentos"
+GROUP BY "veterinario_id", "pet_id";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -133,6 +133,7 @@ model Pet {
   acoesClinicas     AcaoClinica[]
   appointments      Appointment[]
   notasClinicas     NotaClinica[]
+  veterinarios      PetAtendido[]
 
   @@map("pet")
 }
@@ -288,8 +289,31 @@ model Veterinario {
   vacinas       VaccineRecord[]
   vermifugos    DewormingRecord[]
   medicacoes    MedicationRecord[]
+  petsAtendidos PetAtendido[]
 
   @@map("veterinario")
+}
+
+/// Vínculo explícito entre veterinário e pet.
+///
+/// O dashboard do veterinário era derivado dos registros clínicos vivos, então
+/// apagar o próprio registro fazia o pet sumir da lista — e, sem scanner na
+/// web, não havia como trazer um pet novo. O pet entra aqui quando o
+/// veterinário abre a carteira pelo token do QR e só sai quando ele remove.
+model PetAtendido {
+  id             String   @id @default(uuid())
+  veterinarioId  String   @map("veterinario_id")
+  petId          String   @map("pet_id")
+  createdAt      DateTime @default(now()) @map("created_at")
+  /// Último atendimento: acesso pelo QR ou ação clínica sobre o pet.
+  ultimoAcessoEm DateTime @default(now()) @map("ultimo_acesso_em")
+
+  veterinario Veterinario @relation(fields: [veterinarioId], references: [id], onDelete: Cascade)
+  pet         Pet         @relation(fields: [petId], references: [id], onDelete: Cascade)
+
+  @@unique([veterinarioId, petId])
+  @@index([veterinarioId, ultimoAcessoEm])
+  @@map("pet_atendido")
 }
 
 model NotaClinica {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -252,6 +252,11 @@ const medications: MedicationSeed[] = [
   },
 ];
 
+interface RegistroDoVet {
+  veterinarioId: string | null;
+  petId: string;
+}
+
 async function main() {
   console.log('🌱 Iniciando seed do banco de dados...');
 
@@ -399,6 +404,41 @@ async function main() {
       });
     }
     console.log(`✅ ${medications.length} registros de medicação criados`);
+
+    /**
+     * Vincula ao veterinário os pets em que ele registrou algo.
+     *
+     * O dashboard do vet lê do vínculo, não dos registros. O seed grava
+     * direto pelo Prisma, sem passar pelos serviços que criam o vínculo, então
+     * sem isto a Dra. Camila abriria a demo com o dashboard vazio.
+     */
+    const vinculos = new Map<
+      string,
+      { veterinarioId: string; petId: string }
+    >();
+    for (const modelo of [
+      tx.vaccineRecord,
+      tx.dewormingRecord,
+      tx.medicationRecord,
+      tx.notaClinica,
+    ]) {
+      const registros = await (
+        modelo as { findMany: (args: unknown) => Promise<RegistroDoVet[]> }
+      ).findMany({ select: { veterinarioId: true, petId: true } });
+      for (const r of registros) {
+        if (!r.veterinarioId) continue;
+        vinculos.set(`${r.veterinarioId}:${r.petId}`, {
+          veterinarioId: r.veterinarioId,
+          petId: r.petId,
+        });
+      }
+    }
+
+    await tx.petAtendido.deleteMany();
+    for (const vinculo of vinculos.values()) {
+      await tx.petAtendido.create({ data: vinculo });
+    }
+    console.log(`✅ ${vinculos.size} vínculos veterinário↔pet criados`);
   });
 
   console.log('🌱 Seed concluído com sucesso!');

--- a/src/modules/historico/__tests__/acao-clinica.service.spec.ts
+++ b/src/modules/historico/__tests__/acao-clinica.service.spec.ts
@@ -9,6 +9,7 @@ describe('AcaoClinicaService', () => {
     acaoClinica: { create: jest.Mock };
     veterinario: { findUnique: jest.Mock };
     tutor: { findUnique: jest.Mock };
+    petAtendido: { upsert: jest.Mock };
   };
 
   const base = {
@@ -23,6 +24,7 @@ describe('AcaoClinicaService', () => {
       acaoClinica: { create: jest.fn() },
       veterinario: { findUnique: jest.fn() },
       tutor: { findUnique: jest.fn() },
+      petAtendido: { upsert: jest.fn() },
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -95,6 +97,7 @@ describe('AcaoClinicaService', () => {
       acaoClinica: { create: jest.fn() },
       veterinario: { findUnique: jest.fn().mockResolvedValue(null) },
       tutor: { findUnique: jest.fn() },
+      petAtendido: { upsert: jest.fn() },
     };
 
     await service.registrar(
@@ -105,5 +108,37 @@ describe('AcaoClinicaService', () => {
     // A trilha precisa cair junto com a operação que a originou.
     expect(tx.acaoClinica.create).toHaveBeenCalled();
     expect(prisma.acaoClinica.create).not.toHaveBeenCalled();
+    expect(tx.petAtendido.upsert).toHaveBeenCalled();
+  });
+
+  it('mantém o pet na lista do veterinário que agiu sobre ele', async () => {
+    prisma.veterinario.findUnique.mockResolvedValue({
+      nome: 'Dra. Camila',
+      crmv: 'CRMV-SP 12345',
+    });
+
+    await service.registrar({ ...base, autorId: 'vet-1', autorTipo: Role.VET });
+
+    // Sem isto, o veterinário poderia registrar uma vacina num pet ausente
+    // do próprio dashboard.
+    const [[chamada]] = prisma.petAtendido.upsert.mock.calls as Array<
+      [{ where: { veterinarioId_petId: Record<string, string> } }]
+    >;
+    expect(chamada.where.veterinarioId_petId).toEqual({
+      veterinarioId: 'vet-1',
+      petId: 'pet-1',
+    });
+  });
+
+  it('não vincula pet ao tutor — a lista é do veterinário', async () => {
+    prisma.tutor.findUnique.mockResolvedValue({ name: 'Ana Silva' });
+
+    await service.registrar({
+      ...base,
+      autorId: 'tutor-1',
+      autorTipo: Role.TUTOR,
+    });
+
+    expect(prisma.petAtendido.upsert).not.toHaveBeenCalled();
   });
 });

--- a/src/modules/historico/acao-clinica.service.ts
+++ b/src/modules/historico/acao-clinica.service.ts
@@ -52,6 +52,31 @@ export class AcaoClinicaService {
         detalhes: input.detalhes,
       },
     });
+
+    if (input.autorTipo === Role.VET) {
+      await this.manterNaListaDoVet(input.autorId, input.petId, tx);
+    }
+  }
+
+  /**
+   * Garante que o pet está na lista do veterinário que acabou de agir sobre
+   * ele, e marca o atendimento como o mais recente.
+   *
+   * Todo caminho de escrita clínica passa por aqui, então é o único ponto
+   * que precisa saber disso. Sem ele, um veterinário poderia registrar uma
+   * vacina num pet ausente do próprio dashboard — o defeito que o vínculo
+   * explícito veio corrigir.
+   */
+  private async manterNaListaDoVet(
+    veterinarioId: string,
+    petId: string,
+    tx: PrismaLike,
+  ): Promise<void> {
+    await tx.petAtendido.upsert({
+      where: { veterinarioId_petId: { veterinarioId, petId } },
+      create: { veterinarioId, petId },
+      update: { ultimoAcessoEm: new Date() },
+    });
   }
 
   /**

--- a/src/modules/veterinario/__tests__/dashboard.service.spec.ts
+++ b/src/modules/veterinario/__tests__/dashboard.service.spec.ts
@@ -1,3 +1,4 @@
+import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { PrismaService } from '../../../prisma/prisma.service';
 import { VeterinarioService } from '../veterinario.service';
@@ -12,14 +13,17 @@ jest.mock('bcrypt', () => ({
   },
 }));
 
-describe('VeterinarioService - findAttendedPets', () => {
+describe('VeterinarioService - lista de pets atendidos', () => {
   let service: VeterinarioService;
   let prisma: {
-    notaClinica: { findMany: jest.Mock };
-    vaccineRecord: { findMany: jest.Mock };
-    dewormingRecord: { findMany: jest.Mock };
-    medicationRecord: { findMany: jest.Mock };
-    pet: { findMany: jest.Mock };
+    petAtendido: {
+      count: jest.Mock;
+      findMany: jest.Mock;
+      findUnique: jest.Mock;
+      upsert: jest.Mock;
+      delete: jest.Mock;
+    };
+    carteiraDigital: { findUnique: jest.Mock };
     veterinario: {
       create: jest.Mock;
       findMany: jest.Mock;
@@ -29,7 +33,12 @@ describe('VeterinarioService - findAttendedPets', () => {
     };
   };
 
-  const petFixture = {
+  const vinculo = (
+    pet: Record<string, unknown>,
+    ultimoAcessoEm = new Date('2026-08-18T10:00:00Z'),
+  ) => ({ id: `v-${String(pet.id)}`, ultimoAcessoEm, pet });
+
+  const rex = {
     id: 'pet-1',
     name: 'Rex',
     species: 'DOG',
@@ -39,7 +48,7 @@ describe('VeterinarioService - findAttendedPets', () => {
     tutor: { name: 'Alice' },
   };
 
-  const petFixture2 = {
+  const mimi = {
     id: 'pet-2',
     name: 'Mimi',
     species: 'CAT',
@@ -51,12 +60,14 @@ describe('VeterinarioService - findAttendedPets', () => {
 
   beforeEach(async () => {
     prisma = {
-      notaClinica: { findMany: jest.fn() },
-      // O dashboard agora reúne os quatro tipos de registro (web#34).
-      vaccineRecord: { findMany: jest.fn().mockResolvedValue([]) },
-      dewormingRecord: { findMany: jest.fn().mockResolvedValue([]) },
-      medicationRecord: { findMany: jest.fn().mockResolvedValue([]) },
-      pet: { findMany: jest.fn() },
+      petAtendido: {
+        count: jest.fn().mockResolvedValue(0),
+        findMany: jest.fn().mockResolvedValue([]),
+        findUnique: jest.fn().mockResolvedValue(null),
+        upsert: jest.fn(),
+        delete: jest.fn(),
+      },
+      carteiraDigital: { findUnique: jest.fn() },
       veterinario: {
         create: jest.fn(),
         findMany: jest.fn(),
@@ -76,137 +87,174 @@ describe('VeterinarioService - findAttendedPets', () => {
     service = module.get<VeterinarioService>(VeterinarioService);
   });
 
-  it('should return pets attended by the authenticated vet', async () => {
-    prisma.notaClinica.findMany.mockResolvedValue([
-      { petId: 'pet-1', createdAt: new Date('2026-05-30') },
-    ]);
-    prisma.pet.findMany.mockResolvedValue([petFixture]);
+  describe('findAttendedPets', () => {
+    it('lista os pets vinculados ao veterinário autenticado', async () => {
+      prisma.petAtendido.count.mockResolvedValue(1);
+      prisma.petAtendido.findMany.mockResolvedValue([vinculo(rex)]);
 
-    const result = await service.findAttendedPets('vet-1', {});
+      const result = await service.findAttendedPets('vet-1', {});
 
-    expect(result.items).toHaveLength(1);
-    expect(result.items[0].name).toBe('Rex');
-    expect(result.items[0].tutor_name).toBe('Alice');
-    expect(result.total).toBe(1);
-    expect(prisma.notaClinica.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        // Nota excluída não traz o pet de volta ao dashboard (api#117).
-        where: { veterinarioId: 'vet-1', deletedAt: null },
-      }),
-    );
-  });
-
-  it('should not return pets from another vet', async () => {
-    prisma.notaClinica.findMany.mockResolvedValue([]);
-
-    const result = await service.findAttendedPets('vet-other', {});
-
-    expect(result.items).toHaveLength(0);
-    expect(result.total).toBe(0);
-  });
-
-  it('should search by pet name', async () => {
-    prisma.notaClinica.findMany.mockResolvedValue([
-      { petId: 'pet-1', createdAt: new Date('2026-05-30') },
-    ]);
-    prisma.pet.findMany.mockResolvedValue([petFixture]);
-
-    const result = await service.findAttendedPets('vet-1', { search: 'Rex' });
-
-    expect(result.items).toHaveLength(1);
-
-    const [[chamada]] = prisma.notaClinica.findMany.mock.calls as Array<
-      [{ where: { pet?: { OR?: unknown[] } } }]
-    >;
-    // A busca passou a filtrar pelo pet, não por campos da nota.
-    expect(chamada.where.pet?.OR).toBeDefined();
-  });
-
-  it('should search by tutor name', async () => {
-    prisma.notaClinica.findMany.mockResolvedValue([
-      { petId: 'pet-2', createdAt: new Date('2026-05-28') },
-    ]);
-    prisma.pet.findMany.mockResolvedValue([petFixture2]);
-
-    const result = await service.findAttendedPets('vet-1', { search: 'Bob' });
-
-    expect(result.items).toHaveLength(1);
-    expect(result.items[0].tutor_name).toBe('Bob');
-  });
-
-  it('should paginate results', async () => {
-    prisma.notaClinica.findMany.mockResolvedValue([
-      { petId: 'pet-1', createdAt: new Date('2026-05-30') },
-      { petId: 'pet-2', createdAt: new Date('2026-05-28') },
-    ]);
-    prisma.pet.findMany.mockResolvedValue([petFixture]);
-
-    const result = await service.findAttendedPets('vet-1', {
-      page: 1,
-      pageSize: 1,
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].name).toBe('Rex');
+      expect(result.items[0].tutor_name).toBe('Alice');
+      expect(result.total).toBe(1);
+      const [[chamada]] = prisma.petAtendido.findMany.mock.calls as Array<
+        [{ where: { veterinarioId: string } }]
+      >;
+      expect(chamada.where.veterinarioId).toBe('vet-1');
     });
 
-    expect(result.items).toHaveLength(1);
-    expect(result.total).toBe(2);
-    expect(result.totalPages).toBe(2);
-    expect(result.page).toBe(1);
-    expect(result.pageSize).toBe(1);
+    it('mantém o pet na lista mesmo sem registro clínico vivo', async () => {
+      // O defeito que motivou o vínculo: a lista era derivada dos registros,
+      // então o veterinário que apagasse os próprios via o pet sumir.
+      prisma.petAtendido.count.mockResolvedValue(1);
+      prisma.petAtendido.findMany.mockResolvedValue([vinculo(rex)]);
+
+      const result = await service.findAttendedPets('vet-1', {});
+
+      expect(result.items).toHaveLength(1);
+      const [[chamada]] = prisma.petAtendido.findMany.mock.calls as Array<
+        [{ where: Record<string, unknown> }]
+      >;
+      expect(chamada.where).not.toHaveProperty('deletedAt');
+    });
+
+    it('não devolve pet de outro veterinário', async () => {
+      const result = await service.findAttendedPets('vet-other', {});
+
+      expect(result.items).toHaveLength(0);
+      expect(result.total).toBe(0);
+    });
+
+    it('busca por nome do pet', async () => {
+      prisma.petAtendido.count.mockResolvedValue(1);
+      prisma.petAtendido.findMany.mockResolvedValue([vinculo(rex)]);
+
+      const result = await service.findAttendedPets('vet-1', { search: 'Rex' });
+
+      expect(result.items).toHaveLength(1);
+      const [[chamada]] = prisma.petAtendido.findMany.mock.calls as Array<
+        [{ where: { pet?: { OR?: unknown[] } } }]
+      >;
+      expect(chamada.where.pet?.OR).toHaveLength(2);
+    });
+
+    it('busca por nome do tutor', async () => {
+      prisma.petAtendido.count.mockResolvedValue(1);
+      prisma.petAtendido.findMany.mockResolvedValue([vinculo(mimi)]);
+
+      const result = await service.findAttendedPets('vet-1', { search: 'Bob' });
+
+      expect(result.items[0].tutor_name).toBe('Bob');
+    });
+
+    it('pagina o resultado', async () => {
+      prisma.petAtendido.count.mockResolvedValue(2);
+      prisma.petAtendido.findMany.mockResolvedValue([vinculo(rex)]);
+
+      const result = await service.findAttendedPets('vet-1', {
+        page: 1,
+        pageSize: 1,
+      });
+
+      expect(result.items).toHaveLength(1);
+      expect(result.total).toBe(2);
+      expect(result.totalPages).toBe(2);
+      expect(prisma.petAtendido.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ skip: 0, take: 1 }),
+      );
+    });
+
+    it('ordena pelo atendimento mais recente', async () => {
+      prisma.petAtendido.count.mockResolvedValue(1);
+      prisma.petAtendido.findMany.mockResolvedValue([
+        vinculo(rex, new Date('2026-08-19T09:00:00Z')),
+      ]);
+
+      const result = await service.findAttendedPets('vet-1', {});
+
+      expect(result.items[0].last_attended_at).toEqual(
+        new Date('2026-08-19T09:00:00Z'),
+      );
+      expect(prisma.petAtendido.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ orderBy: { ultimoAcessoEm: 'desc' } }),
+      );
+    });
+
+    it('devolve lista vazia quando o veterinário não atendeu ninguém', async () => {
+      const result = await service.findAttendedPets('vet-1', {});
+
+      expect(result.items).toHaveLength(0);
+      expect(result.totalPages).toBe(1);
+    });
   });
 
-  it('should return empty list when no notes exist', async () => {
-    prisma.notaClinica.findMany.mockResolvedValue([]);
+  describe('adicionarPetPorToken', () => {
+    beforeEach(() => {
+      prisma.carteiraDigital.findUnique.mockResolvedValue({
+        petId: 'pet-1',
+        pet: { id: 'pet-1', name: 'Rex' },
+      });
+      prisma.petAtendido.upsert.mockResolvedValue({
+        id: 'v-1',
+        createdAt: new Date('2026-08-19T12:00:00Z'),
+      });
+    });
 
-    const result = await service.findAttendedPets('vet-1', {});
+    it('vincula o pet ao veterinário que leu o QR', async () => {
+      const result = await service.adicionarPetPorToken('vet-1', 'token-abc');
 
-    expect(result.items).toHaveLength(0);
-    expect(result.total).toBe(0);
+      expect(result).toMatchObject({
+        pet_id: 'pet-1',
+        pet_nome: 'Rex',
+        novo: true,
+      });
+      expect(prisma.petAtendido.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          create: { veterinarioId: 'vet-1', petId: 'pet-1' },
+        }),
+      );
+    });
+
+    it('reabrir a carteira não duplica: só atualiza o atendimento', async () => {
+      prisma.petAtendido.findUnique.mockResolvedValue({ id: 'v-1' });
+
+      const result = await service.adicionarPetPorToken('vet-1', 'token-abc');
+
+      expect(result.novo).toBe(false);
+      const [[chamada]] = prisma.petAtendido.upsert.mock.calls as Array<
+        [{ update: { ultimoAcessoEm: Date } }]
+      >;
+      expect(chamada.update.ultimoAcessoEm).toBeInstanceOf(Date);
+    });
+
+    it('404 quando o token não corresponde a nenhuma carteira', async () => {
+      prisma.carteiraDigital.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.adicionarPetPorToken('vet-1', 'token-inexistente'),
+      ).rejects.toThrow(NotFoundException);
+      expect(prisma.petAtendido.upsert).not.toHaveBeenCalled();
+    });
   });
-  it('traz o pet em que o veterinário só aplicou vacina, sem nota', async () => {
-    prisma.notaClinica.findMany.mockResolvedValue([]);
-    prisma.vaccineRecord.findMany.mockResolvedValue([
-      { petId: 'pet-1', createdAt: new Date('2026-08-18T10:00:00Z') },
-    ]);
-    prisma.pet.findMany.mockResolvedValue([
-      {
-        id: 'pet-1',
-        name: 'Rex',
-        species: 'DOG',
-        breed: null,
-        photoUrl: null,
-        tutor: { name: 'Ana Silva' },
-      },
-    ]);
 
-    const result = await service.findAttendedPets('vet-1', {});
+  describe('removerPetAtendido', () => {
+    it('tira o pet da lista sem tocar no pet nem nos registros', async () => {
+      prisma.petAtendido.findUnique.mockResolvedValue({ id: 'v-1' });
 
-    // Antes o dashboard olhava só a nota clínica: quem registrava apenas uma
-    // vacina perdia o pet da própria lista (web#34).
-    expect(result.items).toHaveLength(1);
-    expect(result.items[0].name).toBe('Rex');
-  });
+      await service.removerPetAtendido('vet-1', 'pet-1');
 
-  it('usa o atendimento mais recente entre os tipos de registro', async () => {
-    prisma.notaClinica.findMany.mockResolvedValue([
-      { petId: 'pet-1', createdAt: new Date('2026-08-10T10:00:00Z') },
-    ]);
-    prisma.medicationRecord.findMany.mockResolvedValue([
-      { petId: 'pet-1', createdAt: new Date('2026-08-18T10:00:00Z') },
-    ]);
-    prisma.pet.findMany.mockResolvedValue([
-      {
-        id: 'pet-1',
-        name: 'Rex',
-        species: 'DOG',
-        breed: null,
-        photoUrl: null,
-        tutor: { name: 'Ana Silva' },
-      },
-    ]);
+      // Some o vínculo e só ele: o histórico clínico continua (api#117).
+      expect(prisma.petAtendido.delete).toHaveBeenCalledWith({
+        where: { id: 'v-1' },
+      });
+    });
 
-    const result = await service.findAttendedPets('vet-1', {});
-
-    expect(result.items[0].last_attended_at).toEqual(
-      new Date('2026-08-18T10:00:00Z'),
-    );
+    it('404 quando o pet não está na lista do veterinário', async () => {
+      await expect(
+        service.removerPetAtendido('vet-1', 'pet-alheio'),
+      ).rejects.toThrow(NotFoundException);
+      expect(prisma.petAtendido.delete).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/modules/veterinario/__tests__/veterinario.controller.spec.ts
+++ b/src/modules/veterinario/__tests__/veterinario.controller.spec.ts
@@ -20,8 +20,14 @@ describe('VeterinarioController (integração)', () => {
       update: jest.Mock;
       delete: jest.Mock;
     };
-    notaClinica: { findMany: jest.Mock };
-    pet: { findMany: jest.Mock };
+    petAtendido: {
+      count: jest.Mock;
+      findMany: jest.Mock;
+      findUnique: jest.Mock;
+      upsert: jest.Mock;
+      delete: jest.Mock;
+    };
+    carteiraDigital: { findUnique: jest.Mock };
   };
   let crmv: { getStatus: jest.Mock; verify: jest.Mock };
 
@@ -45,11 +51,14 @@ describe('VeterinarioController (integração)', () => {
         update: jest.fn(),
         delete: jest.fn(),
       },
-      notaClinica: { findMany: jest.fn() },
-      vaccineRecord: { findMany: jest.fn().mockResolvedValue([]) },
-      dewormingRecord: { findMany: jest.fn().mockResolvedValue([]) },
-      medicationRecord: { findMany: jest.fn().mockResolvedValue([]) },
-      pet: { findMany: jest.fn() },
+      petAtendido: {
+        count: jest.fn().mockResolvedValue(0),
+        findMany: jest.fn().mockResolvedValue([]),
+        findUnique: jest.fn().mockResolvedValue(null),
+        upsert: jest.fn(),
+        delete: jest.fn(),
+      },
+      carteiraDigital: { findUnique: jest.fn() },
     };
     crmv = {
       getStatus: jest.fn().mockResolvedValue({ verified: false }),
@@ -117,17 +126,19 @@ describe('VeterinarioController (integração)', () => {
 
   describe('GET /veterinarios/dashboard/pets', () => {
     it('retorna os pets atendidos paginados (200)', async () => {
-      prisma.notaClinica.findMany.mockResolvedValue([
-        { petId: 'pet-1', createdAt: new Date('2026-02-01') },
-      ]);
-      prisma.pet.findMany.mockResolvedValue([
+      prisma.petAtendido.count.mockResolvedValue(1);
+      prisma.petAtendido.findMany.mockResolvedValue([
         {
-          id: 'pet-1',
-          name: 'Rex',
-          species: 'DOG',
-          breed: null,
-          photoUrl: null,
-          tutor: { name: 'Alice' },
+          id: 'v-1',
+          ultimoAcessoEm: new Date('2026-02-01'),
+          pet: {
+            id: 'pet-1',
+            name: 'Rex',
+            species: 'DOG',
+            breed: null,
+            photoUrl: null,
+            tutor: { name: 'Alice' },
+          },
         },
       ]);
 
@@ -143,6 +154,67 @@ describe('VeterinarioController (integração)', () => {
       await request(harness.app.getHttpServer())
         .get('/veterinarios/dashboard/pets?page=0')
         .expect(400);
+    });
+  });
+
+  describe('POST /veterinarios/me/pets', () => {
+    beforeEach(() => {
+      crmv.getStatus.mockResolvedValue({ verified: true });
+      prisma.carteiraDigital.findUnique.mockResolvedValue({
+        petId: 'pet-1',
+        pet: { id: 'pet-1', name: 'Rex' },
+      });
+      prisma.petAtendido.upsert.mockResolvedValue({
+        id: 'v-1',
+        createdAt: new Date('2026-08-19'),
+      });
+    });
+
+    it('adiciona o pet lido no QR à lista do veterinário (200)', async () => {
+      const res = await request(harness.app.getHttpServer())
+        .post('/veterinarios/me/pets')
+        .send({ token: 'token-abc' })
+        .expect(200);
+
+      expect(res.body).toMatchObject({ pet_id: 'pet-1', novo: true });
+    });
+
+    it('recusa veterinário sem CRMV verificado (403)', async () => {
+      crmv.getStatus.mockResolvedValue({ verified: false });
+
+      await request(harness.app.getHttpServer())
+        .post('/veterinarios/me/pets')
+        .send({ token: 'token-abc' })
+        .expect(403);
+    });
+
+    it('rejeita corpo sem token (400)', async () => {
+      await request(harness.app.getHttpServer())
+        .post('/veterinarios/me/pets')
+        .send({})
+        .expect(400);
+    });
+  });
+
+  describe('DELETE /veterinarios/me/pets/:petId', () => {
+    it('tira o pet da lista (204)', async () => {
+      prisma.petAtendido.findUnique.mockResolvedValue({ id: 'v-1' });
+
+      await request(harness.app.getHttpServer())
+        .delete('/veterinarios/me/pets/pet-1')
+        .expect(204);
+
+      expect(prisma.petAtendido.delete).toHaveBeenCalled();
+    });
+
+    it('404 quando o pet não está na lista', async () => {
+      // clearAllMocks zera chamadas, não implementações: sem isto o vínculo
+      // do teste anterior continuaria valendo.
+      prisma.petAtendido.findUnique.mockResolvedValue(null);
+
+      await request(harness.app.getHttpServer())
+        .delete('/veterinarios/me/pets/pet-alheio')
+        .expect(404);
     });
   });
 

--- a/src/modules/veterinario/veterinario.controller.ts
+++ b/src/modules/veterinario/veterinario.controller.ts
@@ -12,15 +12,21 @@ import {
 } from '@nestjs/common';
 import {
   ApiNotFoundResponse,
+  ApiOkResponse,
   ApiOperation,
   ApiQuery,
   ApiTags,
 } from '@nestjs/swagger';
 import { Auth } from '../auth/decorators/auth.decorator';
+import { AuthCrmvVerificado } from './crmv/auth-crmv.decorator';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { Role } from '../auth/enums/role.enum';
 import type { JwtPayload } from '../auth/strategies/jwt.strategy';
-import { UpdateVeterinarioDto } from '@petcardorg/shared';
+import {
+  AdicionarPetAtendidoDto,
+  PetAtendidoResponseDto,
+  UpdateVeterinarioDto,
+} from '@petcardorg/shared';
 import { DashboardQueryDto } from './dto/dashboard-query.dto';
 import {
   CrmvVerificationService,
@@ -78,6 +84,42 @@ export class VeterinarioController {
     @Query() query: DashboardQueryDto,
   ): Promise<PaginatedResponse<DashboardPetItem>> {
     return this.veterinarioService.findAttendedPets(user.sub, query);
+  }
+
+  @Post('me/pets')
+  @AuthCrmvVerificado(Role.VET)
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Adicionar à minha lista o pet cuja carteira foi lida no QR',
+    description:
+      'Ter o token do QR é a autorização de fato para o atendimento. Reabrir ' +
+      'a carteira de um pet que já está na lista só atualiza o último ' +
+      'atendimento. Exige CRMV verificado, como o acesso à carteira clínica.',
+  })
+  @ApiOkResponse({ type: PetAtendidoResponseDto })
+  @ApiNotFoundResponse({ description: 'Carteira não encontrada' })
+  async adicionarPet(
+    @CurrentUser() user: JwtPayload,
+    @Body() dto: AdicionarPetAtendidoDto,
+  ): Promise<PetAtendidoResponseDto> {
+    return this.veterinarioService.adicionarPetPorToken(user.sub, dto.token);
+  }
+
+  @Delete('me/pets/:petId')
+  @Auth(Role.VET)
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({
+    summary: 'Tirar o pet da minha lista',
+    description:
+      'Remove só o vínculo. O pet, os registros clínicos e a trilha de ações ' +
+      'permanecem — inclusive para outros veterinários.',
+  })
+  @ApiNotFoundResponse({ description: 'Pet não está na lista' })
+  async removerPet(
+    @CurrentUser() user: JwtPayload,
+    @Param('petId') petId: string,
+  ): Promise<void> {
+    return this.veterinarioService.removerPetAtendido(user.sub, petId);
   }
 
   @Get()

--- a/src/modules/veterinario/veterinario.service.ts
+++ b/src/modules/veterinario/veterinario.service.ts
@@ -5,7 +5,10 @@ import {
 } from '@nestjs/common';
 import { Prisma, Veterinario } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
-import { UpdateVeterinarioDto } from '@petcardorg/shared';
+import {
+  PetAtendidoResponseDto,
+  UpdateVeterinarioDto,
+} from '@petcardorg/shared';
 import { DashboardQueryDto } from './dto/dashboard-query.dto';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -91,6 +94,13 @@ export class VeterinarioService {
     await this.prisma.veterinario.delete({ where: { id } });
   }
 
+  /**
+   * Lista os pets vinculados a este veterinário.
+   *
+   * A lista era derivada dos registros clínicos vivos, então o veterinário
+   * que apagasse o próprio registro via o pet sumir do dashboard. Agora o
+   * vínculo é um fato guardado: entra pelo QR, sai só por remoção explícita.
+   */
   async findAttendedPets(
     veterinarioId: string,
     query: DashboardQueryDto,
@@ -99,91 +109,106 @@ export class VeterinarioService {
     const pageSize = query.pageSize ?? 10;
     const search = query.search?.trim();
 
-    /**
-     * O dashboard reúne todo pet que este veterinário atendeu, não só aquele
-     * em que escreveu nota (web#34). Desde que ele passou a registrar vacina,
-     * vermifugação e medicação pela tela, olhar apenas a nota clínica fazia o
-     * pet sumir da lista de quem tinha acabado de ser atendido.
-     *
-     * Registro excluído não traz o pet de volta: o filtro é sobre o que está
-     * vivo, mantendo a decisão da api#117.
-     */
-    const filtroPet: Prisma.PetWhereInput | undefined = search
-      ? {
-          OR: [
-            { name: { contains: search, mode: 'insensitive' } },
-            { tutor: { name: { contains: search, mode: 'insensitive' } } },
-          ],
-        }
-      : undefined;
-
-    const base = {
+    const where: Prisma.PetAtendidoWhereInput = {
       veterinarioId,
-      deletedAt: null,
-      ...(filtroPet ? { pet: filtroPet } : {}),
-    };
-    const selecao = {
-      distinct: ['petId'] as ['petId'],
-      orderBy: { createdAt: 'desc' as const },
-      select: { petId: true, createdAt: true },
+      ...(search
+        ? {
+            pet: {
+              OR: [
+                { name: { contains: search, mode: 'insensitive' } },
+                { tutor: { name: { contains: search, mode: 'insensitive' } } },
+              ],
+            },
+          }
+        : {}),
     };
 
-    const [notas, vacinas, vermifugos, medicacoes] = await Promise.all([
-      this.prisma.notaClinica.findMany({ where: base, ...selecao }),
-      this.prisma.vaccineRecord.findMany({ where: base, ...selecao }),
-      this.prisma.dewormingRecord.findMany({ where: base, ...selecao }),
-      this.prisma.medicationRecord.findMany({ where: base, ...selecao }),
+    const [total, vinculos] = await Promise.all([
+      this.prisma.petAtendido.count({ where }),
+      this.prisma.petAtendido.findMany({
+        where,
+        orderBy: { ultimoAcessoEm: 'desc' },
+        skip: (page - 1) * pageSize,
+        take: pageSize,
+        include: { pet: { include: { tutor: { select: { name: true } } } } },
+      }),
     ]);
 
-    // Um pet pode ter registros de tipos diferentes; vale o atendimento mais
-    // recente entre eles.
-    const maisRecentePorPet = new Map<string, Date>();
-    for (const r of [...notas, ...vacinas, ...vermifugos, ...medicacoes]) {
-      const atual = maisRecentePorPet.get(r.petId);
-      if (!atual || r.createdAt > atual) {
-        maisRecentePorPet.set(r.petId, r.createdAt);
-      }
-    }
-
-    const distinctPetIds = [...maisRecentePorPet.entries()]
-      .map(([petId, createdAt]) => ({ petId, createdAt }))
-      .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
-
-    const total = distinctPetIds.length;
-    const totalPages = Math.ceil(total / pageSize) || 1;
-    const skip = (page - 1) * pageSize;
-
-    const paginatedPetIds = distinctPetIds.slice(skip, skip + pageSize);
-
-    if (paginatedPetIds.length === 0) {
-      return { items: [], total, page, pageSize, totalPages };
-    }
-
-    const lastAttendedMap = new Map(
-      paginatedPetIds.map((n) => [n.petId, n.createdAt]),
-    );
-
-    const pets = await this.prisma.pet.findMany({
-      where: { id: { in: paginatedPetIds.map((n) => n.petId) } },
-      include: { tutor: { select: { name: true } } },
-    });
-
-    const items: DashboardPetItem[] = [];
-    for (const n of paginatedPetIds) {
-      const pet = pets.find((p) => p.id === n.petId);
-      if (!pet) continue;
-      items.push({
+    const items: DashboardPetItem[] = vinculos.map(
+      ({ pet, ultimoAcessoEm }) => ({
         id: pet.id,
         name: pet.name,
         species: pet.species,
         breed: pet.breed ?? undefined,
         photo_url: pet.photoUrl ?? undefined,
         tutor_name: pet.tutor.name,
-        last_attended_at: lastAttendedMap.get(pet.id)!,
-      });
+        last_attended_at: ultimoAcessoEm,
+      }),
+    );
+
+    return {
+      items,
+      total,
+      page,
+      pageSize,
+      totalPages: Math.ceil(total / pageSize) || 1,
+    };
+  }
+
+  /**
+   * Vincula ao veterinário o pet cuja carteira foi aberta pelo QR.
+   *
+   * Ter o token é a autorização de fato: quem o leu esteve com o pet na
+   * frente. Reabrir a carteira de um pet que já está na lista não duplica
+   * nada — só atualiza o último atendimento, que ordena o dashboard.
+   */
+  async adicionarPetPorToken(
+    veterinarioId: string,
+    token: string,
+  ): Promise<PetAtendidoResponseDto> {
+    const carteira = await this.prisma.carteiraDigital.findUnique({
+      where: { token },
+      include: { pet: { select: { id: true, name: true } } },
+    });
+    if (!carteira) {
+      throw new NotFoundException('Carteira não encontrada');
     }
 
-    return { items, total, page, pageSize, totalPages };
+    const existente = await this.prisma.petAtendido.findUnique({
+      where: { veterinarioId_petId: { veterinarioId, petId: carteira.petId } },
+    });
+
+    const vinculo = await this.prisma.petAtendido.upsert({
+      where: { veterinarioId_petId: { veterinarioId, petId: carteira.petId } },
+      create: { veterinarioId, petId: carteira.petId },
+      update: { ultimoAcessoEm: new Date() },
+    });
+
+    return {
+      pet_id: carteira.pet.id,
+      pet_nome: carteira.pet.name,
+      adicionado_em: vinculo.createdAt,
+      novo: existente === null,
+    };
+  }
+
+  /**
+   * Tira o pet da lista do veterinário.
+   *
+   * Some o vínculo, não o pet nem o que foi registrado nele: o histórico
+   * clínico e a trilha de ações continuam intactos (api#117).
+   */
+  async removerPetAtendido(
+    veterinarioId: string,
+    petId: string,
+  ): Promise<void> {
+    const vinculo = await this.prisma.petAtendido.findUnique({
+      where: { veterinarioId_petId: { veterinarioId, petId } },
+    });
+    if (!vinculo) {
+      throw new NotFoundException('Pet não está na lista deste veterinário');
+    }
+    await this.prisma.petAtendido.delete({ where: { id: vinculo.id } });
   }
 
   private async assertUniqueFields(

--- a/test/e2e/pets-atendidos.e2e-spec.ts
+++ b/test/e2e/pets-atendidos.e2e-spec.ts
@@ -1,0 +1,178 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import type { INestApplication } from '@nestjs/common';
+import type { App } from 'supertest/types';
+import request from 'supertest';
+import { createE2EApp, E2EApp } from '../utils/e2e-app';
+import { createAndLoginVet, registerTutor, resetDb } from '../utils/e2e-db';
+import { PrismaService } from '../../src/prisma/prisma.service';
+
+/**
+ * Lista de pets do veterinário (vínculo explícito).
+ *
+ * Antes o dashboard era derivado dos registros clínicos vivos: apagar o
+ * próprio registro fazia o pet sumir da lista, e sem scanner na web não havia
+ * como trazer um pet novo. Estes testes exercitam o caminho que substituiu
+ * isso — entra pelo token do QR, sai só por remoção explícita.
+ */
+describe('Pets atendidos pelo veterinário (e2e)', () => {
+  let ctx: E2EApp;
+  let app: INestApplication<App>;
+  let prisma: PrismaService;
+  let tutorToken: string;
+  let vetToken: string;
+  let petId: string;
+
+  const TOKEN_QR = 'qr-token-rex';
+
+  beforeAll(async () => {
+    ctx = await createE2EApp();
+    ({ app, prisma } = ctx);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(async () => {
+    await resetDb(prisma);
+    ({ token: tutorToken } = await registerTutor(app));
+    ({ token: vetToken } = await createAndLoginVet(app, prisma));
+
+    const pet = await request(app.getHttpServer())
+      .post('/pets')
+      .set('Authorization', `Bearer ${tutorToken}`)
+      .send({ name: 'Rex', species: 'DOG', sex: 'MALE' })
+      .expect(201);
+    petId = pet.body.id as string;
+
+    await prisma.carteiraDigital.create({
+      data: { petId, token: TOKEN_QR },
+    });
+  });
+
+  function adicionarPeloQr(token = TOKEN_QR) {
+    return request(app.getHttpServer())
+      .post('/veterinarios/me/pets')
+      .set('Authorization', `Bearer ${vetToken}`)
+      .send({ token });
+  }
+
+  async function listarDashboard() {
+    const res = await request(app.getHttpServer())
+      .get('/veterinarios/dashboard/pets')
+      .set('Authorization', `Bearer ${vetToken}`)
+      .expect(200);
+    return res.body as { total: number; items: { id: string }[] };
+  }
+
+  async function aplicarVacina(): Promise<string> {
+    const res = await request(app.getHttpServer())
+      .post(`/pets/${petId}/vaccines`)
+      .set('Authorization', `Bearer ${vetToken}`)
+      .send({
+        pet_id: petId,
+        vaccine_name: 'Antirrábica',
+        applied_at: '2026-08-19',
+      })
+      .expect(201);
+    return res.body.id as string;
+  }
+
+  it('o pet entra na lista ao abrir a carteira pelo token do QR', async () => {
+    expect((await listarDashboard()).total).toBe(0);
+
+    const res = await adicionarPeloQr().expect(200);
+    expect(res.body).toMatchObject({ pet_id: petId, novo: true });
+
+    const dashboard = await listarDashboard();
+    expect(dashboard.total).toBe(1);
+    expect(dashboard.items[0].id).toBe(petId);
+  });
+
+  it('reabrir a carteira não duplica o pet na lista', async () => {
+    await adicionarPeloQr().expect(200);
+    const segunda = await adicionarPeloQr().expect(200);
+
+    expect(segunda.body.novo).toBe(false);
+    expect((await listarDashboard()).total).toBe(1);
+  });
+
+  it('o pet continua na lista depois de apagar o registro que o vet fez', async () => {
+    // Era exatamente o defeito: a lista vinha dos registros vivos.
+    await adicionarPeloQr().expect(200);
+    const vacinaId = await aplicarVacina();
+
+    await request(app.getHttpServer())
+      .delete(`/vaccines/${vacinaId}`)
+      .set('Authorization', `Bearer ${vetToken}`)
+      .expect(204);
+
+    const dashboard = await listarDashboard();
+    expect(dashboard.total).toBe(1);
+    expect(dashboard.items[0].id).toBe(petId);
+  });
+
+  it('registrar no pet o traz para a lista mesmo sem passar pelo QR', async () => {
+    await aplicarVacina();
+
+    expect((await listarDashboard()).total).toBe(1);
+  });
+
+  it('o pet sai da lista só quando o veterinário remove', async () => {
+    await adicionarPeloQr().expect(200);
+
+    await request(app.getHttpServer())
+      .delete(`/veterinarios/me/pets/${petId}`)
+      .set('Authorization', `Bearer ${vetToken}`)
+      .expect(204);
+
+    expect((await listarDashboard()).total).toBe(0);
+
+    // Some o vínculo, não o pet nem o que foi registrado nele.
+    const pet = await prisma.pet.findUnique({ where: { id: petId } });
+    expect(pet).not.toBeNull();
+  });
+
+  it('remover pet que não está na lista devolve 404', async () => {
+    await request(app.getHttpServer())
+      .delete(`/veterinarios/me/pets/${petId}`)
+      .set('Authorization', `Bearer ${vetToken}`)
+      .expect(404);
+  });
+
+  it('token inexistente não vincula nada (404)', async () => {
+    await adicionarPeloQr('token-que-nao-existe').expect(404);
+
+    expect((await listarDashboard()).total).toBe(0);
+  });
+
+  it('a lista de um veterinário não vaza para outro', async () => {
+    await adicionarPeloQr().expect(200);
+
+    const { token: outroVet } = await createAndLoginVet(app, prisma, {
+      email: 'outro@petcard.com',
+      crmv: 'CRMV-CE-9999',
+    });
+
+    const res = await request(app.getHttpServer())
+      .get('/veterinarios/dashboard/pets')
+      .set('Authorization', `Bearer ${outroVet}`)
+      .expect(200);
+
+    expect(res.body.total).toBe(0);
+  });
+
+  it('veterinário sem CRMV verificado não adiciona pet pelo QR (403)', async () => {
+    const { token: semCrmv } = await createAndLoginVet(app, prisma, {
+      email: 'sem-crmv@petcard.com',
+      crmv: 'CRMV-CE-5555',
+      crmvVerificado: false,
+    });
+
+    await request(app.getHttpServer())
+      .post('/veterinarios/me/pets')
+      .set('Authorization', `Bearer ${semCrmv}`)
+      .send({ token: TOKEN_QR })
+      .expect(403);
+  });
+});


### PR DESCRIPTION
Fecha api#130.

## Problema

O dashboard do veterinário era **derivado** dos registros clínicos vivos. Apagar o último registro que se fez num pet tirava o pet da lista — e, como a `VetScanPage` saiu da web na web#34, não havia caminho para trazer um pet novo. Os pets que apareciam vinham do seed.

## O que muda

**Modelo `PetAtendido`** — vínculo vet↔pet, único por par, com `ultimoAcessoEm` ordenando o dashboard. A migration **semeia os vínculos a partir dos registros existentes** (inclusive excluídos: o atendimento aconteceu), senão todo veterinário perderia a lista no deploy.

**Endpoints**

- `POST /veterinarios/me/pets` — recebe o token do QR, vincula o pet. Exige CRMV verificado, como o acesso à carteira clínica (api#113). Reabrir a carteira não duplica: atualiza o último atendimento e devolve `novo: false`.
- `DELETE /veterinarios/me/pets/:petId` — tira o pet da lista. Some só o vínculo; pet, registros e trilha de ações continuam (api#117).

**`AcaoClinicaService.registrar`** passa a manter o vínculo quando quem age é veterinário. É o ponto único por onde toda escrita clínica passa, então evita o caso de registrar uma vacina num pet ausente do próprio dashboard.

**Seed** cria os vínculos: ele grava direto pelo Prisma, sem passar pelos serviços, e sem isso a Dra. Camila abriria a demo com o dashboard vazio.

## Testes

- unit: dashboard lendo do vínculo, busca, paginação, ordenação, adicionar/remover, 404s;
- integração: os dois endpoints novos, incluindo 403 sem CRMV verificado e 400 sem token;
- **e2e novo (`pets-atendidos.e2e-spec.ts`, 9 cenários)** contra Postgres real, entre eles o defeito relatado: o pet continua na lista depois de apagar o registro, e a lista de um veterinário não vaza para outro.

477 unit + 50 e2e passando. Cobertura 86.2/81.3/93.9/87.6, acima da catraca.

Consome `@petcardorg/shared@0.16.0`.