### PR TITLE
feat(perfil): exclusão de conta do tutor e foto do veterinário

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@nestjs/schedule": "^6.1.3",
         "@nestjs/swagger": "^11.4.4",
         "@nestjs/throttler": "^6.5.0",
-        "@petcardorg/shared": "^0.18.0",
+        "@petcardorg/shared": "^0.19.0",
         "@prisma/client": "^6.19.3",
         "amqp-connection-manager": "^5.0.0",
         "amqplib": "^1.0.3",
@@ -3847,9 +3847,9 @@
       }
     },
     "node_modules/@petcardorg/shared": {
-      "version": "0.18.0",
-      "resolved": "https://npm.pkg.github.com/download/@petcardorg/shared/0.18.0/6a3d3c6ed40357015b3a58ace8fb7050e13529d7",
-      "integrity": "sha512-WbGU7FpnwR7iwiTdD19fAQJ/qEkXCOi6aTJJ+0oRVaqs+HcLIW82/kFfSNoAxIuzbSdk9lrt5nJWzzrVoeWl4Q==",
+      "version": "0.19.0",
+      "resolved": "https://npm.pkg.github.com/download/@petcardorg/shared/0.19.0/2dbf6d3afa8dbd9eb4783308c4d64dbba9517243",
+      "integrity": "sha512-944t8LEsrPl/Uwirkyh3qzQAzjFkgRYYk9M5rp28+GOMoll96qIlnv69HbcDGyWL8v3jC/OSyGIDFF4G3E6aWw==",
       "license": "MIT",
       "peerDependencies": {
         "class-transformer": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@nestjs/schedule": "^6.1.3",
     "@nestjs/swagger": "^11.4.4",
     "@nestjs/throttler": "^6.5.0",
-    "@petcardorg/shared": "^0.18.0",
+    "@petcardorg/shared": "^0.19.0",
     "@prisma/client": "^6.19.3",
     "amqp-connection-manager": "^5.0.0",
     "amqplib": "^1.0.3",

--- a/prisma/migrations/20260824000231_perfil_foto_do_vet_e_exclusao_de_conta/migration.sql
+++ b/prisma/migrations/20260824000231_perfil_foto_do_vet_e_exclusao_de_conta/migration.sql
@@ -1,0 +1,8 @@
+-- DropForeignKey
+ALTER TABLE "pet" DROP CONSTRAINT "pet_tutor_id_fkey";
+
+-- AlterTable
+ALTER TABLE "veterinario" ADD COLUMN     "photo_url" TEXT;
+
+-- AddForeignKey
+ALTER TABLE "pet" ADD CONSTRAINT "pet_tutor_id_fkey" FOREIGN KEY ("tutor_id") REFERENCES "tutor"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -125,7 +125,7 @@ model Pet {
   createdAt DateTime  @default(now()) @map("created_at")
   updatedAt DateTime  @updatedAt @map("updated_at")
 
-  tutor             Tutor              @relation(fields: [tutorId], references: [id])
+  tutor             Tutor              @relation(fields: [tutorId], references: [id], onDelete: Cascade)
   vaccineRecords    VaccineRecord[]
   dewormingRecords  DewormingRecord[]
   medicationRecords MedicationRecord[]
@@ -277,6 +277,7 @@ model Veterinario {
   password String
   crmv     String  @unique
   telefone String?
+  photoUrl String? @map("photo_url")
 
   /// Verificação do CRMV numa base externa (api#113). Nulo = não verificado.
   crmvVerifiedAt DateTime? @map("crmv_verified_at")

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -211,6 +211,7 @@ export class AuthService {
       email: vet.email,
       crmv: vet.crmv,
       telefone: vet.telefone,
+      foto_url: vet.photoUrl ?? undefined,
       role: Role.VET,
     };
   }

--- a/src/modules/tutor/__tests__/tutor.controller.spec.ts
+++ b/src/modules/tutor/__tests__/tutor.controller.spec.ts
@@ -13,7 +13,7 @@ import { TutorService } from '../tutor.service';
 describe('TutorController (integração)', () => {
   let harness: ControllerHarness;
   let prisma: {
-    tutor: { findUnique: jest.Mock; update: jest.Mock };
+    tutor: { findUnique: jest.Mock; update: jest.Mock; delete: jest.Mock };
     petAtendido: { findFirst: jest.Mock };
   };
 
@@ -33,7 +33,7 @@ describe('TutorController (integração)', () => {
 
   beforeAll(async () => {
     prisma = {
-      tutor: { findUnique: jest.fn(), update: jest.fn() },
+      tutor: { findUnique: jest.fn(), update: jest.fn(), delete: jest.fn() },
       petAtendido: { findFirst: jest.fn() },
     };
 
@@ -137,6 +137,49 @@ describe('TutorController (integração)', () => {
       await request(harness.app.getHttpServer())
         .get('/tutors/missing')
         .expect(404);
+    });
+  });
+
+  describe('DELETE /tutors/me', () => {
+    it('apaga a conta do tutor autenticado (204)', async () => {
+      prisma.tutor.delete.mockResolvedValue(tutor);
+
+      await request(harness.app.getHttpServer())
+        .delete('/tutors/me')
+        .expect(204);
+
+      // Sempre a conta de quem está autenticado, nunca um id do corpo.
+      expect(prisma.tutor.delete).toHaveBeenCalledWith({
+        where: { id: 'tutor-1' },
+      });
+    });
+
+    it('proíbe VET de apagar conta de tutor (403)', async () => {
+      harness.setUser(VET);
+
+      await request(harness.app.getHttpServer())
+        .delete('/tutors/me')
+        .expect(403);
+
+      expect(prisma.tutor.delete).not.toHaveBeenCalled();
+    });
+
+    it('exige autenticação (401)', async () => {
+      harness.setUser(null);
+
+      await request(harness.app.getHttpServer())
+        .delete('/tutors/me')
+        .expect(401);
+    });
+
+    it('devolve 404 se a conta já não existe', async () => {
+      prisma.tutor.findUnique.mockResolvedValue(null);
+
+      await request(harness.app.getHttpServer())
+        .delete('/tutors/me')
+        .expect(404);
+
+      expect(prisma.tutor.delete).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/modules/tutor/tutor.controller.ts
+++ b/src/modules/tutor/tutor.controller.ts
@@ -1,4 +1,13 @@
-import { Body, Controller, Get, Param, Patch } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Patch,
+} from '@nestjs/common';
 import {
   ApiForbiddenResponse,
   ApiNotFoundResponse,
@@ -34,6 +43,20 @@ export class TutorController {
     return this.tutorService.updateById(user.sub, dto);
   }
 
+  @Delete('me')
+  @Auth(Role.TUTOR)
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({
+    summary: 'Excluir definitivamente a conta do tutor autenticado',
+    description:
+      'Apaga a conta e tudo que depende dela: pets, prontuário, carteira ' +
+      'digital, agendamentos e notificações. Não há desfazer.',
+  })
+  async removeMe(@CurrentUser() user: JwtPayload): Promise<void> {
+    return this.tutorService.removeById(user.sub);
+  }
+
+  // Declarada depois de 'me', senão a rota por id capturaria a palavra.
   @Get(':id')
   @Auth(Role.VET)
   @ApiOperation({

--- a/src/modules/tutor/tutor.service.ts
+++ b/src/modules/tutor/tutor.service.ts
@@ -62,6 +62,20 @@ export class TutorService {
     return tutor;
   }
 
+  /**
+   * Apaga a conta do tutor e tudo que pende dela.
+   *
+   * O cascata leva pets, prontuário, carteira, agendamentos e notificações —
+   * inclusive a trilha de ações clínicas dos pets dele, que é a consequência
+   * de "exclusão definitiva" pedida por quem apaga a conta. A trilha das ações
+   * que um veterinário registrou em pets de OUTROS tutores não é afetada:
+   * nome e CRMV do autor são copiados na gravação, não referenciados.
+   */
+  async removeById(id: string): Promise<void> {
+    await this.findById(id);
+    await this.prisma.tutor.delete({ where: { id } });
+  }
+
   async findByEmail(email: string): Promise<Tutor | null> {
     return this.prisma.tutor.findUnique({ where: { email } });
   }

--- a/src/modules/veterinario/__tests__/veterinario.service.spec.ts
+++ b/src/modules/veterinario/__tests__/veterinario.service.spec.ts
@@ -100,6 +100,29 @@ describe('VeterinarioService', () => {
       );
     });
 
+    it('grava a foto de perfil no campo do banco', async () => {
+      prisma.veterinario.findUnique.mockResolvedValueOnce(vetFixture);
+      prisma.veterinario.update.mockResolvedValue(vetFixture);
+
+      await service.update('vet-1', {
+        foto_url: 'https://bucket.s3.us-east-1.amazonaws.com/vets/foto.png',
+      });
+
+      expect(dadosGravados()).toEqual({
+        photoUrl: 'https://bucket.s3.us-east-1.amazonaws.com/vets/foto.png',
+      });
+    });
+
+    it('não toca na foto quando o campo não vem no pedido', async () => {
+      // Editar só o nome não pode apagar a foto já cadastrada.
+      prisma.veterinario.findUnique.mockResolvedValueOnce(vetFixture);
+      prisma.veterinario.update.mockResolvedValue(vetFixture);
+
+      await service.update('vet-1', { nome: 'Dra. Camila Ferreira' });
+
+      expect(dadosGravados()).not.toHaveProperty('photoUrl');
+    });
+
     it('derruba a verificação quando o CRMV muda', async () => {
       prisma.veterinario.findUnique
         .mockResolvedValueOnce(vetFixture)

--- a/src/modules/veterinario/veterinario.service.ts
+++ b/src/modules/veterinario/veterinario.service.ts
@@ -82,6 +82,7 @@ export class VeterinarioService {
       data.crmvSituacao = null;
     }
     if (dto.telefone !== undefined) data.telefone = dto.telefone;
+    if (dto.foto_url !== undefined) data.photoUrl = dto.foto_url;
     if (dto.password !== undefined) {
       data.password = await bcrypt.hash(dto.password, BCRYPT_ROUNDS);
     }

--- a/test/e2e/conta-do-tutor.e2e-spec.ts
+++ b/test/e2e/conta-do-tutor.e2e-spec.ts
@@ -1,0 +1,101 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import type { INestApplication } from '@nestjs/common';
+import type { App } from 'supertest/types';
+import request from 'supertest';
+import { createE2EApp, E2EApp } from '../utils/e2e-app';
+import {
+  createAndLoginVet,
+  registerTutor,
+  resetDb,
+  vincularPetAoVet,
+} from '../utils/e2e-db';
+import { PrismaService } from '../../src/prisma/prisma.service';
+
+/**
+ * Exclusão definitiva da conta do tutor.
+ *
+ * O cascata é do banco, então só um Postgres de verdade prova que ele existe:
+ * o `Pet` apontava para `Tutor` sem `onDelete`, o que em Prisma é `Restrict` —
+ * apagar tutor com pet falhava com erro de chave estrangeira.
+ */
+describe('Conta do tutor — exclusão (e2e)', () => {
+  let ctx: E2EApp;
+  let app: INestApplication<App>;
+  let prisma: PrismaService;
+  let tutorToken: string;
+  let tutorId: string;
+  let petId: string;
+
+  beforeAll(async () => {
+    ctx = await createE2EApp();
+    ({ app, prisma } = ctx);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(async () => {
+    await resetDb(prisma);
+    const tutor = await registerTutor(app);
+    tutorToken = tutor.token;
+    tutorId = tutor.user.id;
+
+    const pet = await request(app.getHttpServer())
+      .post('/pets')
+      .set('Authorization', `Bearer ${tutorToken}`)
+      .send({ name: 'Rex', species: 'DOG', sex: 'MALE' })
+      .expect(201);
+    petId = pet.body.id as string;
+  });
+
+  it('apaga a conta e leva junto pets, prontuário e carteira', async () => {
+    await request(app.getHttpServer())
+      .post(`/pets/${petId}/vaccines`)
+      .set('Authorization', `Bearer ${tutorToken}`)
+      .send({ pet_id: petId, vaccine_name: 'V8', applied_at: '2026-01-10' })
+      .expect(201);
+
+    await request(app.getHttpServer())
+      .delete('/tutors/me')
+      .set('Authorization', `Bearer ${tutorToken}`)
+      .expect(204);
+
+    expect(
+      await prisma.tutor.findUnique({ where: { id: tutorId } }),
+    ).toBeNull();
+    expect(await prisma.pet.count()).toBe(0);
+    expect(await prisma.vaccineRecord.count()).toBe(0);
+    expect(await prisma.carteiraDigital.count()).toBe(0);
+  });
+
+  it('desfaz o vínculo com o veterinário que atendia o pet', async () => {
+    const vet = await createAndLoginVet(app, prisma);
+    await vincularPetAoVet(prisma, vet.user.id, petId);
+
+    await request(app.getHttpServer())
+      .delete('/tutors/me')
+      .set('Authorization', `Bearer ${tutorToken}`)
+      .expect(204);
+
+    // O veterinário continua existindo; some só o pet da lista dele.
+    expect(await prisma.petAtendido.count()).toBe(0);
+    expect(
+      await prisma.veterinario.findUnique({ where: { id: vet.user.id } }),
+    ).not.toBeNull();
+  });
+
+  it('o token deixa de servir depois da exclusão', async () => {
+    await request(app.getHttpServer())
+      .delete('/tutors/me')
+      .set('Authorization', `Bearer ${tutorToken}`)
+      .expect(204);
+
+    // O JWT continua com assinatura válida até expirar, mas não há mais conta
+    // por trás dele: as rotas que resolvem o tutor precisam recusar.
+    await request(app.getHttpServer())
+      .get('/tutors/me')
+      .set('Authorization', `Bearer ${tutorToken}`)
+      .expect(404);
+  });
+});


### PR DESCRIPTION
## Rascunho — bloqueado na dependência

Requer `@petcardorg/shared` **0.19.0** (já publicada), que define `foto_url`. O install autenticado é seu:

```bash
cd petcard-api && npm install @petcardorg/shared@^0.19.0
```

## Exclusão de conta do tutor

Não havia rota. E não bastava criar uma: `Pet` apontava para `Tutor` **sem `onDelete`**, que em Prisma é `Restrict` — apagar um tutor com pet falhava com erro de chave estrangeira. A migração troca por `Cascade`.

`DELETE /tutors/me` apaga a conta e o que pende dela: pets, prontuário, carteira digital, agendamentos, notificações e o vínculo com veterinários.

**Consequência que vale registrar:** vai junto a trilha de ações clínicas (`AcaoClinica`) dos pets desse tutor. É o que "exclusão definitiva" significa para quem pede — e o oposto seria guardar dado pessoal depois de um pedido de apagamento. A trilha das ações que um veterinário registrou em pets de **outros** tutores não é afetada: nome e CRMV do autor são copiados na gravação, não referenciados (api#117).

Se a preferência for preservar a trilha anonimizada em vez de apagá-la, é outra migração — me diga.

## Foto do veterinário

O tutor já tinha `profileImageUrl`; o veterinário não tinha equivalente. Coluna nova, gravada em `PATCH /veterinarios/me` e devolvida no perfil.

Editar só o nome **não** apaga a foto — há teste para isso, porque o padrão `if (dto.x !== undefined)` é fácil de errar.

## Testes

**486 unitários** e **52 e2e**.

O e2e novo é o que importa aqui: o cascata é do banco, então só Postgres de verdade prova que existe. Cobre a conta sumindo com pets e prontuário, o vínculo com o veterinário desfeito sem apagar o veterinário, e o token deixando de servir depois da exclusão.

## Nota

`DELETE /tutors/me` foi declarada **antes** de `@Get(':id')` — senão a rota por id capturaria a palavra `me`. Mesmo cuidado que o controller de veterinário já tinha.