### PR TITLE
fix: fechar o cadastro de veterinários ao próprio dono

### DIFF
--- a/src/modules/veterinario/__tests__/veterinario.controller.spec.ts
+++ b/src/modules/veterinario/__tests__/veterinario.controller.spec.ts
@@ -111,19 +111,6 @@ describe('VeterinarioController (integração)', () => {
     });
   });
 
-  describe('GET /veterinarios', () => {
-    it('lista os veterinários (200)', async () => {
-      prisma.veterinario.findMany.mockResolvedValue([vet]);
-
-      const res = await request(harness.app.getHttpServer())
-        .get('/veterinarios')
-        .expect(200);
-
-      expect(res.body).toHaveLength(1);
-      expect(res.body[0].password).toBeUndefined();
-    });
-  });
-
   describe('GET /veterinarios/dashboard/pets', () => {
     it('retorna os pets atendidos paginados (200)', async () => {
       prisma.petAtendido.count.mockResolvedValue(1);
@@ -218,26 +205,6 @@ describe('VeterinarioController (integração)', () => {
     });
   });
 
-  describe('GET /veterinarios/:id', () => {
-    it('retorna o veterinário (200)', async () => {
-      prisma.veterinario.findUnique.mockResolvedValue(vet);
-
-      const res = await request(harness.app.getHttpServer())
-        .get('/veterinarios/vet-1')
-        .expect(200);
-
-      expect(res.body.id).toBe('vet-1');
-    });
-
-    it('retorna 404 para id inexistente', async () => {
-      prisma.veterinario.findUnique.mockResolvedValue(null);
-
-      await request(harness.app.getHttpServer())
-        .get('/veterinarios/missing')
-        .expect(404);
-    });
-  });
-
   describe('cadastro do próprio veterinário', () => {
     it('PATCH /veterinarios/me altera quem está no token (200)', async () => {
       prisma.veterinario.findUnique.mockResolvedValue(vet);
@@ -252,6 +219,7 @@ describe('VeterinarioController (integração)', () => {
         .expect(200);
 
       expect(res.body.nome).toBe('Dra. Nova');
+      expect(res.body).not.toHaveProperty('password');
       // O alvo vem do token, nunca da rota: é o que impede um veterinário
       // de editar o cadastro de outro.
       expect(prisma.veterinario.update).toHaveBeenCalledWith(
@@ -272,9 +240,9 @@ describe('VeterinarioController (integração)', () => {
       });
     });
 
-    it('não expõe rota para alterar o cadastro de outro veterinário (404)', async () => {
-      // Havia PATCH/DELETE /veterinarios/:id sem checagem de posse: qualquer
-      // veterinário autenticado alterava a conta de outro passando o id.
+    it('não expõe rota alguma para o cadastro de outro veterinário', async () => {
+      // Havia PATCH/DELETE /veterinarios/:id sem checagem de posse e GET
+      // /veterinarios devolvendo e-mail, telefone e CRMV de todo mundo.
       await request(harness.app.getHttpServer())
         .patch('/veterinarios/vet-2')
         .send({ nome: 'Invadida' })
@@ -284,8 +252,17 @@ describe('VeterinarioController (integração)', () => {
         .delete('/veterinarios/vet-2')
         .expect(404);
 
+      await request(harness.app.getHttpServer())
+        .get('/veterinarios/vet-2')
+        .expect(404);
+
+      await request(harness.app.getHttpServer())
+        .get('/veterinarios')
+        .expect(404);
+
       expect(prisma.veterinario.update).not.toHaveBeenCalled();
       expect(prisma.veterinario.delete).not.toHaveBeenCalled();
+      expect(prisma.veterinario.findMany).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/modules/veterinario/__tests__/veterinario.controller.spec.ts
+++ b/src/modules/veterinario/__tests__/veterinario.controller.spec.ts
@@ -238,8 +238,8 @@ describe('VeterinarioController (integração)', () => {
     });
   });
 
-  describe('PATCH /veterinarios/:id', () => {
-    it('atualiza o veterinário (200)', async () => {
+  describe('cadastro do próprio veterinário', () => {
+    it('PATCH /veterinarios/me altera quem está no token (200)', async () => {
       prisma.veterinario.findUnique.mockResolvedValue(vet);
       prisma.veterinario.update.mockResolvedValue({
         ...vet,
@@ -247,22 +247,45 @@ describe('VeterinarioController (integração)', () => {
       });
 
       const res = await request(harness.app.getHttpServer())
-        .patch('/veterinarios/vet-1')
+        .patch('/veterinarios/me')
         .send({ nome: 'Dra. Nova' })
         .expect(200);
 
       expect(res.body.nome).toBe('Dra. Nova');
+      // O alvo vem do token, nunca da rota: é o que impede um veterinário
+      // de editar o cadastro de outro.
+      expect(prisma.veterinario.update).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: VET.sub } }),
+      );
     });
-  });
 
-  describe('DELETE /veterinarios/:id', () => {
-    it('remove o veterinário (204)', async () => {
+    it('DELETE /veterinarios/me apaga a própria conta (204)', async () => {
       prisma.veterinario.findUnique.mockResolvedValue(vet);
       prisma.veterinario.delete.mockResolvedValue(vet);
 
       await request(harness.app.getHttpServer())
-        .delete('/veterinarios/vet-1')
+        .delete('/veterinarios/me')
         .expect(204);
+
+      expect(prisma.veterinario.delete).toHaveBeenCalledWith({
+        where: { id: VET.sub },
+      });
+    });
+
+    it('não expõe rota para alterar o cadastro de outro veterinário (404)', async () => {
+      // Havia PATCH/DELETE /veterinarios/:id sem checagem de posse: qualquer
+      // veterinário autenticado alterava a conta de outro passando o id.
+      await request(harness.app.getHttpServer())
+        .patch('/veterinarios/vet-2')
+        .send({ nome: 'Invadida' })
+        .expect(404);
+
+      await request(harness.app.getHttpServer())
+        .delete('/veterinarios/vet-2')
+        .expect(404);
+
+      expect(prisma.veterinario.update).not.toHaveBeenCalled();
+      expect(prisma.veterinario.delete).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/modules/veterinario/__tests__/veterinario.service.spec.ts
+++ b/src/modules/veterinario/__tests__/veterinario.service.spec.ts
@@ -61,17 +61,6 @@ describe('VeterinarioService', () => {
     service = module.get<VeterinarioService>(VeterinarioService);
   });
 
-  describe('findAll', () => {
-    it('should return a list of veterinarios without passwords', async () => {
-      prisma.veterinario.findMany.mockResolvedValue([vetFixture]);
-
-      const result = await service.findAll();
-
-      expect(result).toHaveLength(1);
-      expect(result[0]).not.toHaveProperty('password');
-    });
-  });
-
   describe('findById', () => {
     it('should throw NotFoundException when veterinario is missing', async () => {
       prisma.veterinario.findUnique.mockResolvedValue(null);

--- a/src/modules/veterinario/__tests__/veterinario.service.spec.ts
+++ b/src/modules/veterinario/__tests__/veterinario.service.spec.ts
@@ -83,6 +83,14 @@ describe('VeterinarioService', () => {
   });
 
   describe('update', () => {
+    /** O `data` que chegou no Prisma na primeira (e única) gravação. */
+    function dadosGravados(): Record<string, unknown> {
+      const [[argumento]] = prisma.veterinario.update.mock.calls as [
+        [{ data: Record<string, unknown> }],
+      ];
+      return argumento.data;
+    }
+
     it('should throw ConflictException when updating to duplicated CRMV', async () => {
       const otherVet = { ...vetFixture, id: 'vet-2' };
       // 1st call: findById, 2nd call: assertUniqueFields (crmv check)
@@ -101,6 +109,39 @@ describe('VeterinarioService', () => {
       await expect(service.update('missing', { nome: 'Test' })).rejects.toThrow(
         NotFoundException,
       );
+    });
+
+    it('derruba a verificação quando o CRMV muda', async () => {
+      prisma.veterinario.findUnique
+        .mockResolvedValueOnce(vetFixture)
+        .mockResolvedValueOnce(null);
+      prisma.veterinario.update.mockResolvedValue(vetFixture);
+
+      await service.update('vet-1', { crmv: 'CRMV-SP 54321' });
+
+      // Sem zerar o carimbo, um registro que ninguém conferiu herdaria o
+      // acesso clínico conquistado pelo registro anterior (api#113).
+      expect(dadosGravados()).toMatchObject({
+        crmv: 'CRMV-SP 54321',
+        crmvVerifiedAt: null,
+        crmvSituacao: null,
+      });
+    });
+
+    it('mantém a verificação quando o CRMV enviado é o mesmo', async () => {
+      prisma.veterinario.findUnique
+        .mockResolvedValueOnce(vetFixture)
+        .mockResolvedValueOnce(vetFixture);
+      prisma.veterinario.update.mockResolvedValue(vetFixture);
+
+      // Salvar o formulário sem mexer no CRMV não pode custar uma nova
+      // consulta paga ao conselho.
+      await service.update('vet-1', {
+        nome: 'Dr. Carlos Silva',
+        crmv: vetFixture.crmv,
+      });
+
+      expect(dadosGravados()).not.toHaveProperty('crmvVerifiedAt');
     });
   });
 

--- a/src/modules/veterinario/veterinario.controller.ts
+++ b/src/modules/veterinario/veterinario.controller.ts
@@ -146,18 +146,8 @@ export class VeterinarioController {
     return this.veterinarioService.removerPetAtendido(user.sub, petId);
   }
 
-  @Get()
-  @Auth(Role.VET)
-  @ApiOperation({ summary: 'Listar veterinários' })
-  async findAll(): Promise<VeterinarioResponse[]> {
-    return this.veterinarioService.findAll();
-  }
-
-  @Get(':id')
-  @Auth(Role.VET)
-  @ApiOperation({ summary: 'Buscar veterinário por id' })
-  @ApiNotFoundResponse({ description: 'Veterinário não encontrado' })
-  async findOne(@Param('id') id: string): Promise<VeterinarioResponse> {
-    return this.veterinarioService.findById(id);
-  }
+  // Não há rota para ler o cadastro de outro veterinário. A listagem geral
+  // entregava e-mail, telefone e CRMV de todo mundo a qualquer vet logado —
+  // dado pessoal que nenhuma tela usa. O próprio cadastro vem do login, em
+  // `GET /auth/veterinario/profile`.
 }

--- a/src/modules/veterinario/veterinario.controller.ts
+++ b/src/modules/veterinario/veterinario.controller.ts
@@ -74,6 +74,30 @@ export class VeterinarioController {
     return this.crmvVerification.verify(user.sub, force === 'true');
   }
 
+  @Patch('me')
+  @Auth(Role.VET)
+  @ApiOperation({
+    summary: 'Atualizar meu cadastro',
+    description:
+      'Só o próprio veterinário altera o próprio cadastro — o id vem do ' +
+      'token, não da rota. Trocar o CRMV zera a verificação: o registro novo ' +
+      'precisa ser verificado antes de liberar dado clínico de novo.',
+  })
+  async updateMe(
+    @CurrentUser() user: JwtPayload,
+    @Body() dto: UpdateVeterinarioDto,
+  ): Promise<VeterinarioResponse> {
+    return this.veterinarioService.update(user.sub, dto);
+  }
+
+  @Delete('me')
+  @Auth(Role.VET)
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Excluir minha conta de veterinário' })
+  async removeMe(@CurrentUser() user: JwtPayload): Promise<void> {
+    return this.veterinarioService.remove(user.sub);
+  }
+
   @Get('dashboard/pets')
   @Auth(Role.VET)
   @ApiOperation({
@@ -135,25 +159,5 @@ export class VeterinarioController {
   @ApiNotFoundResponse({ description: 'Veterinário não encontrado' })
   async findOne(@Param('id') id: string): Promise<VeterinarioResponse> {
     return this.veterinarioService.findById(id);
-  }
-
-  @Patch(':id')
-  @Auth(Role.VET)
-  @ApiOperation({ summary: 'Atualizar veterinário' })
-  @ApiNotFoundResponse({ description: 'Veterinário não encontrado' })
-  async update(
-    @Param('id') id: string,
-    @Body() dto: UpdateVeterinarioDto,
-  ): Promise<VeterinarioResponse> {
-    return this.veterinarioService.update(id, dto);
-  }
-
-  @Delete(':id')
-  @Auth(Role.VET)
-  @HttpCode(HttpStatus.NO_CONTENT)
-  @ApiOperation({ summary: 'Remover veterinário' })
-  @ApiNotFoundResponse({ description: 'Veterinário não encontrado' })
-  async remove(@Param('id') id: string): Promise<void> {
-    return this.veterinarioService.remove(id);
   }
 }

--- a/src/modules/veterinario/veterinario.service.ts
+++ b/src/modules/veterinario/veterinario.service.ts
@@ -62,11 +62,18 @@ export class VeterinarioService {
     return toResponse(vet);
   }
 
+  /**
+   * Atualiza o cadastro do veterinário.
+   *
+   * Trocar o CRMV derruba a verificação junto: manter o carimbo antigo
+   * deixaria o registro novo — que ninguém conferiu — acessando dado clínico
+   * com a credencial que o registro anterior conquistou (api#113).
+   */
   async update(
     id: string,
     dto: UpdateVeterinarioDto,
   ): Promise<VeterinarioResponse> {
-    await this.findById(id);
+    const atual = await this.findById(id);
 
     if (dto.email || dto.crmv) {
       await this.assertUniqueFields(dto.email, dto.crmv, id);
@@ -75,7 +82,11 @@ export class VeterinarioService {
     const data: Record<string, unknown> = {};
     if (dto.nome !== undefined) data.nome = dto.nome;
     if (dto.email !== undefined) data.email = dto.email;
-    if (dto.crmv !== undefined) data.crmv = dto.crmv;
+    if (dto.crmv !== undefined && dto.crmv !== atual.crmv) {
+      data.crmv = dto.crmv;
+      data.crmvVerifiedAt = null;
+      data.crmvSituacao = null;
+    }
     if (dto.telefone !== undefined) data.telefone = dto.telefone;
     if (dto.password !== undefined) {
       data.password = await bcrypt.hash(dto.password, BCRYPT_ROUNDS);

--- a/src/modules/veterinario/veterinario.service.ts
+++ b/src/modules/veterinario/veterinario.service.ts
@@ -47,13 +47,7 @@ function toResponse(vet: Veterinario): VeterinarioResponse {
 export class VeterinarioService {
   constructor(private readonly prisma: PrismaService) {}
 
-  async findAll(): Promise<VeterinarioResponse[]> {
-    const vets = await this.prisma.veterinario.findMany({
-      orderBy: { createdAt: 'desc' },
-    });
-    return vets.map(toResponse);
-  }
-
+  /** Apoio interno de `update` e `remove` — não há rota que leia outro vet. */
   async findById(id: string): Promise<VeterinarioResponse> {
     const vet = await this.prisma.veterinario.findUnique({ where: { id } });
     if (!vet) {


### PR DESCRIPTION
## Problema

O `/veterinarios` estava aberto entre contas em quatro rotas, todas com apenas `@Auth(Role.VET)` e **nenhuma checagem de posse**:

| Rota | O que dava para fazer |
| --- | --- |
| `PATCH /veterinarios/:id` | renomear, trocar e-mail, CRMV ou senha de outro veterinário |
| `DELETE /veterinarios/:id` | apagar a conta de outro veterinário |
| `GET /veterinarios` | ler e-mail, telefone e CRMV de **todos** |
| `GET /veterinarios/:id` | ler o cadastro completo de um |

As duas últimas alimentavam as duas primeiras: a listagem entregava justamente os ids necessários.

Reproduzido contra o banco real antes da correção: logado como `marcos.andrade`, `PATCH /veterinarios/<id-da-camila>` devolvia 200 e alterava o cadastro dela. Depois: 404 nas quatro, cadastro intacto.

## Mudanças

- `PATCH /veterinarios/me` e `DELETE /veterinarios/me` substituem as rotas por id — o alvo vem de `user.sub`, então não existe forma de endereçar a conta de outro.
- `GET /veterinarios` e `GET /veterinarios/:id` **saem**, junto com o `findAll` do service. Nenhuma tela consumia; o próprio cadastro continua vindo do login, em `GET /auth/veterinario/profile`. `findById` fica como apoio interno de `update`/`remove`.
- **Trocar o CRMV zera a verificação** (`crmvVerifiedAt` e `crmvSituacao`). Sem isso, um veterinário verificado trocaria o registro por outro qualquer e manteria o acesso clínico que o registro anterior conquistou. Enviar o mesmo CRMV não zera nada — salvar o formulário sem mexer no campo não pode custar uma consulta paga ao conselho.

Escolhi **remover** as rotas em vez de adicionar checagem de posse: a superfície some, em vez de depender de um `if` que a próxima rota pode esquecer de repetir.

O `PATCH /me` é o que destrava o veterinário que digitou o CRMV errado no cadastro — hoje ele fica preso, porque reconsultar o mesmo número recusado não resolve e não há tela de perfil. O lado da web é o petcard-web#46.

## Testes

451 passando; cobertura 84,7 / 79,4 / 91,3 / 86,3, acima da catraca (83/78/90/85).

Casos novos, todos ligados a regra real (ADR-006): `/me` grava no id do token e não devolve senha; nenhuma das quatro rotas por id existe mais (404 e zero escrita/leitura no Prisma); a troca de CRMV zera a verificação; o mesmo CRMV a preserva. O teste da invalidação foi conferido revertendo a correção — falha sem ela.

⚠️ O contrato mudou (4 rotas a menos, 2 a mais): o `openapi.json` e a collection do Postman em `petcard-docs/docs/api/` precisam ser regerados.