### PR TITLE
fix(segurança): validar upload por conteúdo, limitar query e tirar segredos do exemplo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,14 +18,17 @@ CORS_ORIGINS=http://localhost:5173,http://localhost:8081,http://localhost:19006
 DATABASE_URL="postgresql://petcard:petcard123@localhost:5432/petcard_dev?schema=public"
 
 # ---------- Autenticação (JWT) ----------
-JWT_SECRET=uma_chave_secreta_segura_aqui
+# Obrigatória, e com no mínimo 32 caracteres quando NODE_ENV=production —
+# o boot falha se faltar. Gere com: openssl rand -hex 32
+JWT_SECRET=
 JWT_EXPIRES_IN=7d
 
 # ---------- Criptografia em repouso (AES-256-GCM) ----------
 # Cifra os tokens OAuth do Google Calendar antes de persistir (ADR-002 #4).
-# Chave de 32 bytes em hexadecimal (64 caracteres). O valor abaixo é só para
-# dev local; gere um próprio com: openssl rand -hex 32
-ENCRYPTION_KEY=3e9c3ded29be54622a73784a9e5554b9ec3ae8b0c52e5a6be501b4137879faad
+# Chave de 32 bytes em hexadecimal (64 caracteres). Gere a SUA com:
+#   openssl rand -hex 32
+# Nunca versione uma chave real aqui: este arquivo vai para o git.
+ENCRYPTION_KEY=
 
 # ---------- Storage (AWS S3) ----------
 AWS_REGION=us-east-1
@@ -38,6 +41,8 @@ REDIS_HOST=localhost
 REDIS_PORT=6379
 
 # ---------- Fila (RabbitMQ) ----------
+# Credenciais abaixo casam com o docker-compose local. Em staging/produção,
+# use usuário e senha próprios — nunca estes.
 RABBITMQ_URL=amqp://petcard:petcard123@localhost:5672
 RABBITMQ_QR_CODE_QUEUE=qr-code.generate
 RABBITMQ_QR_CODE_DLQ=qr-code.generate.dlq
@@ -84,12 +89,20 @@ PUBLIC_CARD_BASE_URL="https://card.petcard.app/#/card"
 PUBLIC_CARD_THROTTLE_TTL_SECONDS=60
 PUBLIC_CARD_THROTTLE_LIMIT=10
 
+# ---------- Rate limit das rotas de autenticação ----------
+# Tentativas de login/cadastro por IP dentro da janela. Valor inválido cai no
+# padrão em vez de desligar o limite.
+AUTH_THROTTLE_TTL_SECONDS=60
+AUTH_THROTTLE_LIMIT=10
+
 # --- Verificação de CRMV (api#113) ---
 # Provedor da consulta: "infosimples" consulta a base real (paga por chamada);
 # qualquer outro valor usa o stub, que não faz chamada externa.
 CRMV_PROVIDER=stub
-# Token da Infosimples — só necessário com CRMV_PROVIDER=infosimples
-INFOSIMPLES_TOKEN=b64WQxqyVohe_kIzY7IhjTVK2Ie3g7ZDuyrzTlov
+# Token da Infosimples — só necessário com CRMV_PROVIDER=infosimples.
+# A consulta é cobrada por chamada: token vazado vira crédito gasto por
+# terceiro. Nunca versione o valor real aqui.
+INFOSIMPLES_TOKEN=seu_token_infosimples
 INFOSIMPLES_CFMV_URL=https://api.infosimples.com/api/v2/consultas/cfmv/cadastro
 # Tipo de inscrição na consulta: 0 = pessoa física (veterinário), 1 = jurídica.
 # Vazio usa 0, que é o caso do profissional.

--- a/src/modules/clinica/clinica.controller.ts
+++ b/src/modules/clinica/clinica.controller.ts
@@ -13,6 +13,7 @@ import {
 } from '@petcardorg/shared';
 import { Auth } from '../auth/decorators/auth.decorator';
 import { Role } from '../auth/enums/role.enum';
+import { GeocodeQueryDto } from './dto/geocode-query.dto';
 import { GeocodingService } from './geocoding.service';
 import { PlacesService } from './places.service';
 
@@ -48,9 +49,7 @@ export class ClinicaController {
   @ApiOkResponse({ type: GeocodeResponseDto })
   @ApiQuery({ name: 'address', description: 'Endereço a geocodificar' })
   @ApiNotFoundResponse({ description: 'Endereço não encontrado' })
-  async geocode(
-    @Query('address') address: string,
-  ): Promise<GeocodeResponseDto> {
-    return this.geocodingService.geocode(address);
+  async geocode(@Query() query: GeocodeQueryDto): Promise<GeocodeResponseDto> {
+    return this.geocodingService.geocode(query.address);
   }
 }

--- a/src/modules/clinica/dto/geocode-query.dto.ts
+++ b/src/modules/clinica/dto/geocode-query.dto.ts
@@ -1,0 +1,14 @@
+import { IsString, MaxLength, MinLength } from 'class-validator';
+
+/**
+ * `@Query('address')` entregava a string crua: o ValidationPipe global só age
+ * sobre parâmetros tipados por classe, então nada limitava tamanho nem
+ * garantia que o valor fosse mesmo uma string. A rota repassa a entrada para
+ * uma API externa cobrada por chamada — vale recusar lixo antes de gastar.
+ */
+export class GeocodeQueryDto {
+  @IsString()
+  @MinLength(3)
+  @MaxLength(200)
+  address!: string;
+}

--- a/src/modules/upload/__tests__/upload.service.spec.ts
+++ b/src/modules/upload/__tests__/upload.service.spec.ts
@@ -36,6 +36,10 @@ const makeConfig = (
 ): ConfigService =>
   ({ get: (key: string) => values[key] }) as unknown as ConfigService;
 
+/** Assinatura de um PNG de verdade — o serviço confere os bytes, não o header. */
+const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+const PNG_BUFFER = Buffer.concat([PNG_MAGIC, Buffer.from('conteudo')]);
+
 const makeFile = (
   overrides: Partial<Express.Multer.File> = {},
 ): Express.Multer.File =>
@@ -43,7 +47,7 @@ const makeFile = (
     originalname: 'foto do rex!.png',
     mimetype: 'image/png',
     size: 1024,
-    buffer: Buffer.from('binary'),
+    buffer: PNG_BUFFER,
     ...overrides,
   }) as Express.Multer.File;
 
@@ -82,6 +86,56 @@ describe('UploadService', () => {
     it('rejeita mime type não permitido', async () => {
       await expect(
         service.uploadFile(makeFile({ mimetype: 'application/pdf' }), 'pets'),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejeita conteúdo que não bate com o mime declarado', async () => {
+      // O mimetype é escrito pelo cliente. Aceitar só ele deixava subir HTML
+      // ou script dizendo ser PNG.
+      await expect(
+        service.uploadFile(
+          makeFile({ buffer: Buffer.from('<html>nao sou imagem</html>') }),
+          'pets',
+        ),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('aceita JPEG e WebP pela assinatura real', async () => {
+      await expect(
+        service.uploadFile(
+          makeFile({
+            mimetype: 'image/jpeg',
+            buffer: Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00]),
+          }),
+          'pets',
+        ),
+      ).resolves.toContain('https://');
+
+      const webp = Buffer.concat([
+        Buffer.from('RIFF'),
+        Buffer.from([0, 0, 0, 0]),
+        Buffer.from('WEBP'),
+      ]);
+      await expect(
+        service.uploadFile(
+          makeFile({ mimetype: 'image/webp', buffer: webp }),
+          'pets',
+        ),
+      ).resolves.toContain('https://');
+    });
+
+    it('rejeita JPEG cujos bytes são de outro formato', async () => {
+      await expect(
+        service.uploadFile(
+          makeFile({ mimetype: 'image/jpeg', buffer: PNG_BUFFER }),
+          'pets',
+        ),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejeita arquivo vazio', async () => {
+      await expect(
+        service.uploadFile(makeFile({ buffer: Buffer.alloc(0) }), 'pets'),
       ).rejects.toThrow(BadRequestException);
     });
 

--- a/src/modules/upload/upload.controller.ts
+++ b/src/modules/upload/upload.controller.ts
@@ -17,7 +17,7 @@ import {
 } from '@nestjs/swagger';
 import { Auth } from '../auth/decorators/auth.decorator';
 import { Role } from '../auth/enums/role.enum';
-import { UploadService } from './upload.service';
+import { MAX_FILE_SIZE_BYTES, UploadService } from './upload.service';
 
 const ALLOWED_FOLDERS = ['pets', 'tutors'] as const;
 type AllowedFolder = (typeof ALLOWED_FOLDERS)[number];
@@ -29,7 +29,12 @@ export class UploadController {
 
   @Post('image')
   @Auth(Role.TUTOR, Role.VET)
-  @UseInterceptors(FileInterceptor('file'))
+  // O teto vai no multer, não só na validação: sem ele o arquivo inteiro era
+  // lido para a memória antes de alguém conferir o tamanho, e um POST de
+  // gigabytes derrubava o processo antes de chegar na checagem.
+  @UseInterceptors(
+    FileInterceptor('file', { limits: { fileSize: MAX_FILE_SIZE_BYTES } }),
+  )
   @ApiOperation({ summary: 'Upload de imagem para o S3 (máx. 5MB)' })
   @ApiConsumes('multipart/form-data')
   @ApiBody({

--- a/src/modules/upload/upload.service.ts
+++ b/src/modules/upload/upload.service.ts
@@ -13,7 +13,29 @@ import {
 import { ConfigService } from '@nestjs/config';
 
 const ALLOWED_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
-const MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024;
+export const MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024;
+
+/**
+ * Assinatura real de cada formato aceito.
+ *
+ * `file.mimetype` é o `Content-Type` que o cliente escreveu na parte do
+ * multipart — dado, não fato. Conferir só ele deixava subir qualquer conteúdo
+ * (HTML, SVG com script, executável) desde que a requisição dissesse
+ * `image/png`, e o objeto ia para o S3 servido com esse tipo.
+ */
+const PNG_SIGNATURE = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+]);
+
+const MAGIC_NUMBERS: Record<string, (buffer: Buffer) => boolean> = {
+  'image/jpeg': (b) => b.length >= 3 && b[0] === 0xff && b[1] === 0xd8,
+  'image/png': (b) => b.length >= 8 && b.subarray(0, 8).equals(PNG_SIGNATURE),
+  // Cabeçalho de WebP tem exatamente 12 bytes: "RIFF", o tamanho, e "WEBP".
+  'image/webp': (b) =>
+    b.length >= 12 &&
+    b.subarray(0, 4).toString('ascii') === 'RIFF' &&
+    b.subarray(8, 12).toString('ascii') === 'WEBP',
+};
 
 @Injectable()
 export class UploadService {
@@ -101,6 +123,13 @@ export class UploadService {
     return `https://${this.bucket}.s3.${this.region}.amazonaws.com/${key}`;
   }
 
+  /**
+   * Remove um objeto do bucket a partir da URL pública dele.
+   *
+   * A URL precisa ser deste bucket: a chave saía do `pathname` de qualquer
+   * endereço recebido, então uma URL forjada apontava o delete para qualquer
+   * objeto do bucket, inclusive fora da pasta de uploads.
+   */
   async deleteFile(fileUrl: string): Promise<void> {
     if (!this.s3Client || !this.bucket) {
       throw new InternalServerErrorException(
@@ -135,15 +164,28 @@ export class UploadService {
     if (file.size > MAX_FILE_SIZE_BYTES) {
       throw new BadRequestException('File exceeds the 5MB size limit');
     }
+    if (!file.buffer?.length) {
+      throw new BadRequestException('Empty file');
+    }
+    if (!MAGIC_NUMBERS[file.mimetype](file.buffer)) {
+      throw new BadRequestException(
+        'File content does not match the declared image type',
+      );
+    }
   }
 
   private extractKeyFromUrl(fileUrl: string): string | null {
     try {
       const url = new URL(fileUrl);
-      // Remove leading slash
-      return url.pathname.startsWith('/')
-        ? url.pathname.substring(1)
-        : url.pathname;
+      if (url.host !== `${this.bucket}.s3.${this.region}.amazonaws.com`) {
+        return null;
+      }
+      const key = decodeURIComponent(url.pathname).replace(/^\/+/, '');
+      // Sem travessia e dentro de uma pasta conhecida.
+      if (!key || key.includes('..') || !/^[\w.-]+\//.test(key)) {
+        return null;
+      }
+      return key;
     } catch {
       return null;
     }


### PR DESCRIPTION
Últimos itens da auditoria — pequenos e independentes, agrupados para não virar quatro PRs de um arquivo.

## ⚠️ Segredo versionado — exige ação sua

`.env.example` **está no git** e trazia:

- `INFOSIMPLES_TOKEN=b64WQ…` — token de aparência real, de uma API **cobrada por chamada**
- `ENCRYPTION_KEY=3e9c3ded…` — chave AES-256 funcional

Trocá-los aqui **não desfaz o vazamento**: os valores seguem no histórico (commit `73bc95b`). Você já trocou o token da Infosimples. A `ENCRYPTION_KEY` precisa de rotação planejada — ela cifra os refresh tokens do Calendar, e trocá-la obriga os tutores conectados a refazer o consentimento.

## Upload (CWE-434, CWE-400)

O tipo era conferido só pelo `file.mimetype` — o `Content-Type` que o cliente escreveu na parte do multipart. Dado, não fato. Aceitava subir HTML ou SVG com script alegando `image/png`, e o objeto ia para o S3 servido com esse tipo.

Agora confere a **assinatura real dos bytes** de JPEG, PNG e WebP.

O teto de 5MB só era aplicado com o arquivo já inteiro em memória: o multer aceitava qualquer tamanho e a validação reclamava tarde demais. O limite foi para o interceptor.

`deleteFile` extraía a chave do `pathname` de **qualquer** URL, então uma URL forjada apontava o delete para qualquer objeto do bucket. Passa a exigir o host do bucket configurado e recusa travessia. Não tem chamador hoje, mas segue exportado.

## Geocoding (CWE-20)

`@Query('address')` chegava cru — o `ValidationPipe` global só age sobre parâmetro tipado por classe. Ganhou DTO com mínimo e máximo, antes de repassar a entrada para uma API externa cobrada por chamada.

## Testes

38 nas duas suítes. Os novos cobrem conteúdo que não bate com o mime declarado, arquivo vazio, e JPEG/WebP aceitos pela assinatura real — este último pegou um off-by-one meu: o cabeçalho WebP tem exatamente 12 bytes e eu exigia mais que 12.