### PR TITLE
fix(segurança): restringir acesso do veterinário aos pets que ele atende

### DIFF
--- a/src/modules/health/deworming/__tests__/deworming.controller.spec.ts
+++ b/src/modules/health/deworming/__tests__/deworming.controller.spec.ts
@@ -30,6 +30,7 @@ describe('DewormingController (integração)', () => {
       update: jest.Mock;
       delete: jest.Mock;
     };
+    petAtendido: { findUnique: jest.Mock };
   };
 
   const pet = { id: 'pet-1', tutorId: 'tutor-1' };
@@ -61,6 +62,7 @@ describe('DewormingController (integração)', () => {
         update: jest.fn(),
         delete: jest.fn(),
       },
+      petAtendido: { findUnique: jest.fn() },
     };
 
     comTransacao(prisma);
@@ -96,6 +98,8 @@ describe('DewormingController (integração)', () => {
     jest.clearAllMocks();
     harness.setUser(TUTOR);
     prisma.pet.findUnique.mockResolvedValue(pet);
+    // Vínculo vet-pet presente por padrão; os casos de bloqueio zeram.
+    prisma.petAtendido.findUnique.mockResolvedValue({ id: 'vinculo-1' });
   });
 
   it('POST cria registro para o dono (201)', async () => {
@@ -114,7 +118,7 @@ describe('DewormingController (integração)', () => {
     expect(res.body.product_name).toBe('Drontal');
   });
 
-  it('POST permite VET registrar em qualquer pet (201)', async () => {
+  it('POST permite ao VET que atende o pet registrar (201)', async () => {
     harness.setUser(VET);
     prisma.pet.findUnique.mockResolvedValue({ ...pet, tutorId: 'outro' });
     prisma.dewormingRecord.create.mockResolvedValue(record);
@@ -127,6 +131,25 @@ describe('DewormingController (integração)', () => {
         applied_at: '2026-02-01',
       })
       .expect(201);
+  });
+
+  it('POST barra o VET que não atende o pet (403)', async () => {
+    // O papel VET, sozinho, não abre o prontuário: sem a leitura do QR Code
+    // o pet não está na lista dele.
+    harness.setUser(VET);
+    prisma.pet.findUnique.mockResolvedValue({ ...pet, tutorId: 'outro' });
+    prisma.petAtendido.findUnique.mockResolvedValue(null);
+
+    await request(harness.app.getHttpServer())
+      .post('/pets/pet-1/dewormings')
+      .send({
+        pet_id: '11111111-1111-4111-8111-111111111111',
+        product_name: 'Drontal',
+        applied_at: '2026-02-01',
+      })
+      .expect(403);
+
+    expect(prisma.dewormingRecord.create).not.toHaveBeenCalled();
   });
 
   it('POST rejeita payload inválido (400)', async () => {

--- a/src/modules/health/medication/__tests__/medication.controller.spec.ts
+++ b/src/modules/health/medication/__tests__/medication.controller.spec.ts
@@ -30,6 +30,7 @@ describe('MedicationController (integração)', () => {
       update: jest.Mock;
       delete: jest.Mock;
     };
+    petAtendido: { findUnique: jest.Mock };
   };
 
   const pet = { id: 'pet-1', tutorId: 'tutor-1' };
@@ -60,6 +61,7 @@ describe('MedicationController (integração)', () => {
         update: jest.fn(),
         delete: jest.fn(),
       },
+      petAtendido: { findUnique: jest.fn() },
     };
 
     comTransacao(prisma);
@@ -95,6 +97,8 @@ describe('MedicationController (integração)', () => {
     jest.clearAllMocks();
     harness.setUser(TUTOR);
     prisma.pet.findUnique.mockResolvedValue(pet);
+    // Vínculo vet-pet presente por padrão; os casos de bloqueio zeram.
+    prisma.petAtendido.findUnique.mockResolvedValue({ id: 'vinculo-1' });
   });
 
   const validBody = {
@@ -117,7 +121,7 @@ describe('MedicationController (integração)', () => {
     expect(res.body.medication_name).toBe('Amoxicilina');
   });
 
-  it('POST permite VET registrar em qualquer pet (201)', async () => {
+  it('POST permite ao VET que atende o pet registrar (201)', async () => {
     harness.setUser(VET);
     prisma.pet.findUnique.mockResolvedValue({ ...pet, tutorId: 'outro' });
     prisma.medicationRecord.create.mockResolvedValue(record);
@@ -126,6 +130,21 @@ describe('MedicationController (integração)', () => {
       .post('/pets/pet-1/medications')
       .send(validBody)
       .expect(201);
+  });
+
+  it('POST barra o VET que não atende o pet (403)', async () => {
+    // O papel VET, sozinho, não abre o prontuário: sem a leitura do QR Code
+    // o pet não está na lista dele.
+    harness.setUser(VET);
+    prisma.pet.findUnique.mockResolvedValue({ ...pet, tutorId: 'outro' });
+    prisma.petAtendido.findUnique.mockResolvedValue(null);
+
+    await request(harness.app.getHttpServer())
+      .post('/pets/pet-1/medications')
+      .send(validBody)
+      .expect(403);
+
+    expect(prisma.medicationRecord.create).not.toHaveBeenCalled();
   });
 
   it('POST rejeita payload inválido (400)', async () => {

--- a/src/modules/health/vaccine/__tests__/vaccine.controller.spec.ts
+++ b/src/modules/health/vaccine/__tests__/vaccine.controller.spec.ts
@@ -30,6 +30,7 @@ describe('VaccineController (integração)', () => {
       update: jest.Mock;
       delete: jest.Mock;
     };
+    petAtendido: { findUnique: jest.Mock };
   };
 
   const pet = { id: 'pet-1', tutorId: 'tutor-1' };
@@ -61,6 +62,7 @@ describe('VaccineController (integração)', () => {
         update: jest.fn(),
         delete: jest.fn(),
       },
+      petAtendido: { findUnique: jest.fn() },
     };
 
     comTransacao(prisma);
@@ -96,6 +98,8 @@ describe('VaccineController (integração)', () => {
     jest.clearAllMocks();
     harness.setUser(TUTOR);
     prisma.pet.findUnique.mockResolvedValue(pet);
+    // Vínculo vet-pet presente por padrão; os casos de bloqueio zeram.
+    prisma.petAtendido.findUnique.mockResolvedValue({ id: 'vinculo-1' });
   });
 
   it('POST cria registro para o dono (201)', async () => {
@@ -114,7 +118,7 @@ describe('VaccineController (integração)', () => {
     expect(res.body.vaccine_name).toBe('Raiva');
   });
 
-  it('POST permite VET registrar em qualquer pet (201)', async () => {
+  it('POST permite ao VET que atende o pet registrar (201)', async () => {
     harness.setUser(VET);
     prisma.pet.findUnique.mockResolvedValue({ ...pet, tutorId: 'outro' });
     prisma.vaccineRecord.create.mockResolvedValue(record);
@@ -127,6 +131,25 @@ describe('VaccineController (integração)', () => {
         applied_at: '2026-01-10',
       })
       .expect(201);
+  });
+
+  it('POST barra o VET que não atende o pet (403)', async () => {
+    // O papel VET, sozinho, não abre o prontuário: sem a leitura do QR Code
+    // o pet não está na lista dele.
+    harness.setUser(VET);
+    prisma.pet.findUnique.mockResolvedValue({ ...pet, tutorId: 'outro' });
+    prisma.petAtendido.findUnique.mockResolvedValue(null);
+
+    await request(harness.app.getHttpServer())
+      .post('/pets/pet-1/vaccines')
+      .send({
+        pet_id: '11111111-1111-4111-8111-111111111111',
+        vaccine_name: 'Raiva',
+        applied_at: '2026-01-10',
+      })
+      .expect(403);
+
+    expect(prisma.vaccineRecord.create).not.toHaveBeenCalled();
   });
 
   it('POST rejeita payload inválido (400)', async () => {

--- a/src/modules/pet/__tests__/pet.controller.spec.ts
+++ b/src/modules/pet/__tests__/pet.controller.spec.ts
@@ -24,6 +24,7 @@ describe('PetController (integração)', () => {
       update: jest.Mock;
       delete: jest.Mock;
     };
+    petAtendido: { findUnique: jest.Mock };
   };
   let qrPublisher: { publishGenerate: jest.Mock };
 
@@ -58,6 +59,7 @@ describe('PetController (integração)', () => {
         update: jest.fn(),
         delete: jest.fn(),
       },
+      petAtendido: { findUnique: jest.fn() },
     };
     qrPublisher = { publishGenerate: jest.fn().mockResolvedValue(undefined) };
 
@@ -175,11 +177,20 @@ describe('PetController (integração)', () => {
       await request(harness.app.getHttpServer()).get('/pets/pet-1').expect(403);
     });
 
-    it('permite acesso de VET mesmo sem ser dono (200)', async () => {
+    it('permite acesso do VET que atende o pet (200)', async () => {
       harness.setUser(VET);
       prisma.pet.findUnique.mockResolvedValue({ ...pet, tutorId: 'outro' });
+      prisma.petAtendido.findUnique.mockResolvedValue({ id: 'vinculo-1' });
 
       await request(harness.app.getHttpServer()).get('/pets/pet-1').expect(200);
+    });
+
+    it('barra o VET que não atende o pet (403)', async () => {
+      harness.setUser(VET);
+      prisma.pet.findUnique.mockResolvedValue({ ...pet, tutorId: 'outro' });
+      prisma.petAtendido.findUnique.mockResolvedValue(null);
+
+      await request(harness.app.getHttpServer()).get('/pets/pet-1').expect(403);
     });
 
     it('retorna 404 quando o pet não existe', async () => {

--- a/src/modules/pet/__tests__/pet.service.spec.ts
+++ b/src/modules/pet/__tests__/pet.service.spec.ts
@@ -17,6 +17,7 @@ describe('PetService', () => {
       update: jest.Mock;
       delete: jest.Mock;
     };
+    petAtendido: { findUnique: jest.Mock };
   };
   let tutorService: { findById: jest.Mock };
   let qrCodePublisher: { publishGenerate: jest.Mock };
@@ -59,6 +60,7 @@ describe('PetService', () => {
         update: jest.fn(),
         delete: jest.fn(),
       },
+      petAtendido: { findUnique: jest.fn().mockResolvedValue(null) },
     };
     tutorService = { findById: jest.fn().mockResolvedValue(tutor) };
     qrCodePublisher = {
@@ -205,15 +207,33 @@ describe('PetService', () => {
       );
     });
 
-    it('should allow any vet to read the pet', async () => {
+    it('libera o vet que tem o pet na lista de atendidos', async () => {
       prisma.pet.findUnique.mockResolvedValue({
         ...petWithCard,
         tutorId: 'other',
       });
+      prisma.petAtendido.findUnique.mockResolvedValue({ id: 'vinculo-1' });
 
       const result = await service.findOne('pet-1', 'vet-1', true);
 
       expect(result.id).toBe('pet-1');
+      expect(prisma.petAtendido.findUnique).toHaveBeenCalledWith({
+        where: {
+          veterinarioId_petId: { veterinarioId: 'vet-1', petId: 'pet-1' },
+        },
+      });
+    });
+
+    it('barra o vet sem vínculo com o pet', async () => {
+      prisma.pet.findUnique.mockResolvedValue({
+        ...petWithCard,
+        tutorId: 'other',
+      });
+      prisma.petAtendido.findUnique.mockResolvedValue(null);
+
+      await expect(service.findOne('pet-1', 'vet-1', true)).rejects.toThrow(
+        ForbiddenException,
+      );
     });
 
     it('should throw NotFoundException when the pet is missing', async () => {
@@ -265,6 +285,54 @@ describe('PetService', () => {
       expect(prisma.pet.delete).toHaveBeenCalledWith({
         where: { id: 'pet-1' },
       });
+    });
+  });
+
+  describe('assertAccess', () => {
+    // Ponto único por onde passam vacina, vermífugo, medicação e histórico.
+    it('devolve o pet para o tutor dono', async () => {
+      prisma.pet.findUnique.mockResolvedValue(pet);
+
+      await expect(
+        service.assertAccess('pet-1', 'tutor-1', false),
+      ).resolves.toMatchObject({ id: 'pet-1' });
+      expect(prisma.petAtendido.findUnique).not.toHaveBeenCalled();
+    });
+
+    it('barra o tutor que não é dono', async () => {
+      prisma.pet.findUnique.mockResolvedValue({ ...pet, tutorId: 'outro' });
+
+      await expect(
+        service.assertAccess('pet-1', 'tutor-1', false),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('devolve o pet para o vet que o atende', async () => {
+      prisma.pet.findUnique.mockResolvedValue({ ...pet, tutorId: 'outro' });
+      prisma.petAtendido.findUnique.mockResolvedValue({ id: 'vinculo-1' });
+
+      await expect(
+        service.assertAccess('pet-1', 'vet-1', true),
+      ).resolves.toMatchObject({ id: 'pet-1' });
+    });
+
+    it('barra o vet sem vínculo, ainda que o pet exista', async () => {
+      // O buraco que isto fecha: com o id do pet em mãos, qualquer vet
+      // verificado lia e escrevia no prontuário de qualquer animal da base.
+      prisma.pet.findUnique.mockResolvedValue({ ...pet, tutorId: 'outro' });
+      prisma.petAtendido.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.assertAccess('pet-1', 'vet-1', true),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('devolve 404 para pet inexistente, mesmo para vet', async () => {
+      prisma.pet.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.assertAccess('missing', 'vet-1', true),
+      ).rejects.toThrow(NotFoundException);
     });
   });
 });

--- a/src/modules/pet/pet.service.ts
+++ b/src/modules/pet/pet.service.ts
@@ -105,7 +105,9 @@ export class PetService {
     if (!pet) {
       throw new NotFoundException(`Pet with id ${id} not found`);
     }
-    if (!isVet && pet.tutorId !== userId) {
+    if (isVet) {
+      await this.assertVinculoVet(id, userId);
+    } else if (pet.tutorId !== userId) {
       throw new ForbiddenException('You do not own this pet');
     }
     return toResponseDto(pet);
@@ -157,6 +159,15 @@ export class PetService {
     return pet;
   }
 
+  /**
+   * Acesso ao pet por tutor dono ou por veterinário que o atende.
+   *
+   * O papel VET sozinho não abre a ficha de ninguém: sem o vínculo, bastava
+   * conhecer o id de um pet para ler e escrever no prontuário de qualquer
+   * animal da base. O vínculo nasce da leitura do QR Code
+   * (`POST /veterinarios/me/pets`), que é a autorização de fato do atendimento
+   * — quem leu o código esteve com o pet na frente.
+   */
   async assertAccess(
     petId: string,
     userId: string,
@@ -167,8 +178,24 @@ export class PetService {
       if (!pet) {
         throw new NotFoundException(`Pet with id ${petId} not found`);
       }
+      await this.assertVinculoVet(petId, userId);
       return pet;
     }
     return this.assertOwnership(petId, userId);
+  }
+
+  /** Exige que o pet esteja na lista de atendidos do veterinário. */
+  private async assertVinculoVet(
+    petId: string,
+    veterinarioId: string,
+  ): Promise<void> {
+    const vinculo = await this.prisma.petAtendido.findUnique({
+      where: { veterinarioId_petId: { veterinarioId, petId } },
+    });
+    if (!vinculo) {
+      throw new ForbiddenException(
+        'Pet fora da sua lista de atendidos. Leia o QR Code da carteira para iniciar o atendimento.',
+      );
+    }
   }
 }

--- a/src/modules/tutor/__tests__/tutor.controller.spec.ts
+++ b/src/modules/tutor/__tests__/tutor.controller.spec.ts
@@ -12,12 +12,18 @@ import { TutorService } from '../tutor.service';
 
 describe('TutorController (integração)', () => {
   let harness: ControllerHarness;
-  let prisma: { tutor: { findUnique: jest.Mock; update: jest.Mock } };
+  let prisma: {
+    tutor: { findUnique: jest.Mock; update: jest.Mock };
+    petAtendido: { findFirst: jest.Mock };
+  };
 
   const tutor = {
     id: 'tutor-1',
     name: 'Alice',
     email: 'tutor@petcard.com',
+    // O hash vem do banco em toda leitura; o que importa é ele não sair na
+    // resposta.
+    password: '$2b$12$hashdoTutor',
     phone: null,
     profileImageUrl: null,
     role: 'TUTOR',
@@ -26,7 +32,10 @@ describe('TutorController (integração)', () => {
   };
 
   beforeAll(async () => {
-    prisma = { tutor: { findUnique: jest.fn(), update: jest.fn() } };
+    prisma = {
+      tutor: { findUnique: jest.fn(), update: jest.fn() },
+      petAtendido: { findFirst: jest.fn() },
+    };
 
     harness = await createControllerTestApp({
       controllers: [TutorController],
@@ -42,6 +51,7 @@ describe('TutorController (integração)', () => {
     jest.clearAllMocks();
     harness.setUser(TUTOR);
     prisma.tutor.findUnique.mockResolvedValue(tutor);
+    prisma.petAtendido.findFirst.mockResolvedValue({ id: 'vinculo-1' });
   });
 
   describe('GET /tutors/me', () => {
@@ -52,6 +62,7 @@ describe('TutorController (integração)', () => {
 
       expect(res.body.id).toBe('tutor-1');
       expect(res.body.email).toBe('tutor@petcard.com');
+      expect(res.body).not.toHaveProperty('password');
       expect(prisma.tutor.findUnique).toHaveBeenCalledWith({
         where: { id: 'tutor-1' },
       });
@@ -74,6 +85,7 @@ describe('TutorController (integração)', () => {
         .expect(200);
 
       expect(res.body.name).toBe('Alice B');
+      expect(res.body).not.toHaveProperty('password');
       expect(prisma.tutor.update).toHaveBeenCalledWith({
         where: { id: 'tutor-1' },
         data: { name: 'Alice B' },
@@ -97,7 +109,7 @@ describe('TutorController (integração)', () => {
         .expect(403);
     });
 
-    it('retorna o tutor para VET (200)', async () => {
+    it('retorna o tutor para o VET que atende um pet dele (200)', async () => {
       harness.setUser(VET);
 
       const res = await request(harness.app.getHttpServer())
@@ -105,6 +117,17 @@ describe('TutorController (integração)', () => {
         .expect(200);
 
       expect(res.body.id).toBe('tutor-1');
+      expect(res.body).not.toHaveProperty('password');
+    });
+
+    it('barra o VET sem pet do tutor na lista (403)', async () => {
+      // O papel VET não dá acesso ao cadastro de qualquer tutor da base.
+      harness.setUser(VET);
+      prisma.petAtendido.findFirst.mockResolvedValue(null);
+
+      await request(harness.app.getHttpServer())
+        .get('/tutors/tutor-1')
+        .expect(403);
     });
 
     it('retorna 404 para tutor inexistente (VET)', async () => {

--- a/src/modules/tutor/tutor.controller.ts
+++ b/src/modules/tutor/tutor.controller.ts
@@ -1,12 +1,16 @@
 import { Body, Controller, Get, Param, Patch } from '@nestjs/common';
-import { ApiNotFoundResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
-import { Tutor } from '@prisma/client';
+import {
+  ApiForbiddenResponse,
+  ApiNotFoundResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
 import { UpdateTutorDto } from '@petcardorg/shared';
 import { Auth } from '../auth/decorators/auth.decorator';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { Role } from '../auth/enums/role.enum';
 import type { JwtPayload } from '../auth/strategies/jwt.strategy';
-import { TutorService } from './tutor.service';
+import { TutorService, type TutorPublico } from './tutor.service';
 
 @ApiTags('tutors')
 @Controller('tutors')
@@ -16,7 +20,7 @@ export class TutorController {
   @Get('me')
   @Auth(Role.TUTOR)
   @ApiOperation({ summary: 'Dados do tutor autenticado' })
-  async getMe(@CurrentUser() user: JwtPayload): Promise<Tutor> {
+  async getMe(@CurrentUser() user: JwtPayload): Promise<TutorPublico> {
     return this.tutorService.findById(user.sub);
   }
 
@@ -26,15 +30,21 @@ export class TutorController {
   async updateMe(
     @CurrentUser() user: JwtPayload,
     @Body() dto: UpdateTutorDto,
-  ): Promise<Tutor> {
+  ): Promise<TutorPublico> {
     return this.tutorService.updateById(user.sub, dto);
   }
 
   @Get(':id')
   @Auth(Role.VET)
-  @ApiOperation({ summary: 'Buscar tutor por id (visão do vet)' })
+  @ApiOperation({
+    summary: 'Buscar tutor por id (vet que atende algum pet dele)',
+  })
+  @ApiForbiddenResponse({ description: 'Tutor fora da lista de atendidos' })
   @ApiNotFoundResponse({ description: 'Tutor não encontrado' })
-  async findOne(@Param('id') id: string): Promise<Tutor> {
-    return this.tutorService.findById(id);
+  async findOne(
+    @Param('id') id: string,
+    @CurrentUser() user: JwtPayload,
+  ): Promise<TutorPublico> {
+    return this.tutorService.findByIdForVet(id, user.sub);
   }
 }

--- a/src/modules/tutor/tutor.service.ts
+++ b/src/modules/tutor/tutor.service.ts
@@ -1,17 +1,64 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { Tutor } from '@prisma/client';
 import { UpdateTutorDto } from '@petcardorg/shared';
 import { PrismaService } from '../../prisma/prisma.service';
+
+/** Tutor sem o hash da senha — o que pode sair da API. */
+export type TutorPublico = Omit<Tutor, 'password'>;
+
+/**
+ * O hash da senha nunca acompanha o tutor para fora do serviço.
+ *
+ * `findUnique` devolve a linha inteira, e as rotas devolviam esse objeto
+ * direto: o hash bcrypt do tutor saía em `GET /tutors/me`, `PATCH /tutors/me`
+ * e `GET /tutors/:id` — este último legível por qualquer veterinário logado,
+ * o que dava a ele material para quebra offline de senha.
+ */
+function semSenha(tutor: Tutor): TutorPublico {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { password, ...rest } = tutor;
+  return rest;
+}
 
 @Injectable()
 export class TutorService {
   constructor(private readonly prisma: PrismaService) {}
 
-  async findById(id: string): Promise<Tutor> {
+  async findById(id: string): Promise<TutorPublico> {
     const tutor = await this.prisma.tutor.findUnique({ where: { id } });
     if (!tutor) {
       throw new NotFoundException(`Tutor with id ${id} not found`);
     }
+    return semSenha(tutor);
+  }
+
+  /**
+   * Tutor visto pelo veterinário, restrito a quem ele de fato atende.
+   *
+   * Sem o recorte, o papel VET lia o cadastro (nome, e-mail, telefone) de
+   * qualquer tutor da base a partir do id. O vínculo com algum pet do tutor —
+   * criado na leitura do QR Code — é o que autoriza a consulta.
+   */
+  async findByIdForVet(
+    id: string,
+    veterinarioId: string,
+  ): Promise<TutorPublico> {
+    const tutor = await this.findById(id);
+
+    const vinculo = await this.prisma.petAtendido.findFirst({
+      where: { veterinarioId, pet: { tutorId: id } },
+      select: { id: true },
+    });
+    if (!vinculo) {
+      throw new ForbiddenException(
+        'Tutor sem pet na sua lista de atendidos. Leia o QR Code da carteira para iniciar o atendimento.',
+      );
+    }
+
     return tutor;
   }
 
@@ -19,11 +66,20 @@ export class TutorService {
     return this.prisma.tutor.findUnique({ where: { email } });
   }
 
-  async updateById(id: string, data: UpdateTutorDto): Promise<Tutor> {
+  async updateById(id: string, data: UpdateTutorDto): Promise<TutorPublico> {
     await this.findById(id);
-    return this.prisma.tutor.update({
+    const tutor = await this.prisma.tutor.update({
       where: { id },
-      data,
+      // Campos listados um a um: espalhar o DTO no `data` do Prisma deixa a
+      // superfície de escrita a reboque do DTO, e um campo novo lá vira
+      // gravação silenciosa aqui.
+      data: {
+        name: data.name,
+        email: data.email,
+        phone: data.phone,
+        profileImageUrl: data.profile_image_url,
+      },
     });
+    return semSenha(tutor);
   }
 }

--- a/src/modules/vet-note/__tests__/vet-note.controller.spec.ts
+++ b/src/modules/vet-note/__tests__/vet-note.controller.spec.ts
@@ -29,6 +29,7 @@ describe('VetNoteController (integração)', () => {
       update: jest.Mock;
       delete: jest.Mock;
     };
+    petAtendido: { findUnique: jest.Mock };
   };
   let notifications: { schedulePush: jest.Mock };
 
@@ -57,8 +58,8 @@ describe('VetNoteController (integração)', () => {
         findFirst: jest.fn(),
         update: jest.fn(),
         delete: jest.fn(),
-        update: jest.fn(),
       },
+      petAtendido: { findUnique: jest.fn() },
     };
     notifications = { schedulePush: jest.fn().mockResolvedValue(undefined) };
 
@@ -91,6 +92,8 @@ describe('VetNoteController (integração)', () => {
     harness.setUser(VET);
     prisma.pet.findUnique.mockResolvedValue(pet);
     prisma.veterinario.findUnique.mockResolvedValue({ id: 'vet-1' });
+    // Vínculo vet-pet presente por padrão; os casos de bloqueio zeram.
+    prisma.petAtendido.findUnique.mockResolvedValue({ id: 'vinculo-1' });
   });
 
   describe('POST /pets/:petId/clinical-notes', () => {
@@ -115,6 +118,19 @@ describe('VetNoteController (integração)', () => {
         .post('/pets/pet-1/clinical-notes')
         .send({ diagnostico: 'Otite' })
         .expect(201);
+    });
+
+    it('barra o VET que não atende o pet (403)', async () => {
+      // Escrever no prontuário exige o vínculo, não só o papel VET: sem a
+      // leitura do QR Code o pet não está na lista dele.
+      prisma.petAtendido.findUnique.mockResolvedValue(null);
+
+      await request(harness.app.getHttpServer())
+        .post('/pets/pet-1/clinical-notes')
+        .send({ diagnostico: 'Otite' })
+        .expect(403);
+
+      expect(prisma.notaClinica.create).not.toHaveBeenCalled();
     });
 
     it('proíbe TUTOR de criar nota (403)', async () => {
@@ -155,6 +171,16 @@ describe('VetNoteController (integração)', () => {
       await request(harness.app.getHttpServer())
         .get('/pets/pet-1/clinical-notes')
         .expect(403);
+    });
+
+    it('proíbe VET que não atende o pet (403)', async () => {
+      prisma.petAtendido.findUnique.mockResolvedValue(null);
+
+      await request(harness.app.getHttpServer())
+        .get('/pets/pet-1/clinical-notes')
+        .expect(403);
+
+      expect(prisma.notaClinica.findMany).not.toHaveBeenCalled();
     });
   });
 

--- a/src/modules/vet-note/__tests__/vet-note.service.spec.ts
+++ b/src/modules/vet-note/__tests__/vet-note.service.spec.ts
@@ -23,6 +23,7 @@ describe('VetNoteService', () => {
     };
     pet: { findUnique: jest.Mock };
     veterinario: { findUnique: jest.Mock };
+    petAtendido: { findUnique: jest.Mock };
   };
   let notificationService: { schedulePush: jest.Mock };
 
@@ -62,10 +63,13 @@ describe('VetNoteService', () => {
         findFirst: jest.fn(),
         update: jest.fn(),
         delete: jest.fn(),
-        update: jest.fn(),
       },
       pet: { findUnique: jest.fn() },
       veterinario: { findUnique: jest.fn() },
+      // Vínculo vet-pet presente por padrão; os casos de bloqueio zeram.
+      petAtendido: {
+        findUnique: jest.fn().mockResolvedValue({ id: 'vinculo-1' }),
+      },
     };
     notificationService = {
       schedulePush: jest.fn().mockResolvedValue([]),

--- a/src/modules/vet-note/vet-note.service.ts
+++ b/src/modules/vet-note/vet-note.service.ts
@@ -57,6 +57,7 @@ export class VetNoteService {
   ): Promise<NotaClinicaResponseDto> {
     const pet = await this.findPetOrFail(petId);
     await this.assertVeterinarioExists(veterinarioId);
+    await this.assertVinculoVet(petId, veterinarioId);
 
     const nota = await this.prisma.$transaction(async (tx) => {
       const criada = await tx.notaClinica.create({
@@ -117,7 +118,9 @@ export class VetNoteService {
   ): Promise<NotaClinicaResponseDto[]> {
     const pet = await this.findPetOrFail(petId);
 
-    if (!isVet && pet.tutorId !== userId) {
+    if (isVet) {
+      await this.assertVinculoVet(petId, userId);
+    } else if (pet.tutorId !== userId) {
       throw new ForbiddenException('You can only view notes for your own pets');
     }
 
@@ -147,7 +150,9 @@ export class VetNoteService {
       throw new NotFoundException(`Clinical note with id ${id} not found`);
     }
 
-    if (!isVet && nota.pet.tutorId !== userId) {
+    if (isVet) {
+      await this.assertVinculoVet(nota.petId, userId);
+    } else if (nota.pet.tutorId !== userId) {
       throw new ForbiddenException('You can only view notes for your own pets');
     }
 
@@ -271,6 +276,28 @@ export class VetNoteService {
       throw new NotFoundException(`Pet with id ${petId} not found`);
     }
     return pet;
+  }
+
+  /**
+   * Exige que o pet esteja na lista de atendidos do veterinário.
+   *
+   * Repete a regra de `PetService.assertAccess` porque as notas clínicas não
+   * passam por lá — e sem a checagem o papel VET, sozinho, lia e escrevia no
+   * prontuário de qualquer pet cujo id fosse conhecido. O vínculo entra pela
+   * leitura do QR Code da carteira.
+   */
+  private async assertVinculoVet(
+    petId: string,
+    veterinarioId: string,
+  ): Promise<void> {
+    const vinculo = await this.prisma.petAtendido.findUnique({
+      where: { veterinarioId_petId: { veterinarioId, petId } },
+    });
+    if (!vinculo) {
+      throw new ForbiddenException(
+        'Pet fora da sua lista de atendidos. Leia o QR Code da carteira para iniciar o atendimento.',
+      );
+    }
   }
 
   private async assertVeterinarioExists(veterinarioId: string): Promise<void> {

--- a/test/e2e/clinical-note.e2e-spec.ts
+++ b/test/e2e/clinical-note.e2e-spec.ts
@@ -3,7 +3,12 @@ import type { INestApplication } from '@nestjs/common';
 import type { App } from 'supertest/types';
 import request from 'supertest';
 import { createE2EApp, E2EApp } from '../utils/e2e-app';
-import { createAndLoginVet, registerTutor, resetDb } from '../utils/e2e-db';
+import {
+  createAndLoginVet,
+  registerTutor,
+  resetDb,
+  vincularPetAoVet,
+} from '../utils/e2e-db';
 import { PrismaService } from '../../src/prisma/prisma.service';
 
 describe('Nota clínica — escrita reversa (e2e)', () => {
@@ -12,6 +17,7 @@ describe('Nota clínica — escrita reversa (e2e)', () => {
   let prisma: PrismaService;
   let tutorToken: string;
   let vetToken: string;
+  let vetId: string;
   let petId: string;
 
   beforeAll(async () => {
@@ -26,7 +32,9 @@ describe('Nota clínica — escrita reversa (e2e)', () => {
   beforeEach(async () => {
     await resetDb(prisma);
     ({ token: tutorToken } = await registerTutor(app));
-    ({ token: vetToken } = await createAndLoginVet(app, prisma));
+    const vet = await createAndLoginVet(app, prisma);
+    vetToken = vet.token;
+    vetId = vet.user.id;
 
     const pet = await request(app.getHttpServer())
       .post('/pets')
@@ -34,6 +42,10 @@ describe('Nota clínica — escrita reversa (e2e)', () => {
       .send({ name: 'Rex', species: 'DOG', sex: 'MALE' })
       .expect(201);
     petId = pet.body.id as string;
+
+    // O atendimento começa pela leitura do QR Code da carteira; sem esse
+    // vínculo o prontuário não abre para o vet.
+    await vincularPetAoVet(prisma, vetId, petId);
   });
 
   it('VET cria a nota, persiste e enfileira o push; tutor consegue lê-la', async () => {
@@ -63,6 +75,20 @@ describe('Nota clínica — escrita reversa (e2e)', () => {
       .set('Authorization', `Bearer ${tutorToken}`)
       .expect(200);
     expect(list.body).toHaveLength(1);
+  });
+
+  it('proíbe VET que não atende o pet de criar nota (403)', async () => {
+    // Só o papel VET não basta: sem a leitura do QR Code o pet não está na
+    // lista dele, e o prontuário permanece fechado.
+    await prisma.petAtendido.deleteMany({ where: { petId } });
+
+    await request(app.getHttpServer())
+      .post(`/pets/${petId}/clinical-notes`)
+      .set('Authorization', `Bearer ${vetToken}`)
+      .send({ diagnostico: 'Otite externa' })
+      .expect(403);
+
+    expect(await prisma.notaClinica.count()).toBe(0);
   });
 
   it('proíbe o TUTOR de criar nota clínica (403)', async () => {

--- a/test/e2e/historico-clinico.e2e-spec.ts
+++ b/test/e2e/historico-clinico.e2e-spec.ts
@@ -3,7 +3,12 @@ import type { INestApplication } from '@nestjs/common';
 import type { App } from 'supertest/types';
 import request from 'supertest';
 import { createE2EApp, E2EApp } from '../utils/e2e-app';
-import { createAndLoginVet, registerTutor, resetDb } from '../utils/e2e-db';
+import {
+  createAndLoginVet,
+  registerTutor,
+  resetDb,
+  vincularPetAoVet,
+} from '../utils/e2e-db';
 import { PrismaService } from '../../src/prisma/prisma.service';
 import type {
   HistoricoClinicoItemResponseDto,
@@ -40,7 +45,8 @@ describe('Histórico clínico (e2e)', () => {
     const tutor = await registerTutor(app);
     tutorToken = tutor.token;
     tutorId = tutor.user.id;
-    ({ token: vetToken } = await createAndLoginVet(app, prisma));
+    const vet = await createAndLoginVet(app, prisma);
+    vetToken = vet.token;
 
     const pet = await request(app.getHttpServer())
       .post('/pets')
@@ -48,6 +54,9 @@ describe('Histórico clínico (e2e)', () => {
       .send({ name: 'Rex', species: 'DOG', sex: 'MALE' })
       .expect(201);
     petId = pet.body.id as string;
+
+    // O atendimento começa pela leitura do QR Code da carteira.
+    await vincularPetAoVet(prisma, vet.user.id, petId);
   });
 
   async function prescreverMedicacao(): Promise<string> {

--- a/test/e2e/pet.e2e-spec.ts
+++ b/test/e2e/pet.e2e-spec.ts
@@ -3,7 +3,12 @@ import type { INestApplication } from '@nestjs/common';
 import type { App } from 'supertest/types';
 import request from 'supertest';
 import { createE2EApp, E2EApp } from '../utils/e2e-app';
-import { createAndLoginVet, registerTutor, resetDb } from '../utils/e2e-db';
+import {
+  createAndLoginVet,
+  registerTutor,
+  resetDb,
+  vincularPetAoVet,
+} from '../utils/e2e-db';
 import { PrismaService } from '../../src/prisma/prisma.service';
 
 describe('Pet + prontuário (e2e)', () => {
@@ -107,14 +112,26 @@ describe('Pet + prontuário (e2e)', () => {
       .expect(403);
   });
 
-  it('permite que o VET leia o pet de qualquer tutor (200)', async () => {
+  it('permite que o VET leia o pet que ele atende (200)', async () => {
+    const petId = await createPet();
+    const vet = await createAndLoginVet(app, prisma);
+    await vincularPetAoVet(prisma, vet.user.id, petId);
+
+    await request(app.getHttpServer())
+      .get(`/pets/${petId}`)
+      .set('Authorization', `Bearer ${vet.token}`)
+      .expect(200);
+  });
+
+  it('proíbe o VET de ler pet que não atende (403)', async () => {
+    // Conhecer o id não é autorização: o vínculo vem da leitura do QR Code.
     const petId = await createPet();
     const { token: vetToken } = await createAndLoginVet(app, prisma);
 
     await request(app.getHttpServer())
       .get(`/pets/${petId}`)
       .set('Authorization', `Bearer ${vetToken}`)
-      .expect(200);
+      .expect(403);
   });
 
   it('proíbe o VET de criar pet (403)', async () => {

--- a/test/utils/e2e-db.ts
+++ b/test/utils/e2e-db.ts
@@ -86,3 +86,23 @@ export async function createAndLoginVet(
 
   return { token: res.body.access_token as string, user: res.body.user };
 }
+
+/**
+ * Põe o pet na lista de atendidos do veterinário.
+ *
+ * Em produção o vínculo nasce da leitura do QR Code da carteira
+ * (`POST /veterinarios/me/pets`) — é ele que autoriza o vet a abrir o
+ * prontuário. Aqui é criado direto, no mesmo espírito de `createAndLoginVet`:
+ * o cenário sob teste é o que vem depois do atendimento começar.
+ */
+export async function vincularPetAoVet(
+  prisma: PrismaService,
+  veterinarioId: string,
+  petId: string,
+): Promise<void> {
+  await prisma.petAtendido.upsert({
+    where: { veterinarioId_petId: { veterinarioId, petId } },
+    create: { veterinarioId, petId },
+    update: { ultimoAcessoEm: new Date() },
+  });
+}


### PR DESCRIPTION
Achado mais grave da auditoria: **BOLA** (OWASP A01 / CWE-639) no prontuário.

## O furo

`PetService.assertAccess(petId, userId, isVet)` devolvia o pet a **qualquer** veterinário quando `isVet` era verdadeiro — sem checar vínculo nenhum. São 13 pontos de chamada: vacina, vermífugo, medicação e histórico clínico.

`VetNoteService` era pior: nem passava por lá. `create` não checava nada além de o pet existir.

Resultado: com o id de um pet, um veterinário verificado lia e escrevia no prontuário de **qualquer animal da base**. Ids são UUID, mas basta um vazar — e o próprio app os expõe a quem já atendeu o pet uma vez.

## O modelo certo já existia

A tabela `PetAtendido`, alimentada por `POST /veterinarios/me/pets` na leitura do QR Code. O comentário do próprio código diz: *"ter o token do QR é a autorização de fato"*. Só não era exigida na leitura — apenas na escrita, e indiretamente.

Agora `assertAccess` exige o vínculo, e `VetNoteService` ganhou a mesma checagem. O fluxo do app não muda: `PublicCardPage` já chama `adicionarPetAtendido` logo após o scan, antes de navegar para o perfil.

## Vazamento do hash de senha

`TutorService.findById` devolvia a linha inteira do Prisma. O hash bcrypt do tutor saía em `GET /tutors/me`, `PATCH /tutors/me` e — pior — em `GET /tutors/:id`, legível por qualquer veterinário logado. O `VeterinarioService` ao lado já fazia o strip; o de tutor, não.

`GET /tutors/:id` passa também a exigir vínculo com algum pet do tutor: o papel VET não dá acesso ao cadastro de todo mundo.

## Mass assignment

`updateById` espalhava o DTO no `data` do Prisma. Campos agora listados um a um — a superfície de escrita não fica a reboque do DTO.

## Testes

Vários testes **afirmavam o comportamento inseguro** — chamavam-se *"permite VET registrar em qualquer pet"* e *"permite acesso de VET mesmo sem ser dono"*. Foram reescritos para exigir o vínculo, e cada um ganhou o caso inverso, verificando o 403.

Novos: `assertAccess` coberto direto nos cinco caminhos, tutor sem vínculo barrado, hash ausente das respostas, e no e2e um veterinário sem vínculo levando 403 ao criar nota.

**465 unitários e 47 e2e** contra Postgres real.