### PR TITLE
fix: preservar o hash na URL pública da carteira

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,9 +71,12 @@ GOOGLE_CALENDAR_CLIENT_SECRET=seu_client_secret
 GOOGLE_CALENDAR_REDIRECT_URI=http://localhost:3000/calendar/callback
 
 # ---------- Carteira Digital (Página Pública) ----------
-# URL base usada no payload do QR Code. O "#" é obrigatório quando o web usa HashRouter.
-# Em dev, aponte para o web local: http://localhost:5173/#/card
-PUBLIC_CARD_BASE_URL=https://card.petcard.app/#
+# URL base do link público e do payload do QR Code.
+# As aspas são obrigatórias: sem elas o dotenv trata o "#" como início de
+# comentário e o valor chega truncado, gerando link sem hash.
+# O "#" também é obrigatório — o web usa HashRouter, e sem ele a rota não resolve.
+# Em dev, aponte para o web local: "http://localhost:5173/#/card"
+PUBLIC_CARD_BASE_URL="https://card.petcard.app/#"
 # Rate-limit da rota pública GET /cards/:token
 PUBLIC_CARD_THROTTLE_TTL_SECONDS=60
 PUBLIC_CARD_THROTTLE_LIMIT=10

--- a/src/modules/card/__tests__/card.service.spec.ts
+++ b/src/modules/card/__tests__/card.service.spec.ts
@@ -2,6 +2,7 @@ import {
   InternalServerErrorException,
   NotFoundException,
 } from '@nestjs/common';
+import { Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import * as QRCode from 'qrcode';
@@ -602,6 +603,34 @@ describe('CardService', () => {
       expect(result.issued_at).toBe(baseDate);
       expect(result.qr_code_url).toBeUndefined();
       expect(result.public_url).toBe('https://card.petcard.app/tok-abc');
+    });
+
+    it('avisa no boot quando a base do link público não tem hash', () => {
+      const aviso = jest
+        .spyOn(Logger.prototype, 'warn')
+        .mockImplementation(() => undefined);
+      // O padrão do repo: base sem "#" costuma ser o dotenv comendo o valor a
+      // partir dele, e o link resultante cai no "não encontrado" do HashRouter.
+      configService.get.mockReturnValue('https://card.petcard.app');
+
+      service.onModuleInit();
+
+      expect(aviso).toHaveBeenCalledWith(
+        expect.stringContaining('PUBLIC_CARD_BASE_URL'),
+      );
+      aviso.mockRestore();
+    });
+
+    it('não avisa quando a base traz o hash', () => {
+      const aviso = jest
+        .spyOn(Logger.prototype, 'warn')
+        .mockImplementation(() => undefined);
+      configService.get.mockReturnValue('https://card.petcard.app/#');
+
+      service.onModuleInit();
+
+      expect(aviso).not.toHaveBeenCalled();
+      aviso.mockRestore();
     });
 
     it('should throw NotFoundException when the pet does not exist', async () => {

--- a/src/modules/card/card.service.ts
+++ b/src/modules/card/card.service.ts
@@ -1,7 +1,9 @@
 import {
   Injectable,
   InternalServerErrorException,
+  Logger,
   NotFoundException,
+  OnModuleInit,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { randomUUID } from 'crypto';
@@ -36,12 +38,35 @@ function isMedicationActive(endDate?: Date | null): boolean {
 }
 
 @Injectable()
-export class CardService {
+export class CardService implements OnModuleInit {
+  private readonly logger = new Logger(CardService.name);
+
   constructor(
     private readonly prisma: PrismaService,
     private readonly configService: ConfigService,
     private readonly tutorService: TutorService,
   ) {}
+
+  /**
+   * Confere a base do link público antes que ela vire QR Code gravado.
+   *
+   * O erro é silencioso de dois jeitos: o web usa HashRouter, então base sem
+   * `#` gera link que cai no "não encontrado"; e o dotenv trata `#` sem aspas
+   * como início de comentário, truncando o valor justamente onde importa. O
+   * QR carrega o endereço dentro da imagem, então um valor errado sobrevive à
+   * correção da variável — só some ao regerar o código.
+   */
+  onModuleInit(): void {
+    const baseUrl = this.publicBaseUrl();
+
+    if (!baseUrl.includes('#')) {
+      this.logger.warn(
+        `PUBLIC_CARD_BASE_URL sem "#" ("${baseUrl}"): o web usa HashRouter e o ` +
+          'link público não vai resolver. Se o valor tem "#" no .env, envolva ' +
+          'em aspas — sem elas o dotenv corta tudo a partir do "#".',
+      );
+    }
+  }
 
   async generateQrCode(token: string): Promise<Buffer> {
     return this.generateBuffer(this.buildPublicUrl(token));
@@ -276,12 +301,15 @@ export class CardService {
     };
   }
 
-  private buildPublicUrl(token: string): string {
-    const baseUrl = this.configService.get<string>(
+  private publicBaseUrl(): string {
+    return this.configService.get<string>(
       'card.publicBaseUrl',
       'https://card.petcard.app/#',
     );
-    return `${baseUrl.replace(/\/+$/, '')}/${token}`;
+  }
+
+  private buildPublicUrl(token: string): string {
+    return `${this.publicBaseUrl().replace(/\/+$/, '')}/${token}`;
   }
 
   private async generateBuffer(data: string): Promise<Buffer> {


### PR DESCRIPTION
Fecha api#132.

## O defeito

`PUBLIC_CARD_BASE_URL=https://card.petcard.app/#` no `.env.example` está sem aspas, e o dotenv trata `#` sem aspas como início de comentário:

```
PUBLIC_CARD_BASE_URL=http://localhost:5173/#/card    →  "http://localhost:5173/"
PUBLIC_CARD_BASE_URL="http://localhost:5173/#/card"  →  "http://localhost:5173/#/card"
```

O valor chega truncado justamente onde importa. O web usa `HashRouter`, então o link resultante (`.../<token>`, sem hash) não bate com rota nenhuma e cai na página de não encontrado. Verificado contra a API local: `public_url` vinha `http://localhost:5173/<token>`, sem o `/#/card` que estava configurado.

Pior: o endereço fica gravado **dentro do PNG do QR Code** quando ele é gerado. Corrigir a variável não conserta QR já emitido — só regerando. E como o `.env.example` é a base de produção, a PC-105 subiria com o link público quebrado.

## O que muda

- **`.env.example`**: valor entre aspas, com nota dizendo que as aspas são obrigatórias e por quê. O comentário ali já avisava que o `#` era obrigatório — o que faltava era o `#` sobreviver ao parse.
- **`CardService.onModuleInit`**: avisa quando a base não tem `#`, apontando as duas causas prováveis (falta do hash ou aspas ausentes). Fica antes de o valor errado virar QR gravado, que é o ponto sem volta.
- `buildPublicUrl` passa a ler a base por `publicBaseUrl()`, compartilhado com a verificação.

## Testes

479 passando. Dois novos: avisa sem hash, cala com hash. Cobertura 86.2/81.3/93.9/87.6, acima da catraca.

## Fora do PR

O `.env` local do Ricardo (não versionado) também foi corrigido. QRs gerados antes da correção continuam apontando para o endereço antigo até serem regerados pelo botão "Regenerar QR" do app.