### PR TITLE
feat(segurança): rate limit na autenticação, cabeçalhos e senhas mais fortes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "class-validator": "^0.15.1",
         "firebase-admin": "^14.1.0",
         "googleapis": "^172.0.0",
+        "helmet": "^8.3.0",
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
         "qrcode": "^1.5.4",
@@ -9307,6 +9308,18 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.3.0.tgz",
+      "integrity": "sha512-Qgpiaws3Sm30Av8Eah6sjMCZZwjlBu+E68rhpCWBshY1lb09HtLwj5GviX0OyQIn+ulUS0iX0AxN5n3tLZzz1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/EvanHahn"
       }
     },
     "node_modules/html-entities": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "class-validator": "^0.15.1",
     "firebase-admin": "^14.1.0",
     "googleapis": "^172.0.0",
+    "helmet": "^8.3.0",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "qrcode": "^1.5.4",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
-import { ConfigModule } from '@nestjs/config';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 import { ScheduleModule } from '@nestjs/schedule';
+import { ThrottlerModule } from '@nestjs/throttler';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { appConfig } from './config/app.config';
@@ -14,6 +15,7 @@ import { rabbitmqConfig } from './config/rabbitmq.config';
 import { reminderConfig } from './config/reminder.config';
 import { googleCalendarConfig } from './config/google-calendar.config';
 import { encryptionConfig } from './config/encryption.config';
+import { throttlerConfig } from './config/throttler.config';
 import { CryptoModule } from './common/crypto/crypto.module';
 import { AppointmentModule } from './modules/appointment/appointment.module';
 import { AuthModule } from './modules/auth/auth.module';
@@ -50,7 +52,27 @@ import { PrismaModule } from './prisma/prisma.module';
         reminderConfig,
         googleCalendarConfig,
         encryptionConfig,
+        throttlerConfig,
       ],
+    }),
+    // Registro único e global dos limites. Ficava dentro do CardModule, o que
+    // dava a impressão de que só a carteira pública podia ser limitada.
+    ThrottlerModule.forRootAsync({
+      inject: [ConfigService],
+      useFactory: (config: ConfigService) => ({
+        throttlers: [
+          {
+            name: 'auth',
+            ttl: config.get<number>('throttler.authTtlSeconds', 60) * 1000,
+            limit: config.get<number>('throttler.authLimit', 10),
+          },
+          {
+            name: 'public-card',
+            ttl: config.get<number>('card.publicThrottleTtlSeconds', 60) * 1000,
+            limit: config.get<number>('card.publicThrottleLimit', 10),
+          },
+        ],
+      }),
     }),
     ScheduleModule.forRoot(),
     CryptoModule,

--- a/src/common/crypto/password.constants.ts
+++ b/src/common/crypto/password.constants.ts
@@ -1,0 +1,20 @@
+/**
+ * Parâmetros de senha, num lugar só.
+ *
+ * O custo do bcrypt estava em 10 e repetido em dois serviços — subir um e
+ * esquecer o outro deixaria metade das contas com hash mais fraco. 12 é o
+ * piso recomendado hoje para bcrypt; o custo é exponencial, então cada
+ * incremento dobra o trabalho de quem tenta quebrar offline.
+ */
+export const BCRYPT_ROUNDS = 12;
+
+/** Mínimo aceito no cadastro. */
+export const PASSWORD_MIN_LENGTH = 8;
+
+/**
+ * Teto de 72 bytes: o bcrypt ignora silenciosamente o que passa disso, então
+ * uma senha maior daria ao usuário uma falsa sensação de força. Recusar é
+ * melhor que truncar sem avisar — e barra corpo grande virando trabalho de
+ * hash caro (o cadastro e o login são rotas sem sessão).
+ */
+export const PASSWORD_MAX_LENGTH = 72;

--- a/src/config/__tests__/config.spec.ts
+++ b/src/config/__tests__/config.spec.ts
@@ -1,5 +1,7 @@
 import { appConfig } from '../app.config';
 import { firebaseConfig } from '../firebase.config';
+import { authConfig } from '../auth.config';
+import { throttlerConfig } from '../throttler.config';
 
 /**
  * Só o que morde de verdade na configuração.
@@ -17,6 +19,9 @@ const CHAVES = [
   'FIREBASE_PROJECT_ID',
   'FIREBASE_CLIENT_EMAIL',
   'FIREBASE_PRIVATE_KEY',
+  'AUTH_THROTTLE_LIMIT',
+  'AUTH_THROTTLE_TTL_SECONDS',
+  'JWT_SECRET',
 ] as const;
 
 describe('configuração de ambiente', () => {
@@ -94,6 +99,59 @@ describe('configuração de ambiente', () => {
       // A chave vem do JSON do service account com `\n` literal; sem desescapar,
       // o Firebase Admin recusa a credencial.
       expect(firebaseConfig().privateKey).toBe('-----BEGIN\nKEY-----');
+    });
+  });
+
+  describe('rate limit das rotas de autenticação', () => {
+    it('usa os padrões quando o ambiente não diz nada', () => {
+      expect(throttlerConfig()).toEqual({ authTtlSeconds: 60, authLimit: 10 });
+    });
+
+    it('respeita os valores declarados', () => {
+      process.env.AUTH_THROTTLE_LIMIT = '3';
+      process.env.AUTH_THROTTLE_TTL_SECONDS = '120';
+
+      expect(throttlerConfig()).toEqual({
+        authTtlSeconds: 120,
+        authLimit: 3,
+      });
+    });
+
+    it('ignora valor inválido em vez de desligar o limite', () => {
+      // NaN como limite faz o throttler liberar tudo: o erro de digitação
+      // derrubaria em silêncio a proteção de força bruta.
+      process.env.AUTH_THROTTLE_LIMIT = 'dez';
+      process.env.AUTH_THROTTLE_TTL_SECONDS = '0';
+
+      expect(throttlerConfig()).toEqual({ authTtlSeconds: 60, authLimit: 10 });
+    });
+  });
+
+  describe('segredo do JWT', () => {
+    it('recusa subir em produção sem segredo', () => {
+      process.env.NODE_ENV = 'production';
+
+      expect(() => authConfig()).toThrow(/JWT_SECRET is required/);
+    });
+
+    it('recusa segredo curto demais em produção', () => {
+      // Segredo curto é adivinhável, e quem o adivinha emite token de
+      // qualquer usuário.
+      process.env.NODE_ENV = 'production';
+      process.env.JWT_SECRET = 'curto';
+
+      expect(() => authConfig()).toThrow(/at least 32 characters/);
+    });
+
+    it('aceita segredo longo em produção', () => {
+      process.env.NODE_ENV = 'production';
+      process.env.JWT_SECRET = 'a'.repeat(32);
+
+      expect(authConfig().jwtSecret).toHaveLength(32);
+    });
+
+    it('não trava o desenvolvimento local sem segredo', () => {
+      expect(authConfig().jwtSecret).toBeUndefined();
     });
   });
 });

--- a/src/config/auth.config.ts
+++ b/src/config/auth.config.ts
@@ -1,6 +1,42 @@
 import { registerAs } from '@nestjs/config';
 
+/** Piso de entropia para um segredo de assinatura em produção. */
+const MIN_SECRET_LENGTH = 32;
+
+/**
+ * O segredo do JWT assina todo token de sessão e o `state` do OAuth do
+ * Calendar. Quem o adivinha emite token de qualquer usuário.
+ *
+ * Ausente, o boot seguia e só quebrava na primeira assinatura; curto, era
+ * aceito sem reclamação. Mesma escolha do CORS: falhar no boot é melhor que
+ * subir com a proteção capenga.
+ */
+function parseJwtSecret(
+  raw: string | undefined,
+  nodeEnv: string,
+): string | undefined {
+  if (!raw) {
+    if (nodeEnv === 'production') {
+      throw new Error(
+        'JWT_SECRET is required in production. Generate one with: openssl rand -hex 32',
+      );
+    }
+    return undefined;
+  }
+
+  if (nodeEnv === 'production' && raw.length < MIN_SECRET_LENGTH) {
+    throw new Error(
+      `JWT_SECRET must be at least ${MIN_SECRET_LENGTH} characters in production. Generate one with: openssl rand -hex 32`,
+    );
+  }
+
+  return raw;
+}
+
 export const authConfig = registerAs('auth', () => ({
-  jwtSecret: process.env.JWT_SECRET,
+  jwtSecret: parseJwtSecret(
+    process.env.JWT_SECRET,
+    process.env.NODE_ENV ?? 'development',
+  ),
   jwtExpiresIn: process.env.JWT_EXPIRES_IN ?? '7d',
 }));

--- a/src/config/throttler.config.ts
+++ b/src/config/throttler.config.ts
@@ -1,0 +1,32 @@
+import { registerAs } from '@nestjs/config';
+
+const DEFAULT_TTL_SECONDS = 60;
+const DEFAULT_LIMIT = 10;
+
+/**
+ * Lê um inteiro positivo do ambiente, caindo no padrão quando o valor não
+ * serve.
+ *
+ * `Number('dez')` é `NaN`, e `NaN` como limite faz o throttler parar de
+ * limitar — a variável mal preenchida desligaria em silêncio justamente a
+ * proteção de força bruta que ela deveria calibrar.
+ */
+function inteiroPositivo(valor: string | undefined, padrao: number): number {
+  const numero = Number(valor);
+  return Number.isInteger(numero) && numero > 0 ? numero : padrao;
+}
+
+/**
+ * Rate limit das rotas sem sessão (login e cadastro).
+ *
+ * Elas eram as únicas superfícies públicas sem limite: dava para varrer senhas
+ * contra `POST /auth/login` na velocidade que a rede permitisse. O limite é por
+ * IP e por janela.
+ */
+export const throttlerConfig = registerAs('throttler', () => ({
+  authTtlSeconds: inteiroPositivo(
+    process.env.AUTH_THROTTLE_TTL_SECONDS,
+    DEFAULT_TTL_SECONDS,
+  ),
+  authLimit: inteiroPositivo(process.env.AUTH_THROTTLE_LIMIT, DEFAULT_LIMIT),
+}));

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,8 @@ import { ConfigService } from '@nestjs/config';
 import { NestFactory } from '@nestjs/core';
 import { MicroserviceOptions, Transport } from '@nestjs/microservices';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import helmet from 'helmet';
+import { json, urlencoded } from 'express';
 import { AppModule } from './app.module';
 import {
   CALENDAR_SYNC_DLQ_ROUTING_KEY,
@@ -13,9 +15,39 @@ import {
   QR_CODE_DLX,
 } from './modules/queue/queue.constants';
 
+/** Tamanho máximo de um corpo JSON aceito. Uploads vão por multipart. */
+const JSON_BODY_LIMIT = '1mb';
+
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   const config = app.get(ConfigService);
+
+  // Cabeçalhos de segurança (HSTS, X-Content-Type-Options, frame-ancestors e
+  // afins). A API responde JSON e as duas páginas HTML do fluxo OAuth, que não
+  // carregam script externo — daí a CSP fechada.
+  app.use(
+    helmet({
+      contentSecurityPolicy: {
+        directives: {
+          defaultSrc: ["'none'"],
+          scriptSrc: ["'self'"],
+          styleSrc: ["'self'", "'unsafe-inline'"],
+          connectSrc: ["'self'"],
+          imgSrc: ["'self'", 'data:'],
+          formAction: ["'none'"],
+          frameAncestors: ["'none'"],
+          baseUri: ["'none'"],
+        },
+      },
+      crossOriginResourcePolicy: { policy: 'same-site' },
+      referrerPolicy: { policy: 'no-referrer' },
+    }),
+  );
+
+  // Teto do corpo das requisições: sem ele o Express aceita payload de
+  // qualquer tamanho e um POST grande vira consumo de memória do processo.
+  app.use(json({ limit: JSON_BODY_LIMIT }));
+  app.use(urlencoded({ extended: true, limit: JSON_BODY_LIMIT }));
 
   app.enableCors({
     origin: config.get<string[]>('app.corsOrigins'),

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -1,9 +1,11 @@
 import { Body, Controller, Get, Post, UseGuards } from '@nestjs/common';
+import { SkipThrottle, Throttle, ThrottlerGuard } from '@nestjs/throttler';
 import {
   ApiBearerAuth,
   ApiConflictResponse,
   ApiOperation,
   ApiTags,
+  ApiTooManyRequestsResponse,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
 import { CreateVeterinarioDto } from '@petcardorg/shared';
@@ -17,6 +19,10 @@ import { Role } from './enums/role.enum';
 import { JwtAuthGuard } from './guards/jwt-auth.guard';
 import type { JwtPayload } from './strategies/jwt.strategy';
 
+/**
+ * Rotas sem sessão levam rate limit por IP: são a superfície de força bruta de
+ * credenciais e de enumeração de contas cadastradas.
+ */
 @ApiTags('auth')
 @Controller('auth')
 export class AuthController {
@@ -24,6 +30,13 @@ export class AuthController {
 
   @Post('register')
   @Public()
+  @UseGuards(ThrottlerGuard)
+  // O guard avalia TODOS os throttlers nomeados da configuração, não só o
+  // citado no @Throttle. Sem dispensar o da carteira pública, o limite dela
+  // (bem mais apertado) é que valeria aqui.
+  @Throttle({ auth: {} })
+  @SkipThrottle({ 'public-card': true })
+  @ApiTooManyRequestsResponse({ description: 'Limite de tentativas excedido' })
   @ApiOperation({ summary: 'Registrar novo tutor' })
   @ApiConflictResponse({ description: 'Email já cadastrado' })
   register(@Body() dto: RegisterDto) {
@@ -32,6 +45,13 @@ export class AuthController {
 
   @Post('login')
   @Public()
+  @UseGuards(ThrottlerGuard)
+  // O guard avalia TODOS os throttlers nomeados da configuração, não só o
+  // citado no @Throttle. Sem dispensar o da carteira pública, o limite dela
+  // (bem mais apertado) é que valeria aqui.
+  @Throttle({ auth: {} })
+  @SkipThrottle({ 'public-card': true })
+  @ApiTooManyRequestsResponse({ description: 'Limite de tentativas excedido' })
   @ApiOperation({ summary: 'Login do tutor (JWT com role TUTOR)' })
   @ApiUnauthorizedResponse({ description: 'Credenciais inválidas' })
   login(@Body() dto: LoginDto) {
@@ -49,6 +69,13 @@ export class AuthController {
 
   @Post('veterinario/register')
   @Public()
+  @UseGuards(ThrottlerGuard)
+  // O guard avalia TODOS os throttlers nomeados da configuração, não só o
+  // citado no @Throttle. Sem dispensar o da carteira pública, o limite dela
+  // (bem mais apertado) é que valeria aqui.
+  @Throttle({ auth: {} })
+  @SkipThrottle({ 'public-card': true })
+  @ApiTooManyRequestsResponse({ description: 'Limite de tentativas excedido' })
   @ApiOperation({
     summary: 'Cadastrar veterinário (JWT com role VET)',
     description:
@@ -63,6 +90,13 @@ export class AuthController {
 
   @Post('veterinario/login')
   @Public()
+  @UseGuards(ThrottlerGuard)
+  // O guard avalia TODOS os throttlers nomeados da configuração, não só o
+  // citado no @Throttle. Sem dispensar o da carteira pública, o limite dela
+  // (bem mais apertado) é que valeria aqui.
+  @Throttle({ auth: {} })
+  @SkipThrottle({ 'public-card': true })
+  @ApiTooManyRequestsResponse({ description: 'Limite de tentativas excedido' })
   @ApiOperation({ summary: 'Login do veterinário (JWT com role VET)' })
   @ApiUnauthorizedResponse({ description: 'Credenciais inválidas' })
   loginVeterinario(@Body() dto: LoginDto) {

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -9,13 +9,27 @@ import {
 import { JwtService } from '@nestjs/jwt';
 import * as bcrypt from 'bcrypt';
 import { CreateVeterinarioDto } from '@petcardorg/shared';
+import { BCRYPT_ROUNDS } from '../../common/crypto/password.constants';
 import { PrismaService } from '../../prisma/prisma.service';
 import { CrmvVerificationService } from '../veterinario/crmv/crmv-verification.service';
 import { LoginDto } from './dto/login.dto';
 import { RegisterDto } from './dto/register.dto';
 import { Role } from './enums/role.enum';
 
-const BCRYPT_ROUNDS = 10;
+/**
+ * Hash descartável, com o mesmo custo dos reais, comparado quando o e-mail não
+ * existe.
+ *
+ * Sem ele o login respondia na hora para e-mail inexistente e só depois do
+ * bcrypt para e-mail cadastrado — diferença medível, que transforma a rota num
+ * oráculo de quais e-mails têm conta no PetCard. Calculado uma vez, na
+ * primeira tentativa frustrada, para não custar 12 rounds no boot.
+ */
+let dummyHash: Promise<string> | undefined;
+function getDummyHash(): Promise<string> {
+  dummyHash ??= bcrypt.hash('petcard-dummy-password', BCRYPT_ROUNDS);
+  return dummyHash;
+}
 
 @Injectable()
 export class AuthService {
@@ -65,13 +79,12 @@ export class AuthService {
       where: { email: dto.email },
     });
 
-    if (!tutor) {
-      throw new UnauthorizedException('Invalid credentials');
-    }
+    const passwordValid = await bcrypt.compare(
+      dto.password,
+      tutor?.password ?? (await getDummyHash()),
+    );
 
-    const passwordValid = await bcrypt.compare(dto.password, tutor.password);
-
-    if (!passwordValid) {
+    if (!tutor || !passwordValid) {
       throw new UnauthorizedException('Invalid credentials');
     }
 
@@ -160,13 +173,12 @@ export class AuthService {
       where: { email: dto.email },
     });
 
-    if (!vet) {
-      throw new UnauthorizedException('Invalid credentials');
-    }
+    const passwordValid = await bcrypt.compare(
+      dto.password,
+      vet?.password ?? (await getDummyHash()),
+    );
 
-    const passwordValid = await bcrypt.compare(dto.password, vet.password);
-
-    if (!passwordValid) {
+    if (!vet || !passwordValid) {
       throw new UnauthorizedException('Invalid credentials');
     }
 

--- a/src/modules/auth/dto/login.dto.ts
+++ b/src/modules/auth/dto/login.dto.ts
@@ -1,9 +1,15 @@
-import { IsEmail, IsString } from 'class-validator';
+import { IsEmail, IsString, MaxLength } from 'class-validator';
+import { PASSWORD_MAX_LENGTH } from '../../../common/crypto/password.constants';
 
 export class LoginDto {
   @IsEmail()
+  @MaxLength(254)
   email: string;
 
+  // Sem teto, o corpo do login era ilimitado e cada tentativa arrastava o
+  // bcrypt junto. O login não exige tamanho mínimo — senha antiga curta
+  // continua entrando; o mínimo vale para quem cadastra.
   @IsString()
+  @MaxLength(PASSWORD_MAX_LENGTH)
   password: string;
 }

--- a/src/modules/auth/dto/register.dto.ts
+++ b/src/modules/auth/dto/register.dto.ts
@@ -1,14 +1,21 @@
-import { IsEmail, IsString, MinLength } from 'class-validator';
+import { IsEmail, IsString, MaxLength, MinLength } from 'class-validator';
+import {
+  PASSWORD_MAX_LENGTH,
+  PASSWORD_MIN_LENGTH,
+} from '../../../common/crypto/password.constants';
 
 export class RegisterDto {
   @IsString()
   @MinLength(2)
+  @MaxLength(120)
   name: string;
 
   @IsEmail()
+  @MaxLength(254)
   email: string;
 
   @IsString()
-  @MinLength(6)
+  @MinLength(PASSWORD_MIN_LENGTH)
+  @MaxLength(PASSWORD_MAX_LENGTH)
   password: string;
 }

--- a/src/modules/card/card.controller.ts
+++ b/src/modules/card/card.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Get, Param, UseGuards } from '@nestjs/common';
-import { Throttle, ThrottlerGuard } from '@nestjs/throttler';
+import { SkipThrottle, Throttle, ThrottlerGuard } from '@nestjs/throttler';
 import {
   ApiForbiddenResponse,
   ApiNotFoundResponse,
@@ -61,6 +61,9 @@ export class CardController {
   @Public()
   @UseGuards(ThrottlerGuard)
   @Throttle({ 'public-card': {} })
+  // Pelo mesmo motivo do @SkipThrottle no auth.controller: o guard olharia
+  // também o throttler de autenticação.
+  @SkipThrottle({ auth: true })
   @ApiOperation({
     summary: 'Carteira pública por token do QR Code (sem autenticação)',
   })

--- a/src/modules/card/card.module.ts
+++ b/src/modules/card/card.module.ts
@@ -1,6 +1,4 @@
 import { Module } from '@nestjs/common';
-import { ConfigModule, ConfigService } from '@nestjs/config';
-import { ThrottlerModule } from '@nestjs/throttler';
 import { AuthModule } from '../auth/auth.module';
 import { TutorModule } from '../tutor/tutor.module';
 import { VeterinarioModule } from '../veterinario/veterinario.module';
@@ -8,24 +6,7 @@ import { CardController } from './card.controller';
 import { CardService } from './card.service';
 
 @Module({
-  imports: [
-    AuthModule,
-    TutorModule,
-    VeterinarioModule,
-    ThrottlerModule.forRootAsync({
-      imports: [ConfigModule],
-      inject: [ConfigService],
-      useFactory: (config: ConfigService) => ({
-        throttlers: [
-          {
-            name: 'public-card',
-            ttl: config.get<number>('card.publicThrottleTtlSeconds', 60) * 1000,
-            limit: config.get<number>('card.publicThrottleLimit', 10),
-          },
-        ],
-      }),
-    }),
-  ],
+  imports: [AuthModule, TutorModule, VeterinarioModule],
   controllers: [CardController],
   providers: [CardService],
   exports: [CardService],

--- a/src/modules/veterinario/veterinario.service.ts
+++ b/src/modules/veterinario/veterinario.service.ts
@@ -4,6 +4,7 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { Prisma, Veterinario } from '@prisma/client';
+import { BCRYPT_ROUNDS } from '../../common/crypto/password.constants';
 import { PrismaService } from '../../prisma/prisma.service';
 import {
   PetAtendidoResponseDto,
@@ -15,7 +16,6 @@ import { DashboardQueryDto } from './dto/dashboard-query.dto';
 const bcrypt = require('bcrypt') as {
   hash(data: string, rounds: number): Promise<string>;
 };
-const BCRYPT_ROUNDS = 10;
 
 export type VeterinarioResponse = Omit<Veterinario, 'password'>;
 

--- a/test/e2e/auth-throttle.e2e-spec.ts
+++ b/test/e2e/auth-throttle.e2e-spec.ts
@@ -1,0 +1,75 @@
+import type { INestApplication } from '@nestjs/common';
+import type { App } from 'supertest/types';
+import request from 'supertest';
+import { createE2EApp, E2EApp } from '../utils/e2e-app';
+import { resetDb } from '../utils/e2e-db';
+import { PrismaService } from '../../src/prisma/prisma.service';
+
+const LIMITE = 3;
+
+/**
+ * Rate limit das rotas sem sessão.
+ *
+ * As rotas de login e cadastro eram a única superfície pública sem limite:
+ * dava para varrer senhas contra `POST /auth/login` na velocidade da rede. O
+ * teto real vem do ambiente, então esta suíte sobe um app próprio com um
+ * limite baixo — o resto do e2e roda com teto alto para não se auto-bloquear.
+ */
+describe('Rate limit de autenticação (e2e)', () => {
+  let ctx: E2EApp;
+  let app: INestApplication<App>;
+  let prisma: PrismaService;
+  let limiteOriginal: string | undefined;
+
+  beforeAll(async () => {
+    limiteOriginal = process.env.AUTH_THROTTLE_LIMIT;
+    // Lido no boot do módulo: precisa estar posto antes do createE2EApp.
+    process.env.AUTH_THROTTLE_LIMIT = String(LIMITE);
+
+    ctx = await createE2EApp();
+    ({ app, prisma } = ctx);
+    await resetDb(prisma);
+  });
+
+  afterAll(async () => {
+    await app.close();
+    if (limiteOriginal === undefined) delete process.env.AUTH_THROTTLE_LIMIT;
+    else process.env.AUTH_THROTTLE_LIMIT = limiteOriginal;
+  });
+
+  it('corta a força bruta de senha depois do limite de tentativas', async () => {
+    const tentativa = () =>
+      request(app.getHttpServer())
+        .post('/auth/login')
+        .send({ email: 'ninguem@petcard.com', password: 'chute' });
+
+    // Credencial errada responde 401 enquanto há orçamento na janela.
+    for (let i = 0; i < LIMITE; i++) {
+      await tentativa().expect(401);
+    }
+
+    // Estourado o limite, o IP para de ser atendido — inclusive antes de
+    // qualquer consulta ao banco.
+    await tentativa().expect(429);
+  });
+
+  it('o cadastro também é limitado, com orçamento próprio', async () => {
+    // O throttler conta por rota: estourar o login não fecha o cadastro. Cada
+    // superfície tem o seu teto, e ambas têm um.
+    const cadastro = (i: number) =>
+      request(app.getHttpServer())
+        .post('/auth/register')
+        .send({
+          name: 'Alice',
+          email: `nova${i}@petcard.com`,
+          password: 'senha123',
+        });
+
+    for (let i = 0; i < LIMITE; i++) {
+      await cadastro(i).expect(201);
+    }
+
+    await cadastro(LIMITE).expect(429);
+    expect(await prisma.tutor.count()).toBe(LIMITE);
+  });
+});

--- a/test/e2e/setup-env.ts
+++ b/test/e2e/setup-env.ts
@@ -12,6 +12,10 @@ process.env.JWT_EXPIRES_IN ??= '1h';
 // Chave AES-256-GCM válida (32 bytes em hex). Só usada em fluxos de OAuth.
 process.env.ENCRYPTION_KEY ??= '0'.repeat(64);
 process.env.RABBITMQ_URL ??= 'amqp://localhost:5672';
+// A suíte registra dezenas de contas do mesmo IP; com o limite de produção ela
+// se auto-bloqueia no meio. O rate limit em si tem spec própria
+// (auth-throttle.e2e-spec.ts), que sobe um app com o teto apertado.
+process.env.AUTH_THROTTLE_LIMIT ??= '1000';
 process.env.FCM_ENABLED ??= 'false';
 // Geocoding/Places exigem a chave no construtor; os fluxos de clínica não são
 // exercitados no e2e, então um valor dummy só satisfaz o boot.

--- a/test/utils/controller-harness.ts
+++ b/test/utils/controller-harness.ts
@@ -7,6 +7,7 @@ import {
   ValidationPipe,
 } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
+import { ThrottlerModule } from '@nestjs/throttler';
 import type { App } from 'supertest/types';
 import { JwtAuthGuard } from '../../src/modules/auth/guards/jwt-auth.guard';
 import { JwtPayload } from '../../src/modules/auth/strategies/jwt.strategy';
@@ -46,6 +47,17 @@ export async function createControllerTestApp(opts: {
   let currentUser: TestUser | null = TUTOR;
 
   const moduleRef: TestingModule = await Test.createTestingModule({
+    // Os limites reais entram em produção pelo AppModule. Aqui os nomes
+    // precisam existir para o ThrottlerGuard resolver, com teto alto para o
+    // rate limit não reprovar suíte nenhuma.
+    imports: [
+      ThrottlerModule.forRoot({
+        throttlers: [
+          { name: 'auth', ttl: 60_000, limit: 10_000 },
+          { name: 'public-card', ttl: 60_000, limit: 10_000 },
+        ],
+      }),
+    ],
     controllers: opts.controllers,
     providers: opts.providers,
   })


### PR DESCRIPTION
Endurecimento das rotas de autenticação, saído da auditoria. Agrupado porque é tudo a mesma superfície.

## Rate limit (CWE-307)

Login e cadastro eram a única superfície pública **sem limite**. O `@nestjs/throttler` já era dependência, mas só a carteira pública o usava.

O registro sai do `CardModule` e vai para o `AppModule`, com um throttler `auth` próprio (10 tentativas / 60s por IP, configurável).

**Armadilha que o e2e pegou:** o `ThrottlerGuard` avalia **todos** os throttlers nomeados da configuração, não apenas o citado no `@Throttle`. Com os dois registrados, as rotas de auth herdavam o limite bem mais apertado da carteira pública, e o valor configurado para auth não valia nada. Resolvido com `@SkipThrottle` cruzado nos dois controllers.

Os buckets são **por rota**: estourar o login não fecha o cadastro. Cada superfície tem o seu teto, e ambas têm um.

## Cabeçalhos e corpo

`helmet` com CSP fechada, HSTS, `frame-ancestors: none` — a API não devolvia cabeçalho de segurança nenhum. E teto de 1MB no corpo JSON.

## JWT_SECRET (CWE-521)

Conferida no boot, mínimo de 32 caracteres em produção. Antes, ausente, o boot seguia e só quebrava na primeira assinatura. A validação ficou no `auth.config`, seguindo o padrão que o CORS já usava — e não no `main.ts`, que não é coberto por teste.

## Senhas

| | Antes | Depois |
| --- | --- | --- |
| Custo bcrypt | 10, **duplicado** em dois serviços | **12**, num só lugar |
| Mínimo | 6 | **8** |
| Máximo | nenhum | **72** (acima disso o bcrypt trunca calado) |

E o login passa a rodar em tempo constante: antes, e-mail inexistente respondia na hora e e-mail cadastrado só depois do bcrypt — diferença medível, que fazia da rota um oráculo de quais e-mails têm conta.

## Testes

**459 unitários e 47 e2e.** O `auth-throttle.e2e-spec.ts` sobe um app com teto baixo e prova o 429 de verdade; o resto da suíte roda com teto alto para não se autobloquear. A config do throttler recusa valor inválido em vez de virar `NaN` — que desligaria o limite em silêncio — e isso tem teste.