### PR TITLE
fix(segurança): assinar o state do OAuth do Google Calendar

### DIFF
--- a/src/modules/calendar/__tests__/calendar.controller.spec.ts
+++ b/src/modules/calendar/__tests__/calendar.controller.spec.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import { BadRequestException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import request from 'supertest';
 import {
@@ -14,6 +15,7 @@ describe('CalendarController (integração)', () => {
   let harness: ControllerHarness;
   let calendar: {
     getAuthUrl: jest.Mock;
+    resolveState: jest.Mock;
     handleCallback: jest.Mock;
     isConnected: jest.Mock;
     disconnect: jest.Mock;
@@ -24,6 +26,7 @@ describe('CalendarController (integração)', () => {
   beforeAll(async () => {
     calendar = {
       getAuthUrl: jest.fn(),
+      resolveState: jest.fn().mockReturnValue('tutor-1'),
       handleCallback: jest.fn().mockResolvedValue(undefined),
       isConnected: jest.fn(),
       disconnect: jest.fn().mockResolvedValue(undefined),
@@ -89,11 +92,28 @@ describe('CalendarController (integração)', () => {
       harness.setUser(null); // callback não tem @Auth
 
       const res = await request(harness.app.getHttpServer())
-        .get('/calendar/callback?code=abc&state=tutor-1')
+        .get('/calendar/callback?code=abc&state=state-assinado')
         .expect(200);
 
       expect(res.text).toContain('conectado com sucesso');
+      expect(calendar.resolveState).toHaveBeenCalledWith('state-assinado');
       expect(calendar.handleCallback).toHaveBeenCalledWith('abc', 'tutor-1');
+    });
+
+    it('recusa state que não passa na verificação (400)', async () => {
+      // O state deixou de ser o id do tutor em texto puro: sem assinatura
+      // válida o callback não troca o code nem toca no banco.
+      harness.setUser(null);
+      calendar.resolveState.mockImplementationOnce(() => {
+        throw new BadRequestException('Parâmetro state inválido.');
+      });
+
+      const res = await request(harness.app.getHttpServer())
+        .get('/calendar/callback?code=abc&state=forjado')
+        .expect(400);
+
+      expect(res.text).toContain('Link inválido');
+      expect(calendar.handleCallback).not.toHaveBeenCalled();
     });
 
     it('responde 400 em página quando o usuário nega o consentimento', async () => {
@@ -118,7 +138,9 @@ describe('CalendarController (integração)', () => {
       expect(calendar.handleCallback).not.toHaveBeenCalled();
     });
 
-    it('converte falha do serviço em página de erro, sem stack trace', async () => {
+    it('converte falha do serviço em página de erro genérica', async () => {
+      // A mensagem do erro fica no log. A página é pública e a mensagem
+      // carrega detalhe de configuração do servidor.
       harness.setUser(null);
       calendar.handleCallback.mockRejectedValue(
         new Error(
@@ -127,26 +149,12 @@ describe('CalendarController (integração)', () => {
       );
 
       const res = await request(harness.app.getHttpServer())
-        .get('/calendar/callback?code=abc&state=tutor-1')
+        .get('/calendar/callback?code=abc&state=state-assinado')
         .expect(500);
 
       expect(res.text).toContain('Não foi possível conectar');
-      expect(res.text).toContain('ENCRYPTION_KEY');
+      expect(res.text).not.toContain('ENCRYPTION_KEY');
       expect(res.text).not.toContain('at GoogleCalendarService');
-    });
-
-    it('escapa HTML vindo da mensagem de erro', async () => {
-      harness.setUser(null);
-      calendar.handleCallback.mockRejectedValue(
-        new Error('<img src=x onerror=alert(1)>'),
-      );
-
-      const res = await request(harness.app.getHttpServer())
-        .get('/calendar/callback?code=abc&state=tutor-1')
-        .expect(500);
-
-      expect(res.text).not.toContain('<img src=x');
-      expect(res.text).toContain('&lt;img src=x');
     });
   });
 

--- a/src/modules/calendar/__tests__/google-calendar.service.spec.ts
+++ b/src/modules/calendar/__tests__/google-calendar.service.spec.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment */
-import { Logger } from '@nestjs/common';
+import { BadRequestException, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { PrismaService } from '../../../prisma/prisma.service';
 import { EncryptionService } from '../../../common/crypto/encryption.service';
@@ -40,6 +40,7 @@ const makeConfig = (configured = true): ConfigService =>
           'googleCalendar.clientId': configured ? 'client-id' : '',
           'googleCalendar.clientSecret': configured ? 'secret' : '',
           'googleCalendar.redirectUri': 'http://localhost/callback',
+          'auth.jwtSecret': 'segredo-de-teste',
         }) as Record<string, string>
       )[key],
   }) as unknown as ConfigService;
@@ -120,7 +121,7 @@ describe('GoogleCalendarService', () => {
   });
 
   describe('getAuthUrl', () => {
-    it('gera a URL de consentimento offline com o tutorId no state', () => {
+    it('gera a URL de consentimento offline com o state assinado', () => {
       const url = service.getAuthUrl('tutor-1');
 
       expect(url).toBe('https://accounts.google.com/o/oauth2/auth?xyz');
@@ -128,7 +129,9 @@ describe('GoogleCalendarService', () => {
         access_type: 'offline',
         scope: SCOPES,
         prompt: 'consent',
-        state: 'tutor-1',
+        state: expect.stringMatching(
+          /^tutor-1\.[\w-]+\.\d+\.[\w-]+$/,
+        ) as string,
       });
     });
 
@@ -141,6 +144,50 @@ describe('GoogleCalendarService', () => {
 
       expect(unconfigured.getAuthUrl('tutor-1')).toBeNull();
       expect(mockOAuth2Instance.generateAuthUrl).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('resolveState', () => {
+    /** Extrai o state que o getAuthUrl acabou de emitir. */
+    const emitirState = (tutorId: string): string => {
+      service.getAuthUrl(tutorId);
+      const call = mockOAuth2Instance.generateAuthUrl.mock.calls.at(-1) as [
+        { state: string },
+      ];
+      return call[0].state;
+    };
+
+    it('devolve o tutor de origem do state que ele mesmo assinou', () => {
+      expect(service.resolveState(emitirState('tutor-1'))).toBe('tutor-1');
+    });
+
+    it('recusa state forjado com outro tutor', () => {
+      // O ataque que a assinatura fecha: chamar o callback com o id da vítima
+      // e um code do atacante, pendurando a agenda dele na conta dela.
+      const state = emitirState('tutor-1');
+      const [, nonce, exp, sig] = state.split('.');
+      const forjado = ['tutor-vitima', nonce, exp, sig].join('.');
+
+      expect(() => service.resolveState(forjado)).toThrow(BadRequestException);
+    });
+
+    it('recusa state sem assinatura', () => {
+      expect(() => service.resolveState('tutor-1')).toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('recusa state expirado', () => {
+      const state = emitirState('tutor-1');
+      const [tutorId, nonce] = state.split('.');
+      const vencido = `${tutorId}.${nonce}.${Date.now() - 1000}`;
+      // Assinatura correta para um prazo já vencido não vale.
+      const service2 = service as unknown as {
+        stateSignature: (p: string) => string;
+      };
+      const assinado = `${vencido}.${service2.stateSignature(vencido)}`;
+
+      expect(() => service.resolveState(assinado)).toThrow(BadRequestException);
     });
   });
 

--- a/src/modules/calendar/calendar.controller.ts
+++ b/src/modules/calendar/calendar.controller.ts
@@ -68,7 +68,10 @@ export class CalendarController {
     summary: 'Callback OAuth do Google (redirecionamento do consentimento)',
   })
   @ApiQuery({ name: 'code', description: 'Código de autorização do Google' })
-  @ApiQuery({ name: 'state', description: 'Id do tutor originador do fluxo' })
+  @ApiQuery({
+    name: 'state',
+    description: 'State assinado emitido em GET /calendar/connect',
+  })
   @ApiQuery({
     name: 'error',
     required: false,
@@ -76,7 +79,7 @@ export class CalendarController {
   })
   async callback(
     @Query('code') code: string,
-    @Query('state') tutorId: string,
+    @Query('state') state: string,
     @Query('error') error: string,
     @Res() res: Response,
   ) {
@@ -96,9 +99,9 @@ export class CalendarController {
       return;
     }
 
-    if (!code || !tutorId) {
+    if (!code || !state) {
       this.logger.warn(
-        `Callback do Google Calendar sem parâmetros (code=${!!code}, state=${!!tutorId})`,
+        `Callback do Google Calendar sem parâmetros (code=${!!code}, state=${!!state})`,
       );
       res
         .status(HttpStatus.BAD_REQUEST)
@@ -107,6 +110,23 @@ export class CalendarController {
             false,
             'Link inválido',
             'Este endereço não veio de uma autorização válida do Google. Inicie a conexão pelo app.',
+          ),
+        );
+      return;
+    }
+
+    let tutorId: string;
+    try {
+      tutorId = this.googleCalendarService.resolveState(state);
+    } catch {
+      this.logger.warn('Callback do Google Calendar com state inválido.');
+      res
+        .status(HttpStatus.BAD_REQUEST)
+        .send(
+          this.renderCallbackPage(
+            false,
+            'Link inválido',
+            'Este endereço não veio de uma autorização válida do Google, ou expirou. Inicie a conexão pelo app.',
           ),
         );
       return;
@@ -126,15 +146,15 @@ export class CalendarController {
         `Falha ao concluir o callback do Google Calendar (tutor ${tutorId})`,
         err instanceof Error ? err.stack : err,
       );
+      // A mensagem do erro fica no log, não na página: ela carrega detalhe
+      // interno (configuração, resposta do Google) para uma rota pública.
       res
         .status(HttpStatus.INTERNAL_SERVER_ERROR)
         .send(
           this.renderCallbackPage(
             false,
             'Não foi possível conectar',
-            err instanceof Error
-              ? err.message
-              : 'Erro inesperado ao conectar o Google Agenda.',
+            'Erro inesperado ao conectar o Google Agenda. Tente novamente pelo app.',
           ),
         );
     }

--- a/src/modules/calendar/google-calendar.service.ts
+++ b/src/modules/calendar/google-calendar.service.ts
@@ -1,10 +1,12 @@
 import {
   BadGatewayException,
+  BadRequestException,
   Injectable,
   Logger,
   ServiceUnavailableException,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
 import { google, calendar_v3 } from 'googleapis';
 import { OAuth2Client } from 'google-auth-library';
 import { PrismaService } from '../../prisma/prisma.service';
@@ -15,6 +17,9 @@ const SCOPES = ['https://www.googleapis.com/auth/calendar.events'];
 
 /** Validade assumida quando o Google não informa expiry_date. */
 const DEFAULT_TOKEN_TTL_MS = 3_600_000;
+
+/** Janela de vida do `state` do OAuth — tempo de dar o consentimento. */
+const STATE_TTL_MS = 10 * 60 * 1000;
 
 @Injectable()
 export class GoogleCalendarService {
@@ -34,6 +39,65 @@ export class GoogleCalendarService {
       this.configService.get<string>('googleCalendar.clientSecret') ?? '';
     this.redirectUri =
       this.configService.get<string>('googleCalendar.redirectUri') ?? '';
+  }
+
+  /**
+   * Assina o `state` do OAuth com o id do tutor, um nonce e um prazo.
+   *
+   * O `state` viajava como o id do tutor em texto puro, e o callback é uma
+   * rota pública: bastava chamar `/calendar/callback?code=<código do
+   * atacante>&state=<id da vítima>` para pendurar a agenda do atacante na
+   * conta da vítima — e passar a receber, no Google Calendar dele, todos os
+   * compromissos que ela criasse. Sem assinatura o parâmetro não prova nada
+   * sobre quem começou o fluxo.
+   */
+  private signState(tutorId: string): string {
+    const nonce = randomBytes(16).toString('base64url');
+    const expiresAt = Date.now() + STATE_TTL_MS;
+    const payload = `${tutorId}.${nonce}.${expiresAt}`;
+    return `${payload}.${this.stateSignature(payload)}`;
+  }
+
+  /**
+   * Confere a assinatura e o prazo do `state` e devolve o tutor de origem.
+   * Qualquer inconsistência derruba o fluxo antes de trocar o código.
+   */
+  resolveState(state: string): string {
+    const partes = state?.split('.') ?? [];
+    if (partes.length !== 4) {
+      throw new BadRequestException('Parâmetro state inválido.');
+    }
+
+    const [tutorId, nonce, expiresAtRaw, assinatura] = partes;
+    const esperada = this.stateSignature(`${tutorId}.${nonce}.${expiresAtRaw}`);
+
+    const recebida = Buffer.from(assinatura);
+    const referencia = Buffer.from(esperada);
+    if (
+      recebida.length !== referencia.length ||
+      !timingSafeEqual(recebida, referencia)
+    ) {
+      throw new BadRequestException('Parâmetro state inválido.');
+    }
+
+    const expiresAt = Number(expiresAtRaw);
+    if (!Number.isFinite(expiresAt) || Date.now() > expiresAt) {
+      throw new BadRequestException(
+        'A autorização expirou. Inicie a conexão pelo app novamente.',
+      );
+    }
+
+    return tutorId;
+  }
+
+  private stateSignature(payload: string): string {
+    const secret = this.configService.get<string>('auth.jwtSecret');
+    if (!secret) {
+      throw new Error(
+        'JWT_SECRET é obrigatória para assinar o state do OAuth.',
+      );
+    }
+    return createHmac('sha256', secret).update(payload).digest('base64url');
   }
 
   private get isConfigured(): boolean {
@@ -56,7 +120,7 @@ export class GoogleCalendarService {
       access_type: 'offline',
       scope: SCOPES,
       prompt: 'consent',
-      state: tutorId,
+      state: this.signState(tutorId),
     });
   }
 


### PR DESCRIPTION
CWE-352 — sequestro de vínculo de conta via OAuth.

## O ataque

O `state` era o `tutorId` **em texto puro**, e `/calendar/callback` é rota pública (`@Public()`, como todo callback de OAuth precisa ser).

Bastava obter um `code` do Google para a própria conta e chamar:

```
/calendar/callback?code=<code do atacante>&state=<id da vítima>
```

O servidor trocava o código e gravava os tokens do **atacante** sob o `tutorId` da **vítima**. A partir daí, todo compromisso que ela criasse era sincronizado para a agenda dele — dados de saúde do pet, endereço da clínica, horários.

Sem assinatura, o parâmetro não prova nada sobre quem começou o fluxo. É exatamente o que o `state` do OAuth existe para fazer, e estava sendo usado só como carona para o id.

## A correção

`state` = `tutorId.nonce.expiração.HMAC-SHA256`, assinado com o segredo do JWT, prazo de 10 minutos, comparado com `timingSafeEqual`. Qualquer inconsistência derruba o fluxo **antes** de trocar o código.

A verificação ficou em `resolveState()`, separada de `handleCallback()`, para o controller poder distinguir "state inválido" (400, página de link inválido) de "falha ao conectar" (500).

## Vazamento de informação (CWE-209)

A página do callback refletia `err.message`. Era escapada — não havia XSS — mas levava detalhe interno de configuração para uma rota pública (`"ENCRYPTION_KEY é obrigatória para..."`). A mensagem agora fica só no log.

## Testes

Cobrem o state legítimo, o **forjado com outro tutor** (que é o ataque), o sem assinatura e o expirado com assinatura válida. Mais o callback recusando state inválido sem tocar no banco. Suíte do calendar em **62**.