### PR TITLE
fix(tutor): devolver profile_image_url em vez de profileImageUrl

### DIFF
--- a/src/modules/tutor/__tests__/tutor.controller.spec.ts
+++ b/src/modules/tutor/__tests__/tutor.controller.spec.ts
@@ -92,6 +92,29 @@ describe('TutorController (integração)', () => {
       });
     });
 
+    it('devolve a foto salva em profile_image_url, não profileImageUrl', async () => {
+      // profileImageUrl é o nome do campo no Prisma Client (a coluna é que se
+      // chama profile_image_url via @map) — a resposta view precisa da chave
+      // em snake_case, que é o que o app mobile lê.
+      const url = 'https://bucket.s3.amazonaws.com/tutors/foto.jpg';
+      prisma.tutor.update.mockResolvedValue({
+        ...tutor,
+        profileImageUrl: url,
+      });
+
+      const res = await request(harness.app.getHttpServer())
+        .patch('/tutors/me')
+        .send({ profile_image_url: url })
+        .expect(200);
+
+      expect(res.body.profile_image_url).toBe(url);
+      expect(res.body).not.toHaveProperty('profileImageUrl');
+      expect(prisma.tutor.update).toHaveBeenCalledWith({
+        where: { id: 'tutor-1' },
+        data: { profileImageUrl: url },
+      });
+    });
+
     it('rejeita email inválido (400)', async () => {
       await request(harness.app.getHttpServer())
         .patch('/tutors/me')

--- a/src/modules/tutor/tutor.service.ts
+++ b/src/modules/tutor/tutor.service.ts
@@ -8,7 +8,9 @@ import { UpdateTutorDto } from '@petcardorg/shared';
 import { PrismaService } from '../../prisma/prisma.service';
 
 /** Tutor sem o hash da senha — o que pode sair da API. */
-export type TutorPublico = Omit<Tutor, 'password'>;
+export type TutorPublico = Omit<Tutor, 'password' | 'profileImageUrl'> & {
+  profile_image_url: string | null;
+};
 
 /**
  * O hash da senha nunca acompanha o tutor para fora do serviço.
@@ -17,11 +19,16 @@ export type TutorPublico = Omit<Tutor, 'password'>;
  * direto: o hash bcrypt do tutor saía em `GET /tutors/me`, `PATCH /tutors/me`
  * e `GET /tutors/:id` — este último legível por qualquer veterinário logado,
  * o que dava a ele material para quebra offline de senha.
+ *
+ * `profileImageUrl` também precisa virar `profile_image_url` aqui: é o nome
+ * da coluna (`@map`), não do campo no Prisma Client, e `TutorResponseDto` no
+ * shared contrata a resposta em snake_case. Sem a troca, o tutor.service do
+ * mobile lia `undefined` e a foto de perfil salva nunca aparecia de volta.
  */
 function semSenha(tutor: Tutor): TutorPublico {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { password, ...rest } = tutor;
-  return rest;
+  const { password, profileImageUrl, ...rest } = tutor;
+  return { ...rest, profile_image_url: profileImageUrl };
 }
 
 @Injectable()


### PR DESCRIPTION
## Resumo
- `GET /tutors/me`, `PATCH /tutors/me` e `GET /tutors/:id` devolviam o campo do Prisma Client em camelCase (`profileImageUrl`) em vez do snake_case (`profile_image_url`) que o `TutorResponseDto` do shared contrata. `@map("profile_image_url")` no schema só renomeia a coluna do banco, não o campo do Prisma Client.
- Efeito: a foto de perfil do tutor era enviada e salva corretamente, mas nunca era reconhecida na resposta pelos clientes (mobile/web), então parecia nunca persistir.

## Test plan
- [x] `npm test` (487/487)
- [x] `npm run test:cov` (cobertura acima da catraca 83/78/90/85)
- [x] Novo teste de regressão em `tutor.controller.spec.ts` cobrindo o mapeamento correto do campo