### PR TITLE
feat(carteira): exibir telefone do tutor na carteira pública

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@nestjs/schedule": "^6.1.3",
         "@nestjs/swagger": "^11.4.4",
         "@nestjs/throttler": "^6.5.0",
-        "@petcardorg/shared": "^0.16.0",
+        "@petcardorg/shared": "^0.18.0",
         "@prisma/client": "^6.19.3",
         "amqp-connection-manager": "^5.0.0",
         "amqplib": "^1.0.3",
@@ -3846,9 +3846,9 @@
       }
     },
     "node_modules/@petcardorg/shared": {
-      "version": "0.16.0",
-      "resolved": "https://npm.pkg.github.com/download/@petcardorg/shared/0.16.0/e5cc6c8ee2af3e7f25c410ac321c3189b3392242",
-      "integrity": "sha512-kdHgFXue1EiJtwvYFGcxgemthxlZ9MLVrOyK10cgDdpmTH7FSBr8RFLQHvJgHYyY3bpE5Jbz4b1ZRK0QycFTqA==",
+      "version": "0.18.0",
+      "resolved": "https://npm.pkg.github.com/download/@petcardorg/shared/0.18.0/6a3d3c6ed40357015b3a58ace8fb7050e13529d7",
+      "integrity": "sha512-WbGU7FpnwR7iwiTdD19fAQJ/qEkXCOi6aTJJ+0oRVaqs+HcLIW82/kFfSNoAxIuzbSdk9lrt5nJWzzrVoeWl4Q==",
       "license": "MIT",
       "peerDependencies": {
         "class-transformer": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@nestjs/schedule": "^6.1.3",
     "@nestjs/swagger": "^11.4.4",
     "@nestjs/throttler": "^6.5.0",
-    "@petcardorg/shared": "^0.16.0",
+    "@petcardorg/shared": "^0.18.0",
     "@prisma/client": "^6.19.3",
     "amqp-connection-manager": "^5.0.0",
     "amqplib": "^1.0.3",

--- a/src/modules/card/__tests__/card.service.spec.ts
+++ b/src/modules/card/__tests__/card.service.spec.ts
@@ -162,7 +162,7 @@ describe('CardService', () => {
           birthDate: new Date('2022-03-10'),
           weight: 12.5,
           photoUrl: 'https://s3/pet.png',
-          tutor: { name: 'Alice' },
+          tutor: { name: 'Alice', phone: '+55 85 99999-0000' },
           vaccineRecords: [
             {
               id: 'v1',
@@ -200,6 +200,7 @@ describe('CardService', () => {
         birth_date: '2022-03-10',
         weight: 12.5,
         tutor_name: 'Alice',
+        tutor_phone: '+55 85 99999-0000',
         qr_code_url: 'https://s3/qr.png',
       });
       expect(result.vaccines).toHaveLength(1);
@@ -212,6 +213,21 @@ describe('CardService', () => {
       expect(
         (result as Record<string, unknown>).clinical_notes,
       ).toBeUndefined();
+    });
+
+    it('omite o telefone quando o tutor não cadastrou', async () => {
+      // O campo é opcional no cadastro: sem ele a carteira não pode inventar
+      // um contato nem mostrar "null" para quem achou o pet.
+      prisma.carteiraDigital.findUnique.mockResolvedValue(
+        makeCard({
+          pet: { ...makeCard().pet, tutor: { name: 'Alice', phone: null } },
+        }),
+      );
+
+      const result = await service.findPublicByToken('tok-abc');
+
+      expect(result.tutor_name).toBe('Alice');
+      expect(result.tutor_phone).toBeUndefined();
     });
 
     it('should map vaccine/deworming optional fields and withhold sensitive clinical data (api#114)', async () => {

--- a/src/modules/card/card.service.ts
+++ b/src/modules/card/card.service.ts
@@ -99,6 +99,10 @@ export class CardService implements OnModuleInit {
    * clínicos sensíveis — notas clínicas (diagnóstico/prescrição/observações do
    * vet) e medicações em uso — NÃO são incluídos aqui; ficam restritos aos
    * endpoints autenticados do tutor/veterinário.
+   *
+   * O telefone do tutor é a exceção deliberada ao estreitamento da api#114:
+   * sem ele o QR na coleira identifica o pet perdido mas não deixa ninguém
+   * avisar o dono. Sai só quando o tutor preencheu o campo.
    */
   async findPublicByToken(
     token: string,
@@ -141,6 +145,7 @@ export class CardService implements OnModuleInit {
       photo_url: pet.photoUrl ?? undefined,
       qr_code_url: card.qrCodeUrl ?? undefined,
       tutor_name: pet.tutor.name,
+      tutor_phone: pet.tutor.phone ?? undefined,
       vaccines: pet.vaccineRecords.map((r) => ({
         id: r.id,
         pet_id: r.petId,


### PR DESCRIPTION
## Rascunho — bloqueado numa dependência

O código está pronto e verificado, mas a api declara `@petcardorg/shared: ^0.16.0`, que não alcança a **0.18.0** onde `tutor_phone` foi definido. Atualizar o `package-lock.json` exige `npm install` autenticado no GitHub Packages, e eu não manuseio o PAT. Com `NODE_AUTH_TOKEN` exportado:

```bash
cd petcard-api && npm install @petcardorg/shared@^0.18.0
```

Feito isso, o PR sai de rascunho e o CI deve passar.

## O que muda

`findPublicByToken` passa a devolver `tutor_phone` quando o tutor preencheu o campo. O registro do tutor já era carregado na consulta — nenhum acesso novo ao banco.

## Por que numa rota pública

A api#114 estreitou de propósito o que sai desta resposta, tirando medicações e notas clínicas por revelarem condições de saúde em tratamento. O telefone é a exceção deliberada: não é dado clínico, e é o que torna o QR da coleira acionável. Sem ele, quem encontra o pet perdido identifica o animal e não consegue avisar o dono.

Limites que permanecem: token UUID aleatório, rate limit de 10 req/min por IP, e o campo só sai se tiver sido preenchido — o cadastro não o exige.

## Testes

Suíte de card em 24. Um teste novo cobre o tutor **sem** telefone, que é a condição do "caso registre": o campo sai como `undefined` em vez de `null` na carteira.

## Verificação local

Typecheck, build e 452 testes passando — com a 0.18.0 copiada manualmente para `node_modules` no lugar do install autenticado.