### PR TITLE
chore: padronizar o link público da carteira em /#/card

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,9 +74,12 @@ GOOGLE_CALENDAR_REDIRECT_URI=http://localhost:3000/calendar/callback
 # URL base do link público e do payload do QR Code.
 # As aspas são obrigatórias: sem elas o dotenv trata o "#" como início de
 # comentário e o valor chega truncado, gerando link sem hash.
-# O "#" também é obrigatório — o web usa HashRouter, e sem ele a rota não resolve.
+# O "#" também é obrigatório — o web usa HashRouter, e sem ele a rota não
+# resolve em hospedagem estática (o host devolve 404 antes do JS carregar).
+# O sufixo "/card" é o formato canônico: a rota curta ("/#/<token>") continua
+# valendo para QR Codes antigos, que trazem o endereço gravado na imagem.
 # Em dev, aponte para o web local: "http://localhost:5173/#/card"
-PUBLIC_CARD_BASE_URL="https://card.petcard.app/#"
+PUBLIC_CARD_BASE_URL="https://card.petcard.app/#/card"
 # Rate-limit da rota pública GET /cards/:token
 PUBLIC_CARD_THROTTLE_TTL_SECONDS=60
 PUBLIC_CARD_THROTTLE_LIMIT=10

--- a/src/config/__tests__/config.spec.ts
+++ b/src/config/__tests__/config.spec.ts
@@ -146,7 +146,7 @@ describe('config factories', () => {
   describe('cardConfig', () => {
     it('should apply the public card defaults', () => {
       expect(cardConfig()).toEqual({
-        publicBaseUrl: 'https://card.petcard.app/#',
+        publicBaseUrl: 'https://card.petcard.app/#/card',
         publicThrottleTtlSeconds: 60,
         publicThrottleLimit: 10,
       });

--- a/src/config/card.config.ts
+++ b/src/config/card.config.ts
@@ -2,7 +2,7 @@ import { registerAs } from '@nestjs/config';
 
 export const cardConfig = registerAs('card', () => ({
   publicBaseUrl:
-    process.env.PUBLIC_CARD_BASE_URL ?? 'https://card.petcard.app/#',
+    process.env.PUBLIC_CARD_BASE_URL ?? 'https://card.petcard.app/#/card',
   publicThrottleTtlSeconds: Number(
     process.env.PUBLIC_CARD_THROTTLE_TTL_SECONDS ?? 60,
   ),

--- a/src/modules/card/card.service.ts
+++ b/src/modules/card/card.service.ts
@@ -50,10 +50,13 @@ export class CardService implements OnModuleInit {
   /**
    * Confere a base do link público antes que ela vire QR Code gravado.
    *
-   * O erro é silencioso de dois jeitos: o web usa HashRouter, então base sem
-   * `#` gera link que cai no "não encontrado"; e o dotenv trata `#` sem aspas
-   * como início de comentário, truncando o valor justamente onde importa. O
-   * QR carrega o endereço dentro da imagem, então um valor errado sobrevive à
+   * O erro é silencioso: o dotenv trata `#` sem aspas como início de
+   * comentário e trunca o valor justamente onde importa. O web usa HashRouter,
+   * então o link sem `#` depende do host devolver o `index.html` para um
+   * caminho qualquer — em hospedagem estática isso é 404 antes de o JS rodar,
+   * e o resgate do `normalizePublicCardLocation` nem chega a acontecer.
+   *
+   * O QR carrega o endereço dentro da imagem, então valor errado sobrevive à
    * correção da variável — só some ao regerar o código.
    */
   onModuleInit(): void {
@@ -304,7 +307,7 @@ export class CardService implements OnModuleInit {
   private publicBaseUrl(): string {
     return this.configService.get<string>(
       'card.publicBaseUrl',
-      'https://card.petcard.app/#',
+      'https://card.petcard.app/#/card',
     );
   }
 


### PR DESCRIPTION
Continuação de api#132 (PR #133).

## Por quê

Os ambientes geravam formatos diferentes:

| Origem | Link gerado |
| --- | --- |
| `.env` de dev | `/#/card/<token>` |
| `.env.example` → produção | `/#/<token>` |

As duas resolvem — o web registra `/card/:token` **e** `/:token`, esta última mantida desde `05e9248` para não quebrar QR Code já emitido, que traz o endereço gravado na imagem. Mas link de evidência (PC-094) e de vídeo (PC-106) precisam ter a mesma cara do link de produção.

## O que muda

`/#/card` passa a ser o formato canônico, no `.env.example` e nos fallbacks do código (`card.config.ts` e `CardService`), que estavam com a forma curta. Nenhuma rota do web muda: a curta continua atendendo os QRs antigos.

O comentário do `.env.example` ganhou o porquê de cada pedaço — aspas, `#` e sufixo.

## Correção de comentário

O doc do `onModuleInit` (PR #133) dizia que link sem `#` cai no "não encontrado". Não é o que acontece: o `normalizePublicCardLocation` do web (`main.tsx:32`) reescreve URL sem hash e resgata o link. O problema real é anterior — em hospedagem estática o host devolve 404 para `/<token>` antes de o JS carregar, e o resgate nunca roda. Comentário ajustado para dizer isso.

479 testes passando, cobertura 86.2/81.3/93.9/87.6.